### PR TITLE
Add Jupyter kernel install entry point

### DIFF
--- a/src/pcobra/jupyter_kernel/__main__.py
+++ b/src/pcobra/jupyter_kernel/__main__.py
@@ -1,0 +1,18 @@
+"""Punto de entrada para instalar el kernel de Jupyter."""
+
+import argparse
+
+from pcobra.jupyter_kernel import install
+
+
+def main() -> int:
+    """Instala el kernel cuando se solicita mediante el único comando válido."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("install",))
+    parser.parse_args()
+    install()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Añadir un entry point mínimo para permitir `python -m pcobra.jupyter_kernel install` que invoque la API pública del paquete sin cambiar otros CLI, Lexer/Parser ni realizar instalaciones reales durante las pruebas.

### Description
- Se creó `src/pcobra/jupyter_kernel/__main__.py` que acepta únicamente el argumento posicional `install`, importa y llama a `pcobra.jupyter_kernel.install()`, devuelve `0` en éxito y usa la guarda `if __name__ == "__main__"` para exponer el entry point.

### Testing
- Se ejecutó una prueba aislada con `unittest.mock` que verificó que `install()` se invoca exactamente una vez con `install` y que argumentos ausentes/inválidos/extra producen `SystemExit(2)`, además de `pytest tests/integration/test_cli_integration.py` (4 tests pasados), `ruff` y comprobaciones `git diff --check`, todos exitosos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b4f86668c832796a5f60113421f60)