### PR TITLE
Use module-level `import_utils` in usar_loader and add test to allow monkeypatching

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -708,7 +708,7 @@ def _cargar_exports_modulo_cobra_proyecto(
     """Carga un módulo Cobra de proyecto usando resolución canónica y cache."""
 
     from pcobra.core.environment import Environment
-    from pcobra.core.import_utils import cargar_ast_modulo
+    from pcobra.core import import_utils
     from pcobra.core.interpreter import InterpretadorCobra
     from pcobra.core.ast_nodes import NodoExport, NodoUsar
 
@@ -741,7 +741,7 @@ def _cargar_exports_modulo_cobra_proyecto(
     interpretador = None
     try:
         try:
-            ast = cargar_ast_modulo(
+            ast = import_utils.cargar_ast_modulo(
                 str(ruta_modulo),
                 modules_path=str(root_canonico),
                 whitelist={root_canonico},

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -131,6 +131,39 @@ def test_ejecucion_desde_cwd_externo_resuelve_usar_con_main_file(
     assert setup.interpretador._project_root == proyecto.resolve()
 
 
+def test_usar_proyecto_respeta_superficie_controlada_de_import_utils(
+    monkeypatch, tmp_path
+):
+    import pcobra.core as core_package
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "util.co"
+    modulo.write_text("", encoding="utf-8")
+    cargas = []
+
+    def fake_cargar_ast_modulo(ruta, **_kwargs):
+        cargas.append(Path(ruta))
+        return [NodoAsignacion("valor", NodoValor(7), declaracion=True)]
+
+    superficie_controlada = SimpleNamespace(
+        cargar_ast_modulo=fake_cargar_ast_modulo
+    )
+    monkeypatch.setattr(core_package, "import_utils", superficie_controlada)
+
+    exports = usar_modulo(
+        "util",
+        project_root=proyecto,
+        current_file=principal,
+        contexto_proyecto_verificado=True,
+    )
+
+    assert cargas == [modulo.resolve()]
+    assert exports["valor"] == 7
+
+
 def test_ejecucion_real_desde_cwd_externo_resuelve_usar_en_cobra_toml(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
### Motivation

- Make the `usar` project loader respect a controlled `import_utils` surface so tests can replace the whole `pcobra.core.import_utils` object at runtime.  

### Description

- Replace `from pcobra.core.import_utils import cargar_ast_modulo` with `from pcobra.core import import_utils` and call `import_utils.cargar_ast_modulo(...)` in `src/pcobra/cobra/usar_loader.py`.  
- Add `test_usar_proyecto_respeta_superficie_controlada_de_import_utils` to `tests/unit/test_project_root_usar_resolution.py` to verify that `pcobra.core.import_utils` can be monkeypatched with a fake object exposing `cargar_ast_modulo`.  

### Testing

- Ran the unit tests in `tests/unit/test_project_root_usar_resolution.py`, including the new `test_usar_proyecto_respeta_superficie_controlada_de_import_utils`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b60d139c48327832ae127bd4320b9)