### PR TITLE
test: aislar la prueba de integración del comando Jupyter

### DIFF
--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -35,15 +35,60 @@ def test_ejecutar_modo_normal():
     assert child.exitstatus == 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="pexpect no es compatible con Windows")
-def test_jupyter_command():
-    if not shutil.which("jupyter"):
-        pytest.skip("jupyter no disponible")
-    child = _spawn("jupyter", {"PEXPECT_TESTING": "1"})
-    child.expect("FAKE_RUN")
-    child.expect(pexpect.EOF)
-    child.wait()
-    assert child.exitstatus == 0
+def test_jupyter_command(monkeypatch):
+    import argparse
+    import subprocess
+    import types
+
+    from pcobra.cobra.cli.commands.jupyter_cmd import JupyterCommand
+
+    monkeypatch.setitem(sys.modules, "jupyter", types.ModuleType("jupyter"))
+
+    llamadas = []
+
+    def run_exitoso(args, **kwargs):
+        llamadas.append((args, kwargs))
+        return subprocess.CompletedProcess(args, returncode=0)
+
+    python_resuelto = "/ruta/determinista/python"
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.commands.jupyter_cmd.subprocess.run", run_exitoso
+    )
+    monkeypatch.setattr(
+        JupyterCommand,
+        "_resolver_ejecutable",
+        staticmethod(lambda _ejecutable: python_resuelto),
+    )
+
+    comando = JupyterCommand()
+    argumentos = argparse.Namespace(notebook=None)
+
+    assert comando.run(argumentos) == 0
+    assert llamadas == [
+        (
+            [sys.executable, "-m", "pcobra.jupyter_kernel", "install"],
+            {"check": True, "capture_output": True, "text": True},
+        ),
+        (
+            [
+                python_resuelto,
+                "-m",
+                "jupyter",
+                "notebook",
+                "--KernelManager.default_kernel_name=cobra",
+            ],
+            {"check": True},
+        ),
+    ]
+
+    def run_con_error(args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args)
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.commands.jupyter_cmd.subprocess.run", run_con_error
+    )
+
+    assert comando.run(argumentos) == 1
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="pexpect no es compatible con Windows")


### PR DESCRIPTION
### Motivation

- Reemplazar una prueba interactiva dependiente de `pexpect` y del binario `jupyter` por una verificación determinista y aislada del comportamiento de `JupyterCommand.run` para reducir fragilidad e incrementar reproducibilidad.
- Evitar tocar la implementación productiva ni modificar Lexer/Parser, manteniendo la API pública del comando intacta.

### Description

- Sustituye `test_jupyter_command` en `tests/integration/test_cli_integration.py` por una prueba que invoca directamente `JupyterCommand.run` con `argparse.Namespace(notebook=None)`.
- Crea un doble del módulo `jupyter` en `sys.modules` usando `monkeypatch` y sustituye `pcobra.cobra.cli.commands.jupyter_cmd.subprocess.run` por una función que registra llamadas y devuelve `subprocess.CompletedProcess(returncode=0)`.
- Sustituye `JupyterCommand._resolver_ejecutable` por un `staticmethod` que devuelve una ruta Python determinista y añade una segunda sustitución de `subprocess.run` que lanza `subprocess.CalledProcessError` para comprobar la conversión de errores en `1`.
- Verifica en orden que las dos llamadas a `subprocess.run` sean exactamente las esperadas: la instalación del kernel con `sys.executable -m pcobra.jupyter_kernel install` y el lanzamiento de Jupyter Notebook con la ruta resuelta y `--KernelManager.default_kernel_name=cobra`.

### Testing

- Ejecuté `pytest -q tests/integration/test_cli_integration.py::test_jupyter_command` y la prueba pasó correctamente.
- Ejecuté `pytest -q tests/integration/test_cli_integration.py` y la suite de integración relacionada pasó (4 tests passed).
- Ejecuté `pytest -q tests/unit/test_cli_jupyter.py` y la suite unitaria pasó (8 tests passed).
- Ejecuté `git diff --check` y comprobé que Lexer y Parser no fueron modificados (ningún problema detectado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b86766d9c8327ac712a310f515ce3)