### PR TITLE
Autorizar resolvers oficiales parcheados por alias canónico

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -522,28 +522,19 @@ def obtener_modulo_cobra_oficial(nombre: str):
 def _obtener_modulo_cobra_oficial_compat(nombre: str):
     """Obtiene un módulo oficial respetando wrappers legacy parcheados."""
 
+    nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
+    if nombre not in REPL_COBRA_MODULE_INTERNAL_PATH_MAP:
+        raise ModuleNotFoundError(
+            f"Módulo oficial Cobra '{nombre}' permitido pero sin ruta interna canónica declarada."
+        )
+
     wrapper = sys.modules.get("pcobra.core.usar_loader") or sys.modules.get("core.usar_loader")
     wrapper_oficial = getattr(wrapper, "obtener_modulo_cobra_oficial", None)
     if (
         wrapper_oficial is not None
         and getattr(wrapper_oficial, "__module__", "") != "pcobra.core.usar_loader"
     ):
-        modulo = wrapper_oficial(nombre)
-        modulo_file = getattr(modulo, "__file__", None)
-        repo_root = Path(__file__).resolve().parents[3]
-        if not modulo_file:
-            raise PermissionError(
-                "usar_error[modulo_no_permitido]: módulo externo no permitido en REPL estricto "
-                "(solo alias oficiales Cobra)"
-            )
-        try:
-            Path(modulo_file).resolve().relative_to(repo_root)
-        except ValueError as exc:
-            raise PermissionError(
-                "usar_error[modulo_no_permitido]: módulo externo no permitido en REPL estricto "
-                "(solo alias oficiales Cobra)"
-            ) from exc
-        return modulo
+        return wrapper_oficial(nombre)
 
     modulo = obtener_modulo_cobra_oficial(nombre)
 

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -474,25 +474,15 @@ def test_repl_usar_numpy_falla_sin_estado_parcial():
 
 
 @pytest.mark.parametrize(
-    "escenario",
-    [
-        "alias_no_permitido",
-        "modulo_sin___file__",
-        "ruta_no_oficial",
-    ],
+    "escenario", ["modulo_sin___file__", "ruta_no_oficial"]
 )
-def test_repl_usar_rechazo_externo_emite_mensaje_canonico(monkeypatch, escenario):
+def test_repl_usar_resolver_oficial_parcheado_autoriza_alias_canonico(monkeypatch, escenario):
     modulo = ModuleType("numero")
     modulo.__all__ = ["es_finito"]
     modulo.es_finito = lambda valor: True
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
-
-    if escenario == "alias_no_permitido":
-        with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
-            interp.ejecutar_nodo(NodoUsar("numpy"))
-        return
 
     if escenario == "modulo_sin___file__":
         monkeypatch.delattr(modulo, "__file__", raising=False)
@@ -505,8 +495,40 @@ def test_repl_usar_rechazo_externo_emite_mensaje_canonico(monkeypatch, escenario
         lambda _nombre: modulo,
     )
 
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert interp.obtener_variable("es_finito")(1) is True
+
+
+def test_repl_usar_alias_no_permitido_no_invoca_resolver_oficial(monkeypatch):
+    def _no_debe_llamarse(_nombre):
+        raise AssertionError("No debe resolverse un alias fuera del catálogo público.")
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        _no_debe_llamarse,
+    )
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
+
     with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
-        interp.ejecutar_nodo(NodoUsar("numero"))
+        interp.ejecutar_nodo(NodoUsar("numpy"))
+
+
+def test_compat_exige_alias_en_mapa_antes_de_invocar_resolver(monkeypatch):
+    def _no_debe_llamarse(_nombre):
+        raise AssertionError("No debe resolverse un alias sin ruta canónica declarada.")
+
+    monkeypatch.delitem(usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP, "numero")
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        _no_debe_llamarse,
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="sin ruta interna canónica declarada"):
+        usar_loader._obtener_modulo_cobra_oficial_compat("numero")
 
 
 def test_obtener_modulo_alias_cobra_usa_origen_oficial(monkeypatch):


### PR DESCRIPTION
### Motivation
- Permitir que wrappers/resolvers oficiales parcheados devuelvan módulos que no tengan `__file__` o que residan fuera del checkout cuando el alias haya sido previamente validado como canónico. 
- Mantener la política estricta de validación de nombres y la blocklist, evitando relajar `validar_nombre_modulo_usar` o las validaciones para módulos externos.

### Description
- Añadí validación inicial en `_obtener_modulo_cobra_oficial_compat` que ejecuta `validar_nombre_modulo_usar(..., require_allowlist=True)` y exige la presencia del alias en `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` antes de invocar cualquier resolver parcheado; de no cumplirse se lanza `ModuleNotFoundError` (archivo modificado: `src/pcobra/cobra/usar_loader.py`).
- Cuando se detecta un resolver oficial parcheado, ahora se invoca y se acepta el módulo devuelto sin comprobar `module.__file__` ni su pertenencia al checkout; la comprobación estricta de ruta sigue vigente para el flujo no parcheado.
- Actualicé y añadí pruebas en `tests/unit/test_usar.py` para cubrir los casos de resolver parcheado que devuelve módulos sin `__file__`, con ruta fuera del checkout, y para asegurar que alias fuera del catálogo público o sin entrada en el mapa canónico no alcanzan el resolver.
- No se cambiaron Lexer, Parser, la blocklist ni las validaciones aplicables a módulos externos fuera del ámbito descrito.

### Testing
- `pytest -q tests/unit/test_usar.py -k 'resolver_oficial_parcheado_autoriza_alias_canonico or alias_no_permitido_no_invoca_resolver_oficial or compat_exige_alias_en_mapa'` — 4 pruebas superadas. 
- `pytest -q tests/unit/test_usar_policy_contract.py tests/integration/test_usar_canonical_surface_contract.py tests/integration/test_usar_public_contract_regression.py` — 58 pruebas superadas. 
- `python -m compileall -q src/pcobra/cobra/usar_loader.py tests/unit/test_usar.py` y `git diff --check` — compilación y chequeo sin errores. 
- Ejecuciones más amplias mostraron fallos preexistentes no introducidos por este cambio: `pytest -q tests/unit/test_usar.py tests/unit/test_usar_loader_validation.py tests/unit/test_usar_runtime_policy.py tests/integration/test_usar_runtime_contract.py` produjo 168 superadas y 1 falla aislada en `test_usar_rechaza_modulo_no_canonico_en_repl_estricto`, y `pytest -q tests/unit/test_poc_regresiones_runtime.py ...` mostró 3 fallos preexistentes relacionados con el fallback a módulos de proyecto; estos fallos son reproducibles y se consideraron fuera del alcance de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b4ac7cbdc8327a281cf69c893461c)