### PR TITLE
refactor(cli): extraer servicio compartido de CobraHub

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -8,8 +8,10 @@ from typing import Optional, Tuple, Dict, TYPE_CHECKING
 from urllib.parse import urlparse
 
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.cobrahub_service import CobraHubService
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.hub.errors import PackageProviderError
+from pcobra.cobra.hub.repository import HttpCobraHubRepository
 
 if TYPE_CHECKING:  # pragma: no cover - solo para tipado
     import requests
@@ -373,23 +375,23 @@ class CobraHubClient:
 
     def publicar_paquete(self, ruta: str) -> bool:
         """Publica un paquete .co usando la API separada de paquetes."""
-        from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
-
-        return CobraHubPackages(self).publicar_paquete(ruta)
+        return CobraHubService(
+            self, HttpCobraHubRepository(self), mostrar_error, mostrar_info
+        ).publicar_paquete(ruta)
 
     def buscar_paquetes(self, consulta: str) -> list[dict]:
         """Busca paquetes usando la API separada de paquetes."""
-        from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
-
-        return CobraHubPackages(self).buscar_paquetes(consulta)
+        return CobraHubService(
+            self, HttpCobraHubRepository(self), mostrar_error, mostrar_info
+        ).buscar_paquetes(consulta)
 
     def instalar_paquete(
         self, nombre: str, destino: str | None = None, version: str | None = None
     ) -> bool:
         """Instala un paquete usando la API separada de paquetes."""
-        from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
-
-        return CobraHubPackages(self).instalar_paquete(nombre, destino, version)
+        return CobraHubService(
+            self, HttpCobraHubRepository(self), mostrar_error, mostrar_info
+        ).instalar_paquete(nombre, destino, version)
 
 
 # Funciones conveniencia para interacción sencilla con CobraHub.

--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -7,12 +7,12 @@ contrato independiente a los mensajes y valores booleanos históricos.
 
 from __future__ import annotations
 
-import logging
-import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.cobrahub_service import CobraHubProvider, CobraHubService
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.hub.errors import (
     CobraHubError,
     PackageIntegrityError,
@@ -25,12 +25,6 @@ from pcobra.cobra.hub.repository import (
     json_dumps,
     package_cache_dir,
 )
-
-if TYPE_CHECKING:  # pragma: no cover - solo para tipado
-    from pcobra.cobra.cli.cobrahub_client import CobraHubClient
-
-logger = logging.getLogger(__name__)
-
 
 def listar_cache() -> list[Path]:
     """Lista los paquetes ``.co`` presentes en la caché local de CobraHub."""
@@ -90,20 +84,6 @@ def validar_cache() -> list[tuple[Path, bool, str | None]]:
     return resultados
 
 
-def _mostrar_error(mensaje: str) -> None:
-    """Emite errores vía la fachada legacy para conservar mocks existentes."""
-    from pcobra.cobra.cli import cobrahub_client
-
-    cobrahub_client.mostrar_error(mensaje)
-
-
-def _mostrar_info(mensaje: str) -> None:
-    """Emite información vía la fachada legacy para conservar mocks existentes."""
-    from pcobra.cobra.cli import cobrahub_client
-
-    cobrahub_client.mostrar_info(mensaje)
-
-
 class CobraHubPackages:
     """Operaciones de paquetes publicables en CobraHub.
 
@@ -115,95 +95,28 @@ class CobraHubPackages:
 
     def __init__(
         self,
-        client: "CobraHubClient",
+        client: CobraHubProvider,
         repository: PackageRepository | None = None,
     ) -> None:
         self.client = client
         self.repository = repository or HttpCobraHubRepository(client)
+        self.service = CobraHubService(
+            client, self.repository, mostrar_error, mostrar_info
+        )
 
     def publicar_paquete(self, ruta: str) -> bool:
         """Publica un paquete .co en CobraHub y lo guarda en caché local."""
-        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
-
-        if not self.client._validar_url():
-            return False
-        try:
-            if not es_paquete_cobra(ruta):
-                raise PackageIntegrityError(
-                    "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
-                )
-            info = validar_paquete(ruta)
-            self.repository.publish(ruta, dict(info.manifest), info.checksum)
-            _mostrar_info(_("Paquete publicado correctamente"))
-            return True
-        except CobraHubError as e:
-            logger.error(f"Error publicando paquete: {e}")
-            _mostrar_error(_("Error publicando paquete: {err}").format(err=_(str(e))))
-            return False
-        except Exception as e:
-            logger.error(f"Error publicando paquete: {e}")
-            _mostrar_error(_("Error publicando paquete: {err}").format(err=str(e)))
-            return False
+        return self.service.publicar_paquete(ruta)
 
     def buscar_paquetes(self, consulta: str) -> list[dict]:
         """Busca paquetes publicados en CobraHub."""
-        if not self.client._validar_url():
-            return []
-        try:
-            return [result.as_dict() for result in self.repository.search(consulta)]
-        except CobraHubError as e:
-            logger.error(f"Error buscando paquetes: {e}")
-            _mostrar_error(_("Error buscando paquetes: {err}").format(err=_(str(e))))
-            return []
-        except Exception as e:
-            logger.error(f"Error buscando paquetes: {e}")
-            _mostrar_error(_("Error buscando paquetes: {err}").format(err=str(e)))
-            return []
+        return self.service.buscar_paquetes(consulta)
 
     def instalar_paquete(
         self, nombre: str, destino: str | None = None, version: str | None = None
     ) -> bool:
         """Descarga, cachea e instala un paquete desde CobraHub."""
-        from pcobra.cobra.packaging import es_paquete_cobra, extraer_paquete
-
-        cache_path: Path | None = None
-        if not self.client._validar_url():
-            return False
-        try:
-            downloaded = self.repository.download(nombre, version)
-            cache_path = downloaded.path
-            if not self.client._validar_nombre_modulo(downloaded.name):
-                if cache_path.exists():
-                    os.unlink(cache_path)
-                return False
-
-            if not es_paquete_cobra(cache_path):
-                os.unlink(cache_path)
-                raise PackageIntegrityError("La descarga no es un paquete Cobra válido")
-
-            install_path = (
-                Path(destino).expanduser()
-                if destino
-                else install_dir() / downloaded.name
-            )
-            extraer_paquete(cache_path, install_path)
-            _mostrar_info(_("Paquete instalado en {dest}").format(dest=install_path))
-            return True
-        except CobraHubError as e:
-            logger.error(f"Error instalando paquete: {e}")
-            _mostrar_error(_("Error instalando paquete: {err}").format(err=_(str(e))))
-            if cache_path is not None and cache_path.exists():
-                cache_path.unlink(missing_ok=True)
-            return False
-        except Exception as e:
-            logger.error(f"Error instalando paquete: {e}")
-            _mostrar_error(_("Error instalando paquete: {err}").format(err=str(e)))
-            if cache_path is not None and cache_path.exists():
-                try:
-                    os.unlink(cache_path)
-                except Exception:
-                    pass
-            return False
+        return self.service.instalar_paquete(nombre, destino, version)
 
     def leer_metadatos(self, ruta: str | Path) -> dict[str, Any]:
         """Lee y devuelve el manifiesto/metadatos de un paquete local ``.co``."""

--- a/src/pcobra/cobra/cli/services/cobrahub_service.py
+++ b/src/pcobra/cobra/cli/services/cobrahub_service.py
@@ -1,0 +1,125 @@
+"""Coordinación compartida de operaciones de paquetes CobraHub."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra import packaging
+from pcobra.cobra.hub.errors import CobraHubError, PackageIntegrityError
+from pcobra.cobra.hub.repository import PackageRepository, install_dir
+
+logger = logging.getLogger(__name__)
+
+
+class CobraHubProvider(Protocol):
+    """Capacidades del proveedor HTTP requeridas por la coordinación."""
+
+    def _validar_url(self) -> bool: ...
+
+    def _validar_nombre_modulo(self, nombre: str) -> bool: ...
+
+
+class CobraHubService:
+    """Coordina publicación, búsqueda e instalación sobre un repositorio."""
+
+    def __init__(
+        self,
+        provider: CobraHubProvider,
+        repository: PackageRepository,
+        error_handler: Callable[[str], None] = mostrar_error,
+        info_handler: Callable[[str], None] = mostrar_info,
+    ) -> None:
+        self.provider = provider
+        self.repository = repository
+        self._mostrar_error = error_handler
+        self._mostrar_info = info_handler
+
+    def publicar_paquete(self, ruta: str) -> bool:
+        """Publica un paquete validado en el repositorio."""
+        if not self.provider._validar_url():
+            return False
+        try:
+            if not packaging.es_paquete_cobra(ruta):
+                raise PackageIntegrityError(
+                    "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                )
+            info = packaging.validar_paquete(ruta)
+            self.repository.publish(ruta, dict(info.manifest), info.checksum)
+            self._mostrar_info(_("Paquete publicado correctamente"))
+            return True
+        except CobraHubError as exc:
+            logger.error("Error publicando paquete: %s", exc)
+            self._mostrar_error(
+                _("Error publicando paquete: {err}").format(err=_(str(exc)))
+            )
+        except Exception as exc:
+            logger.error("Error publicando paquete: %s", exc)
+            self._mostrar_error(
+                _("Error publicando paquete: {err}").format(err=str(exc))
+            )
+        return False
+
+    def buscar_paquetes(self, consulta: str) -> list[dict]:
+        """Busca paquetes y adapta los resultados al contrato histórico."""
+        if not self.provider._validar_url():
+            return []
+        try:
+            return [result.as_dict() for result in self.repository.search(consulta)]
+        except CobraHubError as exc:
+            logger.error("Error buscando paquetes: %s", exc)
+            self._mostrar_error(
+                _("Error buscando paquetes: {err}").format(err=_(str(exc)))
+            )
+        except Exception as exc:
+            logger.error("Error buscando paquetes: %s", exc)
+            self._mostrar_error(
+                _("Error buscando paquetes: {err}").format(err=str(exc))
+            )
+        return []
+
+    def instalar_paquete(
+        self, nombre: str, destino: str | None = None, version: str | None = None
+    ) -> bool:
+        """Descarga, valida e instala un paquete desde el repositorio."""
+        cache_path: Path | None = None
+        if not self.provider._validar_url():
+            return False
+        try:
+            downloaded = self.repository.download(nombre, version)
+            cache_path = downloaded.path
+            if not self.provider._validar_nombre_modulo(downloaded.name):
+                cache_path.unlink(missing_ok=True)
+                return False
+            if not packaging.es_paquete_cobra(cache_path):
+                cache_path.unlink(missing_ok=True)
+                raise PackageIntegrityError("La descarga no es un paquete Cobra válido")
+
+            install_path = (
+                Path(destino).expanduser()
+                if destino
+                else install_dir() / downloaded.name
+            )
+            packaging.extraer_paquete(cache_path, install_path)
+            self._mostrar_info(_("Paquete instalado en {dest}").format(dest=install_path))
+            return True
+        except CobraHubError as exc:
+            logger.error("Error instalando paquete: %s", exc)
+            self._mostrar_error(
+                _("Error instalando paquete: {err}").format(err=_(str(exc)))
+            )
+        except Exception as exc:
+            logger.error("Error instalando paquete: %s", exc)
+            self._mostrar_error(
+                _("Error instalando paquete: {err}").format(err=str(exc))
+            )
+        if cache_path is not None:
+            cache_path.unlink(missing_ok=True)
+        return False
+
+
+__all__ = ["CobraHubProvider", "CobraHubService"]


### PR DESCRIPTION
### Motivation

- Centralizar la lógica compartida de publicación, búsqueda e instalación de paquetes en una capa de servicio para eliminar acoplamientos entre fachadas y facilitar reutilización e inyección de repositorios. 
- Mantener las APIs públicas existentes (`CobraHubClient`, `CobraHubPackages`) como fachadas compatibles mientras se mueve la coordinación a una capa independiente. 
- Evitar importar módulos en ambos sentidos entre `cobrahub_client` y `cobrahub_packages` para prevenir dependencias cíclicas. 

### Description

- Añade `src/pcobra/cobra/cli/services/cobrahub_service.py` que expone `CobraHubService` y el protocolo mínimo `CobraHubProvider` para coordinar `publish`, `search` e `install` contra cualquier `PackageRepository`. 
- Modifica `CobraHubClient` para delegar `publicar_paquete`, `buscar_paquetes` e `instalar_paquete` en `CobraHubService` usando imports de módulo y `HttpCobraHubRepository`. 
- Refactoriza `src/pcobra/cobra/cli/cobrahub_packages.py` para tipar su cliente con `CobraHubProvider` y delegar sus operaciones en una instancia de `CobraHubService`, eliminando cualquier importación de `CobraHubClient` (incluso bajo `TYPE_CHECKING`). 
- Se preserva la compatibilidad de las APIs públicas y no se tocaron Lexer/Parser ni la normativa de sintaxis del lenguaje. 

### Testing

- `python -m pytest -q tests/unit/test_cli_cobrahub.py tests/unit/test_hub_provider_contracts.py tests/unit/test_cobrahub_cache.py tests/unit/test_cli_paquete_symlink.py` — ejecutado y **67 passed**. 
- `python -m ruff check src/pcobra/cobra/cli/cobrahub_client.py src/pcobra/cobra/cli/cobrahub_packages.py src/pcobra/cobra/cli/services/cobrahub_service.py` — lint comprobado sin fallos. 
- Verificación estática con un script AST confirmó que no hay imports directos en ambos sentidos entre `cobrahub_client` y `cobrahub_packages`. 
- `python -m pytest -q tests/unit` (suite completa) — se ejecutó hasta detectar 5 fallos preexistentes no relacionados con este cambio (tabla SQLite de caché no inicializada, dependencia opcional `dask` ausente y dos violaciones del guard de imports), mientras que las pruebas relacionadas con este cambio pasaron; la refactorización no introdujo fallos en los tests específicos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b9048a418832793677da354521afd)