### PR TITLE
Delegate qa-validar runtime checks to verification service

### DIFF
--- a/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
+++ b/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from argparse import Namespace
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -20,7 +19,6 @@ from pcobra.cobra.cli.services.verification_service import (
     parse_verification_targets,
     resolve_executable_targets,
 )
-from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.transpilers.compatibility_matrix import build_feature_gap_report
@@ -213,15 +211,10 @@ class QaValidarCommand(BaseCommand):
                 strict,
             )
 
-        verify_args = Namespace(
-            modo=getattr(args, "modo", "mixto"),
-            archivo=getattr(args, "archivo"),
-            lenguajes=executable_targets,
+        rc = execute_runtime_verification(
+            getattr(args, "archivo"),
+            executable_targets,
         )
-        # Mantiene compatibilidad con pruebas/consumidores que parchean
-        # `VerifyCommand.run`, delegando el detalle de ejecución al adaptador
-        # legacy de verificación.
-        rc = VerifyCommand().run(verify_args)
         has_failures = rc != 0
         message = "equivalencia runtime verificada" if rc == 0 else "falló equivalencia runtime"
 

--- a/tests/integration/test_cli_qa_validar_feature_gap_report.py
+++ b/tests/integration/test_cli_qa_validar_feature_gap_report.py
@@ -29,8 +29,8 @@ def test_cli_qa_validar_exporta_feature_gap_report_json_estable(monkeypatch, tmp
 
     monkeypatch.setattr(cmd_module, "execute_syntax_validation", lambda **_: _execution())
     monkeypatch.setattr(pcobra_cmd_module, "execute_syntax_validation", lambda **_: _execution())
-    monkeypatch.setattr(cmd_module.VerifyCommand, "run", lambda *_: 0)
-    monkeypatch.setattr(pcobra_cmd_module.VerifyCommand, "run", lambda *_: 0)
+    monkeypatch.setattr(cmd_module, "execute_runtime_verification", lambda *_: 0)
+    monkeypatch.setattr(pcobra_cmd_module, "execute_runtime_verification", lambda *_: 0)
 
     fake_report = {
         "python": [],

--- a/tests/unit/test_cli_qa_validar_cmd.py
+++ b/tests/unit/test_cli_qa_validar_cmd.py
@@ -44,7 +44,7 @@ def test_qa_validar_exit_code_0_cuando_todo_ok(monkeypatch):
     command = QaValidarCommand()
 
     monkeypatch.setattr(cmd_module, "execute_syntax_validation", lambda **_: _execution(False))
-    monkeypatch.setattr(cmd_module.VerifyCommand, "run", lambda *_: 0)
+    monkeypatch.setattr(cmd_module, "execute_runtime_verification", lambda *_: 0)
 
     rc = command.run(_args(targets="python,javascript"))
 
@@ -55,7 +55,7 @@ def test_qa_validar_exit_code_1_si_falla_runtime(monkeypatch):
     command = QaValidarCommand()
 
     monkeypatch.setattr(cmd_module, "execute_syntax_validation", lambda **_: _execution(False))
-    monkeypatch.setattr(cmd_module.VerifyCommand, "run", lambda *_: 1)
+    monkeypatch.setattr(cmd_module, "execute_runtime_verification", lambda *_: 1)
 
     rc = command.run(_args(targets="python"))
 
@@ -66,8 +66,8 @@ def test_qa_validar_propaga_errores_en_orquestacion(monkeypatch):
     command = QaValidarCommand()
     monkeypatch.setattr(cmd_module, "execute_syntax_validation", lambda **_: _execution(False))
     monkeypatch.setattr(
-        cmd_module.VerifyCommand,
-        "run",
+        cmd_module,
+        "execute_runtime_verification",
         lambda *_: (_ for _ in ()).throw(RuntimeError("fallo runtime interno")),
     )
 
@@ -91,7 +91,7 @@ def test_qa_validar_reporte_json_agregado(monkeypatch, tmp_path: Path):
     output = tmp_path / "qa.json"
 
     monkeypatch.setattr(cmd_module, "execute_syntax_validation", lambda **_: _execution(False))
-    monkeypatch.setattr(cmd_module.VerifyCommand, "run", lambda *_: 0)
+    monkeypatch.setattr(cmd_module, "execute_runtime_verification", lambda *_: 0)
 
     rc = command.run(_args(targets="python", report_json=str(output)))
 
@@ -105,7 +105,7 @@ def test_qa_validar_exporta_feature_gap_report_markdown(monkeypatch, tmp_path: P
     output = tmp_path / "feature-gaps.md"
 
     monkeypatch.setattr(cmd_module, "execute_syntax_validation", lambda **_: _execution(False))
-    monkeypatch.setattr(cmd_module.VerifyCommand, "run", lambda *_: 0)
+    monkeypatch.setattr(cmd_module, "execute_runtime_verification", lambda *_: 0)
     monkeypatch.setattr(
         cmd_module,
         "build_feature_gap_report",


### PR DESCRIPTION
### Motivation
- Sustituir la dependencia directa de `QaValidarCommand` sobre `VerifyCommand` por el contrato del servicio de verificación existente para centralizar la ejecución runtime.
- Permitir a pruebas e integraciones parchear una frontera de inyección a nivel de módulo sin reimportar ni duplicar la implementación del comando de verificación.

### Description
- Eliminado el import de `VerifyCommand` y sustituida la ejecución interna por la llamada a `execute_runtime_verification(archivo, lenguajes)` en `_run_runtime_scope`.
- Preservada la semántica previa: se conserva el código de retorno de `execute_runtime_verification` y se mapea a `RuntimeEquivalenceReport` exactamente como antes.
- Conservada la frontera de inyección para pruebas mediante el callable de módulo `execute_runtime_verification` sin reintroducir `VerifyCommand` ni duplicar lógica.
- Actualizadas las pruebas unitarias e de integración para parchear `execute_runtime_verification` en lugar de `VerifyCommand.run` y eliminado el `Namespace` import innecesario.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_qa_validar_cmd.py` y obtuvo `6 passed, 1 warning`.
- Ejecutado `pytest -q tests/unit/test_cli_qa_validar_cmd.py tests/integration/test_cli_qa_validar_feature_gap_report.py` y obtuvo `7 passed, 1 warning`.
- Ejecutado la combinación ampliada `pytest -q tests/unit/test_cli_qa_validar_cmd.py tests/unit/test_cli_mode_policy.py tests/integration/test_cli_qa_validar_feature_gap_report.py` y resultó en `22 passed, 5 failed`; los 5 fallos pertenecen a `test_cli_mode_policy.py` y son independientes de los archivos modificados.
- Verificaciones auxiliares automatizadas: `git diff --check` pasó y la comprobación de que `Lexer`/`Parser` no cambiaron también pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b9f6f4fa083279b766f75a94e1099)