### PR TITLE
Evita fallback de `usar` al proyecto en REPL estricto

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -795,6 +795,7 @@ def usar_modulo(
     current_file: str | Path | None = None,
     module_cache: dict[Path, dict[str, Any]] | None = None,
     loading_stack: list[Path] | None = None,
+    permitir_modulos_proyecto: bool | None = None,
 ) -> dict[str, Any]:
     """API única para resolver ``usar`` en runtime y transpilación Python.
 
@@ -808,7 +809,13 @@ def usar_modulo(
     if not nombre_raw:
         raise ValueError("Nombre de módulo vacío en 'usar'.")
 
-    # 1. Intentar cargar como módulo oficial Cobra
+    contexto_proyecto_autorizado = (
+        permitir_modulos_proyecto
+        if permitir_modulos_proyecto is not None
+        else project_root is not None or current_file is not None
+    )
+
+    # Caso 1: alias oficial presente en la superficie pública Cobra.
     try:
         nombre_validado_oficial = validar_nombre_modulo_usar(nombre_raw, require_allowlist=True)
         modulo = obtener_modulo(nombre_validado_oficial)
@@ -827,10 +834,16 @@ def usar_modulo(
             raise ImportError(f"No se encontraron símbolos exportables para usar '{nombre_validado_oficial}'.")
         return _construir_exports_usar(simbolos_saneados, metadata_por_simbolo)
     except PermissionError as permiso_exc:
-        # If we get a PermissionError, only try legacy wrappers or project module
-        # if it's a "modulo fuera catalogo" error; otherwise re-raise
+        # Caso 3: un nombre externo/no canónico no puede convertirse
+        # implícitamente en módulo de proyecto desde el REPL estricto. Se
+        # conserva íntegro el PermissionError contractual de la allowlist.
         if not str(permiso_exc).startswith("usar_error[modulo_fuera_catalogo_publico]"):
             raise permiso_exc
+        if not contexto_proyecto_autorizado:
+            raise permiso_exc
+
+        # Caso 2: sólo un contexto de proyecto autorizado puede continuar al
+        # resolvedor Cobra de proyecto (incluida la compatibilidad legacy).
         wrapper = sys.modules.get("pcobra.core.usar_loader") or sys.modules.get("core.usar_loader")
         wrapper_obtener = getattr(wrapper, "obtener_modulo", None)
         wrapper_obtener_oficial = getattr(wrapper, "obtener_modulo_cobra_oficial", None)
@@ -878,7 +891,11 @@ def usar_modulo(
         # pero podría serlo para un módulo de proyecto (ej. contiene puntos).
         pass
 
-    # 2. Intentar cargar como módulo de proyecto
+    # Caso 2: resolver como módulo Cobra de proyecto únicamente después de
+    # comprobar que el caller aportó/autorizó ese contexto.
+    if not contexto_proyecto_autorizado:
+        validar_nombre_modulo_usar(nombre_raw, require_allowlist=True)
+
     try:
         segmentos_proyecto = validar_nombre_modulo_cobra_proyecto(nombre_raw)
         nombre_validado_proyecto = ".".join(segmentos_proyecto)

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -102,6 +102,7 @@ def _usar_modulo_con_estado_aislado(
     current_file: Path | None,
     module_cache: dict[Path, dict[str, object]],
     loading_stack: list[Path],
+    permitir_modulos_proyecto: bool = True,
 ) -> Mapping[str, object]:
     """Llama a ``usar_modulo`` pasando estado aislado si la función lo soporta."""
 
@@ -115,6 +116,10 @@ def _usar_modulo_con_estado_aislado(
     ):
         kwargs["module_cache"] = module_cache
         kwargs["loading_stack"] = loading_stack
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parametros.values()) or (
+        "permitir_modulos_proyecto" in parametros
+    ):
+        kwargs["permitir_modulos_proyecto"] = permitir_modulos_proyecto
     return usar_modulo(nombre, **kwargs)
 USAR_DIRECT_BACKEND_IMPORT_ERROR = (
     "usar_error[backend_import_directo]: import directo de backend no permitido en usar"
@@ -2565,6 +2570,9 @@ class InterpretadorCobra:
                 current_file=current_file,
                 module_cache=self._usar_module_cache,
                 loading_stack=self._usar_loading_stack,
+                permitir_modulos_proyecto=(
+                    self._repl_usar_alias_map is None or current_file is not None
+                ),
             )
             self._inyectar_exports_modulo_proyecto(exports)
         except Exception as exc:

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -433,6 +433,34 @@ def test_usar_modulo_api_nombre_simple_inexistente_mantiene_error_publico(tmp_pa
         usar_modulo("numpy", current_file=principal)
 
 
+def test_usar_modulo_repl_estricto_no_resuelve_nombre_simple_como_proyecto(
+    monkeypatch, tmp_path
+):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "num.co").write_text("", encoding="utf-8")
+
+    def resolver_no_esperado(*_args, **_kwargs):
+        raise AssertionError("el REPL estricto no debe consultar el proyecto")
+
+    monkeypatch.setattr(
+        "pcobra.cobra.usar_loader._cargar_exports_modulo_cobra_proyecto",
+        resolver_no_esperado,
+    )
+
+    with pytest.raises(PermissionError) as excinfo:
+        usar_modulo(
+            "num",
+            project_root=proyecto,
+            permitir_modulos_proyecto=False,
+        )
+
+    assert str(excinfo.value) == (
+        "usar_error[modulo_fuera_catalogo_publico]: "
+        "'num' está fuera del catálogo público."
+    )
+
+
 def test_interpretador_usar_proyecto_misma_carpeta_con_nombre_simple(monkeypatch, tmp_path):
     proyecto = tmp_path / "app"
     proyecto.mkdir()


### PR DESCRIPTION
### Motivation

- Evitar que un nombre simple no canónico (p. ej. `num`) sea derivado automáticamente al resolvedor de módulos de proyecto cuando la llamada procede del REPL estricto. 
- Preservar el contrato existente que lanza `PermissionError` para módulos fuera del catálogo público, manteniendo intacto tipo y mensaje. 
- Mantener la resolución de módulos de proyecto cuando exista un contexto de proyecto autorizado y conservar todas las validaciones de rutas y traversal.

### Description

- Añadido el parámetro opcional `permitir_modulos_proyecto` a `usar_modulo()` para controlar explícitamente si se permite consultar el resolvedor de módulos de proyecto. 
- Separado el flujo de `usar_modulo()` en tres casos claros: alias oficial en `USAR_COBRA_PUBLIC_MODULES`, módulos Cobra de proyecto autorizados por contexto, y nombres externos/no canónicos que deben respetar el `PermissionError` contractual. 
- Modificada la llamada aislada en el intérprete (`_usar_modulo_con_estado_aislado` y `InterpretadorCobra.ejecutar_usar`) para propagar el permiso de resolución de proyecto en función de si el REPL tiene alias (REPL estricto) o existe `current_file`/`project_root`. 
- Añadida una prueba de regresión que confirma que en REPL estricto no se invoca el cargador de proyecto y que el `PermissionError` conserva exactamente su mensaje.

### Testing

- Ejecutadas pruebas focales: `pytest -q tests/unit/test_project_root_usar_resolution.py -k 'usar_modulo_api_resuelve_util or usar_modulo_repl_estricto_no_resuelve or nombre_simple_inexistente'` y resultaron en 4 pruebas superadas. 
- Ejecutadas pruebas más amplias: `pytest -q tests/unit/test_project_root_usar_resolution.py -k 'not import_archivo_co_detecta_ciclo_de_ejecucion_legacy' tests/core/test_usar_policy_nuevas_corelibs.py tests/test_transpilers.py` y se obtuvieron 127 pruebas superadas (1 excluida por filtro) con 1 warning. 
- Verificado `git diff --check` y que no se modificaron Lexer ni Parser con `git diff --name-only | rg -i '(lexer|parser)'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b4c69ac1c8327bb3d2426b814e06f)