### PR TITLE
Fallback entrypoint and fork-safety in runner; update snapshots and tests

### DIFF
--- a/scripts/bin/cobra
+++ b/scripts/bin/cobra
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
 """Delega en el punto de entrada instalado de Cobra."""
 
-from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError, distribution
+import os
 import sys
 
 
 def main() -> int | None:
     """Carga ``cobra`` desde los metadatos del paquete instalado."""
 
+    try:
+        entry_points = distribution("pcobra").entry_points
+    except PackageNotFoundError:
+        os.execv(
+            sys.executable,
+            [sys.executable, "-m", "cobra.cli.cli", *sys.argv[1:]],
+        )
+
     entry_point = next(
         entry_point
-        for entry_point in distribution("pcobra").entry_points
+        for entry_point in entry_points
         if entry_point.group == "console_scripts" and entry_point.name == "cobra"
     )
     return entry_point.load()()

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -3,6 +3,7 @@ import logging
 import multiprocessing
 from queue import Empty
 from pathlib import Path
+import sys
 from typing import Any
 
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
@@ -138,6 +139,12 @@ class RunService:
         return resolved_path
 
     def limitar_recursos(self, funcion: Any) -> int:
+        try:
+            sys.stdout.fileno()
+            sys.stderr.fileno()
+        except (AttributeError, OSError):
+            return funcion()
+
         if "fork" not in multiprocessing.get_all_start_methods():
             return funcion()
 

--- a/tests/data/expected_examples/factorial_recursivo.py
+++ b/tests/data/expected_examples/factorial_recursivo.py
@@ -1,11 +1,11 @@
-from pcobra.core.nativos import *
+from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
 globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
 globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def factorial(n):
-    if (NodoIdentificador(n) <= 1):
+    if n <= 1:
         return 1
     else:
-        return (NodoIdentificador(n) * factorial((NodoIdentificador(n) - 1)))
+        return n * factorial(n - 1)
 print(factorial(5))

--- a/tests/data/expected_examples/suma.py
+++ b/tests/data/expected_examples/suma.py
@@ -1,9 +1,9 @@
-from pcobra.core.nativos import *
+from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
 globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
 globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def sumar(a, b):
-    c = (NodoIdentificador(a) + NodoIdentificador(b))
+    c = a + b
     print(c)
 sumar(2, 3)

--- a/tests/data/expected_examples/suma_matrices.py
+++ b/tests/data/expected_examples/suma_matrices.py
@@ -1,4 +1,4 @@
-from pcobra.core.nativos import *
+from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
 globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
@@ -12,8 +12,8 @@ def sumar_matriz():
     b12 = 6
     b21 = 7
     b22 = 8
-    print((NodoIdentificador(a11) + NodoIdentificador(b11)))
-    print((NodoIdentificador(a12) + NodoIdentificador(b12)))
-    print((NodoIdentificador(a21) + NodoIdentificador(b21)))
-    print((NodoIdentificador(a22) + NodoIdentificador(b22)))
+    print(a11 + b11)
+    print(a12 + b12)
+    print(a21 + b21)
+    print(a22 + b22)
 sumar_matriz()

--- a/tests/test_ejemplos_io.py
+++ b/tests/test_ejemplos_io.py
@@ -87,12 +87,12 @@ def test_build_muestra_fragmentos(nombre: str, ruta_ejemplos: Path) -> None:
 
 
 def _extraer_codigo_generado(stdout: str) -> str:
-    """Obtiene el código transpilado a partir de la salida de CLI."""
+    """Obtiene el código generado después del encabezado público de ``build``."""
     salida_limpia = _ANSI_RE.sub("", stdout)
     lineas = salida_limpia.splitlines()
     for indice, linea in enumerate(lineas):
-        if linea.startswith("from core.nativos import *"):
-            return "\n".join(lineas[indice:]).strip() + "\n"
+        if linea.startswith("Ruta de artefacto:"):
+            return "\n".join(lineas[indice + 1 :]).strip() + "\n"
     pytest.fail(
         "No se pudo extraer el código transpilado de la salida CLI. "
         "Asegúrate de que el comando 'build' imprima el código generado."

--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -31,6 +31,7 @@ def test_repl_v2_contrato_llama_prevalidacion_y_pipeline_compartido(monkeypatch)
     entradas = iter(["var x = 1", "exit"])
     parse_calls: list[str] = []
     ejecucion_calls: list[str] = []
+    ast_ejecucion: list[object] = []
     runtime_alternativo_calls: list[str] = []
 
     monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
@@ -40,11 +41,11 @@ def test_repl_v2_contrato_llama_prevalidacion_y_pipeline_compartido(monkeypatch)
         return [object()]
 
     monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
-    monkeypatch.setattr(
-        command._delegate,
-        "ejecutar_codigo",
-        lambda codigo: ejecucion_calls.append(codigo),
-    )
+    def _fake_ejecutar(codigo, _validador=None, *, ast_preparseado=None):
+        ejecucion_calls.append(codigo)
+        ast_ejecucion.extend(ast_preparseado or [])
+
+    monkeypatch.setattr(command._delegate, "ejecutar_codigo", _fake_ejecutar)
     monkeypatch.setattr(
         command._delegate,
         "_ejecutar_en_sandbox",
@@ -61,6 +62,7 @@ def test_repl_v2_contrato_llama_prevalidacion_y_pipeline_compartido(monkeypatch)
     assert status == 0
     assert parse_calls == ["var x = 1"]
     assert ejecucion_calls == ["var x = 1"]
+    assert len(ast_ejecucion) == 1
     assert runtime_alternativo_calls == []
 
 
@@ -127,7 +129,8 @@ def test_repl_v2_persistencia_estado_var_x_e_imprimir_x(monkeypatch, capsys):
     monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [object()])
     monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
 
-    def _fake_delegate(codigo: str):
+    def _fake_delegate(codigo: str, _validador=None, *, ast_preparseado=None):
+        assert ast_preparseado is not None
         interpretador = command._delegate.interpretador or estado
         if codigo == "var x = 10":
             interpretador["x"] = 10
@@ -167,7 +170,7 @@ def test_repl_v2_bloque_anidado_real_mientras_si_fin_fin_acumula_hasta_completar
     monkeypatch.setattr(
         command._delegate,
         "ejecutar_codigo",
-        lambda codigo: ejecucion_calls.append(codigo),
+        lambda codigo, _validador=None, **_kwargs: ejecucion_calls.append(codigo),
     )
 
     status = command.run(_args_repl())
@@ -208,7 +211,7 @@ def test_repl_v2_error_sintactico_real_limpia_buffer_y_repl_sigue(monkeypatch):
     monkeypatch.setattr(
         command._delegate,
         "ejecutar_codigo",
-        lambda codigo: ejecucion_calls.append(codigo),
+        lambda codigo, _validador=None, **_kwargs: ejecucion_calls.append(codigo),
     )
 
     status = command.run(_args_repl())
@@ -324,7 +327,7 @@ def test_repl_v2_bloque_incompleto_no_ejecuta_ni_limpia_hasta_completar(monkeypa
     monkeypatch.setattr(
         command._delegate,
         "ejecutar_codigo",
-        lambda codigo: ejecucion_calls.append(codigo),
+        lambda codigo, _validador=None, **_kwargs: ejecucion_calls.append(codigo),
     )
 
     status = command.run(_args_repl())


### PR DESCRIPTION
### Motivation
- Make the installed CLI entrypoint resilient when package metadata is missing and avoid forking in environments where standard streams lack file descriptors, and update generated snapshots and tests to match the new codegen and API shape.

### Description
- In `scripts/bin/cobra` catch `PackageNotFoundError` and fall back to executing `python -m cobra.cli.cli` when the `pcobra` distribution entry points are not available.
- In `src/pcobra/cobra/cli/services/run_service.py` add a check using `sys.stdout.fileno()`/`sys.stderr.fileno()` and avoid spawning a `fork`-based subprocess when these descriptors are unavailable, returning the function result directly.
- Update expected generated example snapshots under `tests/data/expected_examples` to use the new import path `pcobra.cobra.core.nativos` and simplified generated code patterns.
- Adapt tests in `tests/test_ejemplos_io.py` to extract generated code after the `Ruta de artefacto:` header and update `repl` unit tests to accept the new `ejecutar_codigo` calling convention that includes optional `_validador` and `ast_preparseado` parameters.

### Testing
- Ran the updated unit tests under `tests/unit`, including the `repl` command tests, and they completed successfully.
- Ran the example build snapshot test `tests/test_ejemplos_io.py` after updating snapshots and it passed.
- Ran the full test suite with `pytest` and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b3a1035dc8327a8d879cf115676c1)