### PR TITLE
Centralizar la ruta de módulos de la CLI

### DIFF
--- a/src/pcobra/cobra/cli/commands/modules_cmd.py
+++ b/src/pcobra/cobra/cli/commands/modules_cmd.py
@@ -7,7 +7,6 @@ from pcobra.cobra.cli.services.contracts import ModRequest
 from pcobra.cobra.cli.services.mod_service import (
     LOCK_FILE,
     LOCK_KEY,
-    MODULES_PATH,
     MODULE_EXTENSION,
     ModService,
     buscar_modulo,
@@ -23,6 +22,7 @@ from pcobra.cobra.cli.services.mod_service import (
     yaml,
 )
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cobra.cli.utils.module_paths import MODULES_PATH
 
 _cobrahub_module = __import__("pcobra.cobra.cli.cobrahub_client", fromlist=["CobraHubClient"])
 _CobraHubClient = _cobrahub_module.CobraHubClient

--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -6,11 +6,11 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.cli.commands import modules_cmd
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.cli.utils.module_paths import MODULES_PATH
 from pcobra.cobra.packaging import (
     construir_paquete,
     crear_paquete,
@@ -130,11 +130,11 @@ class PaqueteCommand(BaseCommand):
         """Instala paquetes Cobra modernos o ZIP legacy en el directorio de módulos.
 
         Este adaptador conserva el flujo histórico usado por tests y llamadas
-        directas: instala siempre en ``modules_cmd.MODULES_PATH`` y devuelve un
+        directas: instala siempre en ``MODULES_PATH`` y devuelve un
         código de salida en vez de propagar excepciones.
         """
         try:
-            destino = Path(modules_cmd.MODULES_PATH).resolve()
+            destino = Path(MODULES_PATH).resolve()
             if es_paquete_cobra(paquete):
                 extraer_paquete(paquete, destino)
                 mostrar_info(_("Paquete instalado en {dest}").format(dest=destino))

--- a/src/pcobra/cobra/cli/services/mod_service.py
+++ b/src/pcobra/cobra/cli/services/mod_service.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from pcobra.cobra.cli.cobrahub_client import CobraHubClient
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.services.contracts import ModRequest, normalize_mod_request
+from pcobra.cobra.cli.utils.module_paths import MODULES_PATH, USER_CONFIG_DIR
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.semver import es_nueva_version, es_version_valida
 from pcobra.cobra.semantico import mod_validator
@@ -26,8 +27,6 @@ except ModuleNotFoundError:  # pragma: no cover
 logger = logging.getLogger(__name__)
 _client: Optional[CobraHubClient] = None
 
-USER_CONFIG_DIR = Path.home() / ".cobra"
-MODULES_PATH: Path = USER_CONFIG_DIR / "modules"
 LOCK_FILE: Path = USER_CONFIG_DIR / "module_map.toml"
 LOCK_KEY = "lock"
 MODULE_EXTENSION = ".co"

--- a/src/pcobra/cobra/cli/utils/module_paths.py
+++ b/src/pcobra/cobra/cli/utils/module_paths.py
@@ -1,0 +1,7 @@
+"""Rutas compartidas por la gestión de módulos de la CLI."""
+
+from pathlib import Path
+
+
+USER_CONFIG_DIR = Path.home() / ".cobra"
+MODULES_PATH: Path = USER_CONFIG_DIR / "modules"

--- a/tests/unit/test_cli_paquete_symlink.py
+++ b/tests/unit/test_cli_paquete_symlink.py
@@ -19,7 +19,7 @@ def test_instalar_paquete_correcto(tmp_path, monkeypatch):
     pkg = _crear_paquete(tmp_path / "demo.cobra", {"modulo.co": "var x = 1"})
     mods_dir = tmp_path / "mods"
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
-    monkeypatch.setattr(package_cmd.modules_cmd, "MODULES_PATH", mods_dir)
+    monkeypatch.setattr(package_cmd, "MODULES_PATH", mods_dir)
 
     ret = package_cmd.PaqueteCommand._instalar(pkg)
 
@@ -33,7 +33,7 @@ def test_instalar_paquete_destino_symlink(tmp_path, monkeypatch):
     mods_dir = tmp_path / "mods"
     mods_dir.mkdir()
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
-    monkeypatch.setattr(package_cmd.modules_cmd, "MODULES_PATH", mods_dir)
+    monkeypatch.setattr(package_cmd, "MODULES_PATH", mods_dir)
     dest = mods_dir / "m.co"
     dest.symlink_to(tmp_path / "fuente.co")
 
@@ -49,7 +49,7 @@ def test_instalar_paquete_con_ruta_maliciosa(tmp_path, monkeypatch):
     pkg = _crear_paquete(tmp_path / "demo.cobra", {"../malo.co": "pwn"})
     mods_dir = tmp_path / "mods"
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
-    monkeypatch.setattr(package_cmd.modules_cmd, "MODULES_PATH", mods_dir)
+    monkeypatch.setattr(package_cmd, "MODULES_PATH", mods_dir)
 
     with patch("cobra.cli.commands.package_cmd.mostrar_error") as err:
         ret = package_cmd.PaqueteCommand._instalar(pkg)
@@ -68,7 +68,7 @@ def test_instalar_paquete_con_cobra_pkg_json_moderno(tmp_path, monkeypatch):
     package_cmd.construir_paquete(src, pkg, nombre="moderno")
     mods_dir = tmp_path / "mods"
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
-    monkeypatch.setattr(package_cmd.modules_cmd, "MODULES_PATH", mods_dir)
+    monkeypatch.setattr(package_cmd, "MODULES_PATH", mods_dir)
 
     ret = package_cmd.PaqueteCommand._instalar(pkg)
 


### PR DESCRIPTION
### Motivation

- Evitar duplicación de la definición de la ruta de módulos y proporcionar un punto canónico de configuración para la CLI.
- Romper el acoplamiento innecesario de `package_cmd.py` hacia `commands.modules_cmd` manteniendo compatibilidad con tests que parcheaban `modules_cmd.MODULES_PATH`.

### Description

- Añade el módulo utilitario `src/pcobra/cobra/cli/utils/module_paths.py` que define `USER_CONFIG_DIR` y `MODULES_PATH` como fuente canónica de rutas.
- Actualiza `src/pcobra/cobra/cli/services/mod_service.py` para importar `MODULES_PATH` y `USER_CONFIG_DIR` desde la nueva utilidad y eliminar la definición duplicada.
- Modifica `src/pcobra/cobra/cli/commands/modules_cmd.py` para importar `MODULES_PATH` desde la utilidad y conservar el nombre público en su espacio de nombres para compatibilidad.
- Elimina `from pcobra.cobra.cli.commands import modules_cmd` de `src/pcobra/cobra/cli/commands/package_cmd.py` y hace que importe `MODULES_PATH` directamente desde la utilidad, manteniendo la misma lógica de resolución y mensajes.
- Ajusta la prueba `tests/unit/test_cli_paquete_symlink.py` para parchear `package_cmd.MODULES_PATH` en lugar de `package_cmd.modules_cmd.MODULES_PATH`.

### Testing

- Ejecutado `pytest -q tests/unit/test_cli_paquete.py tests/unit/test_cli_paquete_symlink.py tests/unit/test_cli_cobrahub.py tests/unit/test_cli_exit_codes.py tests/integration/test_cli.py` y todas las pruebas reportaron `56 passed`.
- Ejecutado `ruff check` sobre los ficheros cambiados y no se reportaron errores con `ruff` ni problemas en `git diff --check`.
- Verificado que no existe el import eliminado con `rg` y que no hubo cambios en Lexer/Parser mediante `git diff --name-only | rg -i '(^|/)(lexer|parser)(\.|/|$)'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b9c826b148327a50318b330de7301)