### PR TITLE
Detect legacy import execution cycles

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2450,6 +2450,12 @@ class InterpretadorCobra:
         if ruta_canonica in self._imported_module_paths:
             return
 
+        if ruta_canonica in self._import_execution_stack:
+            inicio_ciclo = self._import_execution_stack.index(ruta_canonica)
+            ciclo = self._import_execution_stack[inicio_ciclo:] + [ruta_canonica]
+            nombres = " -> ".join(ruta.name for ruta in ciclo)
+            raise ImportError(f"Ciclo de módulos detectado en import: {nombres}")
+
         if ruta_canonica in ast_cache:
             ast = ast_cache[ruta_canonica]
         else:


### PR DESCRIPTION
### Motivation
- Evitar confundir módulos ya ejecutados con módulos que están en proceso de carga para que los `import` legacy no oculten ciclos.
- Detectar ciclos de ejecución de módulos antes de cargar o ejecutar el AST y ofrecer un mensaje legible que exponga la cadena de importaciones.

### Description
- Conserva la comprobación previa de `self._imported_module_paths` para no reejecutar módulos ya finalizados.
- Añade una comprobación previa a la carga del AST que detecta si `ruta_canonica` ya está en `self._import_execution_stack` y, en tal caso, reconstruye el ciclo desde su primera aparición y lanza `ImportError` con el prefijo solicitado.
- Formatea la representación del ciclo usando `Path.name` para producir cadenas legibles como `a.co -> b.co -> a.co` y no añade la ruta cíclica a ninguna pila antes de lanzar el error.
- Mantiene el `try/finally` existente que limpia `_current_module_stack` y `_import_execution_stack` y conserva la adición posterior a `_imported_module_paths` para módulos ejecutados correctamente.

### Testing
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py -k 'import_archivo_co_duplicado_no_reejecuta_side_effects or import_archivo_co_detecta_ciclo_de_ejecucion_legacy'` y ambas pruebas pasaron (`2 passed`).
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py` y la suite relacionada pasó (`77 passed`).
- Verifiqué `git diff --check` y la ausencia de cambios en `Lexer`/`Parser` mediante `git diff --name-only -- '*lexer*' '*parser*'`, ambas comprobaciones sin problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b7d4c65c08327b42f35a80366093d)