### PR TITLE
Corrige el wrapper cobra para usar el entry point instalado

### DIFF
--- a/scripts/bin/cobra
+++ b/scripts/bin/cobra
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
-"""Punto de entrada de desarrollo para la CLI de Cobra."""
+"""Delega en el punto de entrada instalado de Cobra."""
 
-from pathlib import Path
+from importlib.metadata import distribution
 import sys
 
 
-def _bootstrap_paths() -> None:
-    raiz = Path(__file__).resolve().parents[2]
-    posibles = [raiz, raiz / "src"]
-    for ruta in posibles:
-        ruta_str = str(ruta)
-        if ruta_str not in sys.path:
-            sys.path.insert(0, ruta_str)
+def main() -> int | None:
+    """Carga ``cobra`` desde los metadatos del paquete instalado."""
+
+    entry_point = next(
+        entry_point
+        for entry_point in distribution("pcobra").entry_points
+        if entry_point.group == "console_scripts" and entry_point.name == "cobra"
+    )
+    return entry_point.load()()
 
 
 if __name__ == "__main__":
-    _bootstrap_paths()
-    from pcobra.cli import main as cobra_main
-
-    sys.exit(cobra_main())
+    sys.exit(main())

--- a/tests/integration/test_cobra_wrapper.py
+++ b/tests/integration/test_cobra_wrapper.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "scripts" / "bin" / "cobra"
+
+
+def test_wrapper_ejecuta_entry_point_instalado_sin_importar_checkout(
+    tmp_path: Path,
+) -> None:
+    entorno = tmp_path / "entorno"
+    venv.EnvBuilder(with_pip=False).create(entorno)
+    python = entorno / "bin" / "python3"
+
+    purelib = subprocess.run(
+        [str(python), "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    site_packages = Path(purelib)
+    (site_packages / "entry_point_aislado.py").write_text(
+        "import json, os, sys\n"
+        "def main():\n"
+        "    with open(os.environ['COBRA_MARKER'], 'w') as marker:\n"
+        "        json.dump({'executable': sys.executable, 'path': sys.path}, marker)\n"
+        "    return 37\n",
+        encoding="utf-8",
+    )
+    dist_info = site_packages / "pcobra-0.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: pcobra\nVersion: 0.0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "entry_points.txt").write_text(
+        "[console_scripts]\ncobra = entry_point_aislado:main\n",
+        encoding="utf-8",
+    )
+
+    marker = tmp_path / "entry-point.json"
+    env = {
+        "COBRA_MARKER": str(marker),
+        "HOME": str(tmp_path),
+        # El directorio del wrapper primero reproduce el caso propenso a recursión.
+        "PATH": os.pathsep.join((str(WRAPPER.parent), str(entorno / "bin"))),
+    }
+    result = subprocess.run(
+        [str(WRAPPER)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 37, result.stderr
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert Path(payload["executable"]).parent == entorno / "bin"
+    assert str(REPO_ROOT) not in payload["path"]
+    assert str(REPO_ROOT / "src") not in payload["path"]


### PR DESCRIPTION
### Motivation

- Elimina el bootstrap que insertaba el checkout en `sys.path` para evitar que el wrapper interfiera con el entorno activo o importe código desde el árbol de trabajo.
- Delegar en el entry point instalado garantiza que el ejecutable `cobra` use el paquete distribuido `pcobra` con el intérprete actual en lugar de buscar un binario global.

### Description

- Elimina `_bootstrap_paths` y la dependencia de `Path` en `scripts/bin/cobra` y en su lugar usa `importlib.metadata.distribution("pcobra").entry_points` para localizar el `console_scripts` llamado `cobra`.
- Carga el entry point con `entry_point.load()` y lo ejecuta en el proceso actual, devolviendo su valor y propagándolo con `sys.exit(main())`.
- Evita recursión por `PATH` al no depender de resolución externa de ejecutables; descarta la búsqueda de un `cobra` fuera del entorno activo.
- Añade `tests/integration/test_cobra_wrapper.py`, una prueba de integración que crea un `venv` aislado (sin `pip`), registra un entry point simulado en `site-packages` y verifica que el wrapper ejecuta dicho entry point, preserva el intérprete del entorno y no inserta la raíz del repositorio ni `src/` en `sys.path`.

### Testing

- Ejecuté `python -m pytest -q tests/integration/test_cobra_wrapper.py` y la prueba pasó (`1 passed`).
- Ejecuté `python -m pytest -q tests/test_cli_entrypoint_imports.py tests/integration/test_cobra_wrapper.py` y ambas suites pasaron (`11 passed, 1 warning`).
- Ejecuté `ruff` y `python -m compileall` sobre los archivos modificados y no se encontraron errores; `git diff --check` también está limpio.
- Verifiqué que no se modificaron `Lexer` ni `Parser` y que los cambios quedan limitados al wrapper y a la nueva prueba de integración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b368326488327bf4987ccde29ef14)