### PR TITLE
Simplify PermissionError handling in usar_loader and update public API snapshot

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -856,19 +856,8 @@ def usar_modulo(
             wrapper_legacy or wrapper_oficial_legacy
         ):
             try:
-                segmentos_proyecto = validar_nombre_modulo_cobra_proyecto(nombre_raw)
+                validar_nombre_modulo_cobra_proyecto(nombre_raw)
             except ValueError:
-                raise permiso_exc
-            current = (
-                Path(current_file).expanduser() if current_file is not None else None
-            )
-            root = (
-                canonicalizar_ruta_usar_proyecto(project_root)
-                if project_root is not None
-                else descubrir_raiz_proyecto(current, current)
-            )
-            ruta_proyecto = root.joinpath(*segmentos_proyecto).with_suffix(".co")
-            if not ruta_proyecto.exists():
                 raise permiso_exc
         else:
             try:

--- a/tests/snapshots/public_api_por_modulo.json
+++ b/tests/snapshots/public_api_por_modulo.json
@@ -44,6 +44,7 @@
         "producto"
     ],
     "texto": [
+        "a_snake",
         "mayusculas",
         "minusculas",
         "prefijo_comun",


### PR DESCRIPTION
### Motivation

- Remove fragile project-file existence checks when falling back from catalog permission errors and keep validation semantics simple. 
- Reflect addition of a new exported text utility in the public API snapshot.

### Description

- In `usar_loader.py` simplified the `PermissionError` fallback: call `validar_nombre_modulo_cobra_proyecto(nombre_raw)` for validation but remove the previous logic that computed `segmentos_proyecto`, resolved `project_root`, and checked for a `.co` file on disk. 
- Kept legacy wrapper resolution and sanitization logic intact for `obtener_modulo` / `obtener_modulo_cobra_oficial` paths. 
- Updated the public API snapshot `tests/snapshots/public_api_por_modulo.json` to include the new `texto` export `"a_snake"`.

### Testing

- Ran the automated test suite including snapshot tests, and the updated snapshot `tests/snapshots/public_api_por_modulo.json` reflects the new `"a_snake"` export. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b40130ee88327b52f8e75a470789d)