### PR TITLE
test: actualizar referencias de ‘transpilar’ a ‘build’ en pruebas CLI públicas v2

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,13 +13,12 @@ def test_cli_ayuda() -> None:
     assert "cobra" in salida or "uso" in salida or "usage" in salida
 
 
-def test_cli_transpilar_help() -> None:
+def test_cli_build_help() -> None:
     result = subprocess.run(
-        [sys.executable, "-m", "pcobra.cli", "transpilar", "--help"],
+        [sys.executable, "-m", "pcobra.cli", "build", "--help"],
         capture_output=True,
         text=True,
     )
     assert result.returncode == 0
     salida = result.stdout.lower()
-    assert "transpilar" in salida or "uso" in salida or "usage" in salida
-
+    assert "build" in salida or "uso" in salida or "usage" in salida

--- a/tests/test_ejemplos_io.py
+++ b/tests/test_ejemplos_io.py
@@ -50,12 +50,12 @@ def test_ejecutar_ejemplos(nombre: str, ruta_ejemplos: Path) -> None:
 
 
 @pytest.mark.parametrize("nombre", ejemplos_disponibles())
-def test_transpilar_muestra_fragmentos(nombre: str, ruta_ejemplos: Path) -> None:
-    """Transpila ejemplos y valida que el código contenga fragmentos esperados."""
+def test_build_muestra_fragmentos(nombre: str, ruta_ejemplos: Path) -> None:
+    """Construye ejemplos y valida que el código contenga fragmentos esperados."""
     archivo = ruta_ejemplos / f"{nombre}.cobra"
     if not archivo.exists():
         archivo = ruta_ejemplos / f"{nombre}.co"
-    comando = [sys.executable, "-m", "pcobra.cli", "transpilar", str(archivo)]
+    comando = [sys.executable, "-m", "pcobra.cli", "build", str(archivo)]
     resultado = subprocess.run(
         comando,
         capture_output=True,
@@ -63,7 +63,7 @@ def test_transpilar_muestra_fragmentos(nombre: str, ruta_ejemplos: Path) -> None
     )
     if resultado.returncode != 0:
         mensaje = (
-            f"Transpilación falló para {nombre}\n"
+            f"Build falló para {nombre}\n"
             f"Comando: {' '.join(comando)}\n"
             f"stderr:\n{resultado.stderr.strip() or '<vacío>'}"
         )
@@ -82,7 +82,7 @@ def _extraer_codigo_generado(stdout: str) -> str:
             return "\n".join(lineas[indice:]).strip() + "\n"
     pytest.fail(
         "No se pudo extraer el código transpilado de la salida CLI. "
-        "Asegúrate de que el comando 'transpilar' imprima el código generado."
+        "Asegúrate de que el comando 'build' imprima el código generado."
     )
 
 
@@ -101,12 +101,12 @@ def _resolver_snapshot_esperado(ruta_ejemplos: Path, nombre: str) -> Path:
 
 
 @pytest.mark.parametrize("nombre", ejemplos_disponibles())
-def test_transpilar_coincide_con_archivo(nombre: str, ruta_ejemplos: Path) -> None:
-    """Transpila ejemplos y compara el código generado con el snapshot versionado."""
+def test_build_coincide_con_archivo(nombre: str, ruta_ejemplos: Path) -> None:
+    """Construye ejemplos y compara el código generado con el snapshot versionado."""
     archivo = ruta_ejemplos / f"{nombre}.cobra"
     if not archivo.exists():
         archivo = ruta_ejemplos / f"{nombre}.co"
-    comando = [sys.executable, "-m", "pcobra.cli", "transpilar", str(archivo)]
+    comando = [sys.executable, "-m", "pcobra.cli", "build", str(archivo)]
     resultado = subprocess.run(
         comando,
         capture_output=True,
@@ -114,7 +114,7 @@ def test_transpilar_coincide_con_archivo(nombre: str, ruta_ejemplos: Path) -> No
     )
     if resultado.returncode != 0:
         mensaje = (
-            f"Transpilación falló para {nombre}\n"
+            f"Build falló para {nombre}\n"
             f"Comando: {' '.join(comando)}\n"
             f"stderr:\n{resultado.stderr.strip() or '<vacío>'}"
         )


### PR DESCRIPTION
### Motivation
- Actualizar las pruebas para usar la interfaz pública v2 que expone el comando `build` en lugar del antiguo `transpilar`.
- Mantener la verificación exacta contra snapshots y no suavizar ni reducir aserciones de las pruebas existentes.
- Asegurar que el contrato público sigue exigiendo exactamente `run/build/test/mod/repl/gui` sin introducir aliases legacy.

### Description
- Cambia en `tests/test_cli.py` la prueba `test_cli_transpilar_help` a `test_cli_build_help` y invoca `python -m pcobra.cli build --help`, ajustando la aserción de contenido. 
- Migra en `tests/test_ejemplos_io.py` las pruebas `test_transpilar_muestra_fragmentos` y `test_transpilar_coincide_con_archivo` a `test_build_muestra_fragmentos` y `test_build_coincide_con_archivo`, actualizando los comandos invocados a `python -m pcobra.cli build` y los mensajes descriptivos de error/snapshot. 
- Mantengo intacta la lógica de extracción de código generado y la comparación exacta contra los snapshots, sin alterar las aserciones ni los snapshots versionados. 
- No se añadieron aliases públicos `transpilar`, no se tocaron Lexer/Parser y el contrato público en `tests/integration/test_cli_public_help_contract.py` permanece sin cambios.

### Testing
- Ejecuté `python -m pytest tests/test_cli.py tests/integration/test_cli_public_help_contract.py` y ambas pruebas de archivo pasaron (`13 passed`).
- Ejecuté `python -m pytest tests/test_cli.py tests/test_ejemplos_io.py tests/integration/test_cli_public_help_contract.py` y se reproduce el estado con fallos: `5 failed, 13 passed`; los fallos son `test_ejecutar_ejemplos[suma]` por ejecución (mensaje: "Variable no declarada: c") y cuatro casos `test_build_coincide_con_archivo` donde `build` no imprimió el código esperado para los snapshots (`async_await`, `ejemplo`, `factorial_recursivo`, `hola`).
- Verifiqué que no quedan referencias a `transpilar` en los archivos actualizados y que la constante `PUBLIC_COMMANDS` sigue siendo `("run", "build", "test", "mod", "repl", "gui")`.
- Confirmé con `git diff --check` y la revisión de cambios que no se modificaron archivos de Lexer ni Parser; los cambios se registraron en el commit con mensaje `test: actualizar interfaz pública CLI v2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b3521888c8327a65e953c4224a430)