### PR TITLE
Use KernelSpecManager to install the Cobra Jupyter kernel

### DIFF
--- a/src/pcobra/jupyter_kernel/__init__.py
+++ b/src/pcobra/jupyter_kernel/__init__.py
@@ -1,12 +1,15 @@
 """Kernel de Jupyter que permite ejecutar código Cobra en notebooks."""
 
-import sys
-import io
-import os
 import contextlib
 import importlib
+import io
+import json
+import os
+import sys
+import tempfile
 from importlib.metadata import PackageNotFoundError, version
 from ipykernel.kernelbase import Kernel
+from jupyter_client.kernelspec import KernelSpecManager
 
 
 def _importar_modulo_runtime(
@@ -86,9 +89,32 @@ __version__ = _get_version()
 
 def install(user=True):
     """Instala el kernel de Cobra para Jupyter."""
-    from jupyter_client.kernelspec import install as jupyter_install
+    kernel_spec = {
+        "argv": [
+            sys.executable,
+            "-c",
+            (
+                "from ipykernel.kernelapp import IPKernelApp; "
+                "from pcobra.jupyter_kernel import CobraKernel; "
+                "IPKernelApp.launch_instance(kernel_class=CobraKernel)"
+            ),
+            "-f",
+            "{connection_file}",
+        ],
+        "display_name": "Cobra",
+        "language": "cobra",
+    }
 
-    return jupyter_install(user=user, kernel_name="cobra", display_name="Cobra")
+    with tempfile.TemporaryDirectory() as kernelspec_dir:
+        kernel_json = os.path.join(kernelspec_dir, "kernel.json")
+        with open(kernel_json, "w", encoding="utf-8") as spec_file:
+            json.dump(kernel_spec, spec_file, ensure_ascii=False, indent=2)
+
+        return KernelSpecManager().install_kernel_spec(
+            kernelspec_dir,
+            kernel_name="cobra",
+            user=user,
+        )
 
 
 class CobraKernel(Kernel):

--- a/tests/unit/test_jupyter_kernel_install.py
+++ b/tests/unit/test_jupyter_kernel_install.py
@@ -1,0 +1,28 @@
+import json
+import os
+import sys
+
+import pcobra.jupyter_kernel as jupyter_kernel
+from pcobra.jupyter_kernel import __main__ as jupyter_kernel_main
+
+
+def test_main_instala_kernelspec_cobra(monkeypatch):
+    llamada = {}
+
+    class KernelSpecManagerDoble:
+        def install_kernel_spec(self, source_dir, *, kernel_name, user):
+            llamada["source_dir"] = source_dir
+            llamada["kernel_name"] = kernel_name
+            llamada["user"] = user
+            with open(f"{source_dir}/kernel.json", encoding="utf-8") as spec_file:
+                llamada["kernel_json"] = json.load(spec_file)
+
+    monkeypatch.setattr(jupyter_kernel, "KernelSpecManager", KernelSpecManagerDoble)
+    monkeypatch.setattr(sys, "argv", ["pcobra.jupyter_kernel", "install"])
+
+    assert jupyter_kernel_main.main() == 0
+    assert llamada["kernel_name"] == "cobra"
+    assert llamada["user"] is True
+    assert llamada["kernel_json"]["display_name"] == "Cobra"
+    assert llamada["kernel_json"]["argv"][-2:] == ["-f", "{connection_file}"]
+    assert not os.path.exists(llamada["source_dir"])


### PR DESCRIPTION
### Motivation
- Sustituir la llamada a la API privada/deprecada de instalación de kernelspec por la API pública `KernelSpecManager` y construir un `kernel.json` válido que inicie el kernel `CobraKernel` vía `IPKernelApp` sin usar el módulo `-m pcobra.jupyter_kernel` reservado al subcomando `install`.
- Asegurar que el directorio de kernelspec se cree en un `TemporaryDirectory` y se limpie automáticamente al terminar la instalación.
- Mantener los cambios mínimos y limitados al instalador de kernelspec, sin tocar Lexer, Parser ni `src/pcobra/jupyter_kernel/__main__.py`.

### Description
- En `src/pcobra/jupyter_kernel/__init__.py` se reemplazó la instalación anterior por una implementación de `install(user=True)` que genera un `kernel.json` con `argv` que ejecuta `IPKernelApp.launch_instance(kernel_class=CobraKernel)`, escribe el `kernel.json` en un `TemporaryDirectory` y llama a `KernelSpecManager().install_kernel_spec(...)` con `kernel_name="cobra"` y el valor `user` recibido.
- Se añadieron importaciones necesarias: `json`, `tempfile` y `from jupyter_client.kernelspec import KernelSpecManager` y se reorganizó el orden de imports sin afectar el resto del módulo.
- Se añadió la prueba unitaria `tests/unit/test_jupyter_kernel_install.py` que sustituye `KernelSpecManager` por un doble, verifica los argumentos pasados a `install_kernel_spec`, comprueba que el `kernel.json` contiene `display_name: "Cobra"` y que `main()` (el entrypoint) devuelve `0`, además de comprobar que el directorio temporal se elimina.
- No se modificaron archivos de Lexer/Parser ni `src/pcobra/jupyter_kernel/__main__.py` y se preservó el comportamiento público del entrypoint.

### Testing
- Ejecuté `pytest -q tests/unit/test_jupyter_kernel_install.py` y la prueba dirigida pasó satisfactoriamente.
- Ejecuté `pytest -q tests/unit/test_jupyter_kernel_install.py tests/unit/test_cli_jupyter.py` y ambas suites dirigidas pasaron (9 tests pasaron, 1 warning).
- Ejecuté el linter `python -m ruff check src/pcobra/jupyter_kernel/__init__.py tests/unit/test_jupyter_kernel_install.py` y no arrojó errores relevantes.
- Hice una ejecución ampliada de suites donde aparecieron 3 fallos preexistentes no relacionados (dos `NameError` en `tests/unit/test_runtime_import_resolution.py` y un timeout del sandbox en `tests/integration/test_kernel_transpiler.py`), por lo que no se tocaron ni se silenciaron en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5b7f195c83278ea48ae6dcd5c8d8)