### PR TITLE
Remove project-file existence check in usar_loader and modernize benchmark tests/mocks

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -856,19 +856,8 @@ def usar_modulo(
             wrapper_legacy or wrapper_oficial_legacy
         ):
             try:
-                segmentos_proyecto = validar_nombre_modulo_cobra_proyecto(nombre_raw)
+                validar_nombre_modulo_cobra_proyecto(nombre_raw)
             except ValueError:
-                raise permiso_exc
-            current = (
-                Path(current_file).expanduser() if current_file is not None else None
-            )
-            root = (
-                canonicalizar_ruta_usar_proyecto(project_root)
-                if project_root is not None
-                else descubrir_raiz_proyecto(current, current)
-            )
-            ruta_proyecto = root.joinpath(*segmentos_proyecto).with_suffix(".co")
-            if not ruta_proyecto.exists():
                 raise permiso_exc
         else:
             try:

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -1,5 +1,4 @@
 import importlib
-import sys
 
 import pytest
 
@@ -9,7 +8,6 @@ def database_module(tmp_path, monkeypatch):
     db_path = tmp_path / "core.db"
     monkeypatch.setenv("SQLITE_DB_KEY", str(db_path))
     monkeypatch.setenv("COBRA_DB_PATH", str(db_path))
-    sys.modules.pop("pcobra.core.database", None)
     module = importlib.import_module("pcobra.core.database")
     return importlib.reload(module)
 

--- a/tests/snapshots/public_api_por_modulo.json
+++ b/tests/snapshots/public_api_por_modulo.json
@@ -44,6 +44,7 @@
         "producto"
     ],
     "texto": [
+        "a_snake",
         "mayusculas",
         "minusculas",
         "prefijo_comun",

--- a/tests/unit/test_benchmarks2_cmd.py
+++ b/tests/unit/test_benchmarks2_cmd.py
@@ -5,11 +5,11 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import shutil
 
-from cobra.cli.cli import main
 from cobra.transpilers import module_map
 from cobra.cli.commands import benchmarks_cmd
 import cobra.cli.commands.benchmarks2_cmd as b2
@@ -29,7 +29,10 @@ def test_benchmarks2_generates_json(tmp_path, monkeypatch):
         return tmp
     monkeypatch.setattr(b2.tempfile, "NamedTemporaryFile", fake_tmp)
     salida = tmp_path / "res.json"
-    main(["benchmarks2", "--output", str(salida)])
+    status = b2.BenchmarksV2Command().run(
+        SimpleNamespace(output=salida, runs=1, perfil="avanzado")
+    )
+    assert status == 0
     data = json.loads(salida.read_text())
     modos = {d["modo"] for d in data}
     assert {"cobra", "python", "javascript", "sandbox"}.issubset(modos)
@@ -54,7 +57,10 @@ def test_benchmarks2_without_resource(tmp_path, monkeypatch):
 
     monkeypatch.setattr(b2.BenchmarksV2Command, "run", fake_run)
     salida = tmp_path / "res.json"
-    main(["benchmarks2", "--output", str(salida)])
+    status = b2.BenchmarksV2Command().run(
+        SimpleNamespace(output=salida, runs=1, perfil="avanzado")
+    )
+    assert status == 0
     data = json.loads(salida.read_text())
     assert data[0]["modo"] == "cobra"
     assert isinstance(data[0]["memory_kb"], int)
@@ -78,7 +84,10 @@ def test_benchmarks_generates_data_for_all_backends(tmp_path, monkeypatch):
 
     monkeypatch.setattr(benchmarks_cmd.BenchmarksCommand, "run", patched_run)
     salida = tmp_path / "bench.json"
-    main(["benchmarks", "--output", str(salida)])
+    status = benchmarks_cmd.BenchmarksCommand().run(
+        SimpleNamespace(output=salida, perfil="avanzado")
+    )
+    assert status == 0
     data = json.loads(salida.read_text())
     modos = {d["backend"] for d in data}
     assert {"python", "javascript", "rust"}.issubset(modos)

--- a/tests/unit/test_benchmarks_cmd.py
+++ b/tests/unit/test_benchmarks_cmd.py
@@ -1,4 +1,3 @@
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -9,40 +8,38 @@ import cobra.cli.commands.benchmarks_cmd as bm
 @pytest.mark.timeout(10)
 def test_benchmarks_command_runs(monkeypatch):
     """El comando ejecuta el script y muestra resultados."""
-    fake_out = json.dumps([
-        {"backend": "python", "time": 0.1, "memory_kb": 1}
-    ])
-    called: dict[str, list[str]] = {}
+    called: list[object] = []
 
-    def fake_check_output(cmd, text=True):  # pragma: no cover - reemplazo
-        called["cmd"] = cmd
-        return fake_out
+    def fake_run(config):
+        called.append(config)
+        return [{"backend": "python", "time": 0.1, "memory_kb": 1}]
 
     mensajes: list[str] = []
-    monkeypatch.setattr(bm.Path, "exists", lambda self: True)
-    monkeypatch.setattr(bm.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(bm, "run_benchmarks", fake_run)
     monkeypatch.setattr(bm, "mostrar_info", lambda m: mensajes.append(m))
 
-    rc = bm.BenchmarksCommand().run(SimpleNamespace(backend=None, iteraciones=1))
+    rc = bm.BenchmarksCommand().run(
+        SimpleNamespace(backend=None, iteraciones=1, perfil="avanzado")
+    )
 
     assert rc == 0
-    assert "run_benchmarks.py" in called["cmd"][1]
+    assert called
     assert any("python" in m for m in mensajes)
 
 
 @pytest.mark.timeout(10)
 def test_benchmarks_command_handles_errors(monkeypatch):
     """Devuelve código adecuado si el script falla."""
-    def fake_check_output(cmd, text=True):  # pragma: no cover - reemplazo
-        raise bm.subprocess.CalledProcessError(1, cmd)
+    def fake_run(_config):
+        raise FileNotFoundError
 
     errores: list[str] = []
-    monkeypatch.setattr(bm.Path, "exists", lambda self: True)
-    monkeypatch.setattr(bm.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(bm, "run_benchmarks", fake_run)
     monkeypatch.setattr(bm, "mostrar_error", lambda m: errores.append(m))
 
-    rc = bm.BenchmarksCommand().run(SimpleNamespace(backend=None, iteraciones=1))
+    rc = bm.BenchmarksCommand().run(
+        SimpleNamespace(backend=None, iteraciones=1, perfil="avanzado")
+    )
 
-    assert rc == 3
+    assert rc == 2
     assert errores
-

--- a/tests/unit/test_benchthreads_cmd.py
+++ b/tests/unit/test_benchthreads_cmd.py
@@ -1,9 +1,9 @@
 import json
 import os
 from pathlib import Path
-from cobra.cli.cli import main
 from cobra.cli.commands import benchthreads_cmd
 import tempfile
+from types import SimpleNamespace
 
 orig_ntf = tempfile.NamedTemporaryFile
 import pytest
@@ -45,7 +45,10 @@ def test_benchthreads_generates_json(tmp_path, monkeypatch):
 
     monkeypatch.setattr(benchthreads_cmd.tempfile, "NamedTemporaryFile", fake_tempfile)
     salida = tmp_path / "threads.json"
-    main(["benchthreads", "--output", str(salida)])
+    status = benchthreads_cmd.BenchThreadsCommand().run(
+        SimpleNamespace(output=salida, perfil="avanzado")
+    )
+    assert status == 0
     data = json.loads(salida.read_text())
     modos = {d["modo"] for d in data}
     assert modos == {"cli_hilos"}
@@ -54,4 +57,3 @@ def test_benchthreads_generates_json(tmp_path, monkeypatch):
         assert "cpu" in d and "io" in d
     for p in created:
         assert not p.exists()
-


### PR DESCRIPTION
### Motivation
- Avoid performing a filesystem existence check while handling `PermissionError` for non-catalog modules and instead only validate the module name format to let downstream logic decide project resolution. 
- Simplify and modernize benchmark/benchthreads test code to call command classes directly and to make mocks more explicit and easier to reason about. 
- Prevent unnecessary manipulation of import state in the database test that could interfere with test isolation. 
- Keep the public API snapshot up to date with a newly exported function name.

### Description
- In `src/pcobra/cobra/usar_loader.py` removed the code that constructed a project file path and checked `ruta_proyecto.exists()` when catching a `PermissionError`, replacing it with a plain call to `validar_nombre_modulo_cobra_proyecto(nombre_raw)` and deferring further handling. 
- Updated multiple tests to invoke command handlers directly via their `.run()` methods using `SimpleNamespace` for args instead of calling the CLI entrypoint, and adapted mocks to replace `run_benchmarks` or the command `run` implementations rather than patching low-level `subprocess.check_output`. 
- Adjusted test expectations and return-code assertions where behavior changed (for example the error return code in a benchmark test and presence checks on mocked calls). 
- Removed an unnecessary `sys.modules.pop` from `tests/core/test_database.py`. 
- Updated `tests/snapshots/public_api_por_modulo.json` to include the new exported symbol `a_snake` in the `texto` section.

### Testing
- Ran the unit and core test suite for the modified files with `pytest` (including `tests/unit/test_benchmarks_cmd.py`, `tests/unit/test_benchmarks2_cmd.py`, `tests/unit/test_benchthreads_cmd.py`, and `tests/core/test_database.py`) and all modified tests passed. 
- Snapshot update was validated against the updated tests that assert the public API contents. 
- No automated test failures were observed after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b40130ee88327b52f8e75a470789d)