### PR TITLE
test: cubrir longitud de texto en el REPL

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -160,6 +160,15 @@ def test_repl_entrypoint_numero_es_finito_imprime_verdadero(capsys):
     assert "verdadero" in salida
 
 
+def test_repl_entrypoint_texto_longitud_imprime_cuatro(capsys):
+    cmd = ReplCommandV2()
+    cmd._ejecutar_en_modo_normal('usar "texto"')
+    cmd._ejecutar_en_modo_normal('imprimir(longitud("hola"))')
+
+    salida = [linea.strip() for linea in capsys.readouterr().out.splitlines() if linea.strip()]
+    assert salida == ["4"]
+
+
 def test_repl_entrypoint_archivo_existe_booleano_sin_error_metadata(capsys):
     cmd = ReplCommandV2()
     cmd._ejecutar_en_modo_normal('usar "archivo"')


### PR DESCRIPTION
### Motivation

- Añadir una prueba de regresión mínima que verifique mediante el entry point REPL que `usar "texto"` expone la función `longitud` y que `imprimir(longitud("hola"))` produce exactamente la línea `4`.

### Description

- Se añadió la prueba `test_repl_entrypoint_texto_longitud_imprime_cuatro` en `tests/integration/test_repl_usar_entrypoints_contract.py` que crea un `ReplCommandV2`, ejecuta `usar "texto"` y `imprimir(longitud("hola"))`, captura la salida y exige exactamente `["4"]`.
- No se realizaron cambios en el intérprete, la documentación, ejemplos, snapshots, Lexer ni Parser; solo se añadió el test y se cometió (`test: cubrir longitud de texto en REPL`).

### Testing

- Ejecutado `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py::test_repl_entrypoint_texto_longitud_imprime_cuatro` y la prueba falló con `NameError: Variable no declarada: longitud` (regresión detectada).
- Ejecutado `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y el resultado fue `94 passed, 1 failed`, siendo la única falla la nueva prueba de regresión.
- Verificaciones adicionales: `git diff --check` sin errores y no se detectaron cambios en Lexer/Parser según el estado del repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b4e18d70c8327ae13c00a0226f517)