### PR TITLE
Verifica el contexto de proyecto antes de resolver `usar`

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -796,6 +796,7 @@ def usar_modulo(
     module_cache: dict[Path, dict[str, Any]] | None = None,
     loading_stack: list[Path] | None = None,
     permitir_modulos_proyecto: bool | None = None,
+    contexto_proyecto_verificado: bool | None = None,
 ) -> dict[str, Any]:
     """API única para resolver ``usar`` en runtime y transpilación Python.
 
@@ -809,10 +810,18 @@ def usar_modulo(
     if not nombre_raw:
         raise ValueError("Nombre de módulo vacío en 'usar'.")
 
+    # La señal nueva distingue un contexto derivado de un ``main_file``
+    # canonicalizado del mero hecho de recibir rutas. El parámetro histórico se
+    # conserva para callers externos, pero no interviene cuando la señal
+    # verificable está presente.
     contexto_proyecto_autorizado = (
-        permitir_modulos_proyecto
-        if permitir_modulos_proyecto is not None
-        else project_root is not None or current_file is not None
+        contexto_proyecto_verificado
+        if contexto_proyecto_verificado is not None
+        else (
+            permitir_modulos_proyecto
+            if permitir_modulos_proyecto is not None
+            else project_root is not None or current_file is not None
+        )
     )
 
     # Caso 1: alias oficial presente en la superficie pública Cobra.

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -102,7 +102,7 @@ def _usar_modulo_con_estado_aislado(
     current_file: Path | None,
     module_cache: dict[Path, dict[str, object]],
     loading_stack: list[Path],
-    permitir_modulos_proyecto: bool = True,
+    contexto_proyecto_verificado: bool,
 ) -> Mapping[str, object]:
     """Llama a ``usar_modulo`` pasando estado aislado si la función lo soporta."""
 
@@ -117,9 +117,9 @@ def _usar_modulo_con_estado_aislado(
         kwargs["module_cache"] = module_cache
         kwargs["loading_stack"] = loading_stack
     if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parametros.values()) or (
-        "permitir_modulos_proyecto" in parametros
+        "contexto_proyecto_verificado" in parametros
     ):
-        kwargs["permitir_modulos_proyecto"] = permitir_modulos_proyecto
+        kwargs["contexto_proyecto_verificado"] = contexto_proyecto_verificado
     return usar_modulo(nombre, **kwargs)
 USAR_DIRECT_BACKEND_IMPORT_ERROR = (
     "usar_error[backend_import_directo]: import directo de backend no permitido en usar"
@@ -596,14 +596,10 @@ class InterpretadorCobra:
         # Metadatos de símbolos inyectados por `usar` para soportar reimport idempotente.
         # nombre_simbolo -> {"module": str, "exported_name": str, "callable_id": int}
         self._usar_symbol_metadata: dict[str, dict[str, object]] = {}
-        self._main_file: Path | None = (
-            Path(main_file).expanduser().resolve(strict=False)
-            if main_file is not None
-            else None
-        )
-        self._project_root: Path = descubrir_raiz_proyecto(
-            self._main_file, self._main_file
-        )
+        self._main_file: Path | None = None
+        self._project_root: Path = Path.cwd().resolve()
+        self._contexto_proyecto_verificado = False
+        self.configurar_archivo_principal(main_file)
         self._current_module_stack: list[Path] = []
         self._usar_module_cache: dict[Path, dict[str, object]] = {}
         self._usar_loading_stack: list[Path] = []
@@ -1623,6 +1619,7 @@ class InterpretadorCobra:
             else None
         )
         self._project_root = descubrir_raiz_proyecto(self._main_file, self._main_file)
+        self._contexto_proyecto_verificado = self._main_file is not None
 
     def ejecutar_nodo(self, nodo):
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
@@ -2500,6 +2497,7 @@ class InterpretadorCobra:
             current_file=current_file,
             module_cache=self._usar_module_cache,
             loading_stack=self._usar_loading_stack,
+            contexto_proyecto_verificado=self._contexto_proyecto_verificado,
         )
         self._inyectar_exports_modulo_proyecto(exports)
 
@@ -2570,9 +2568,7 @@ class InterpretadorCobra:
                 current_file=current_file,
                 module_cache=self._usar_module_cache,
                 loading_stack=self._usar_loading_stack,
-                permitir_modulos_proyecto=(
-                    self._repl_usar_alias_map is None or current_file is not None
-                ),
+                contexto_proyecto_verificado=self._contexto_proyecto_verificado,
             )
             self._inyectar_exports_modulo_proyecto(exports)
         except Exception as exc:


### PR DESCRIPTION
### Motivation

- Evitar la condición ad hoc que permitía módulos de proyecto por la mera presencia de `current_file` o el estado REPL, y sustituirla por una señal verificable y explícita derivada de un `main_file` canonicalizado.
- Preservar la política de confianza actual (raíz canonicalizada, verificación dentro de la raíz y caché por ruta canónica) y mantener el REPL estricto sin habilitar módulos de proyecto salvo cuando exista el contexto verificado.

### Description

- Introduce la señal explícita `_contexto_proyecto_verificado` en `InterpretadorCobra`, que se establece al configurar un `main_file` canonicalizado mediante `descubrir_raiz_proyecto` y su descubrimiento ascendente de `cobra.toml` (si procede). (archivo modificado: `src/pcobra/core/interpreter.py`).
- Reemplaza el uso ad hoc previo en `ejecutar_usar` por la transmisión de `contexto_proyecto_verificado` a la API de carga; el intérprete ya no deduce permiso basándose en el mapa REPL o en la mera presencia de `current_file`. (archivo modificado: `src/pcobra/core/interpreter.py`).
- Añade el parámetro `contexto_proyecto_verificado` a la API de `usar_modulo` y hace que esta señal tenga precedencia sobre el parámetro histórico `permitir_modulos_proyecto`, que se conserva por compatibilidad. La resolución de módulos de proyecto sigue usando `resolver_ruta_canonica_modulo_cobra_proyecto`, `_verificar_path_dentro_de_root` y la caché por ruta canónica. (archivo modificado: `src/pcobra/cobra/usar_loader.py`).
- No se modificaron Lexer ni Parser, no se añadieron tokens ni reglas sintácticas, y no se alteraron pruebas ni documentación más allá de los cambios de comportamiento restringidos arriba.

### Testing

- ✅ Ejecuté los escenarios dirigidos relevantes con `pytest -q tests/unit/test_project_root_usar_resolution.py -k "ejecucion_desde_cwd_externo or descubrir_raiz_proyecto_prefiere_cobra_toml or cache_clave_canonica or reutiliza_cache or fuera_de_project_root or fuera_de_la_raiz"` — los casos dirigidos pasaron (4 passed).
- ✅ Ejecuté el conjunto de pruebas unitarias focales sin el caso legacy problemático: `pytest -q tests/unit/test_project_root_usar_resolution.py -k 'not test_import_archivo_co_detecta_ciclo_de_ejecucion_legacy'` — 75 passed.
- ✅ Ejecuté la suite de integración del REPL: `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` — 95 passed, confirmando que los rechazos del REPL estricto se mantienen.
- ⚠️ Al ejecutar ambas suites juntas inicialmente obtuve `170 passed, 1 failed`; ese único fallo corresponde a `test_import_archivo_co_detecta_ciclo_de_ejecucion_legacy` (RecursionError) y es un problema legacy de la ruta `import` que ya existía; no se tocó porque la corrección debía centrarse exclusivamente en la señal de contexto de `usar`.
- ✅ Comprobaciones adicionales: `git diff --check` y verificación de que no hubo cambios en `src/pcobra/core/lexer.py` ni `src/pcobra/core/parser.py` (Lexer/Parser intactos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b596ac218832789c25ae2cac4dc89)