### PR TITLE
Centralizar las operaciones CLI de CobraHub en su servicio

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -10,12 +10,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.services.cobrahub_service import CobraHubProvider, CobraHubService
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.hub.errors import (
     CobraHubError,
-    PackageIntegrityError,
     PackageProviderError,
 )
 from pcobra.cobra.hub.repository import (
@@ -28,23 +26,7 @@ from pcobra.cobra.hub.repository import (
 
 def listar_cache() -> list[Path]:
     """Lista los paquetes ``.co`` presentes en la caché local de CobraHub."""
-    return sorted(
-        path
-        for path in package_cache_dir().iterdir()
-        if path.is_file() and path.suffix == ".co"
-    )
-
-
-def _coincide_nombre_cache(path: Path, nombre: str) -> bool:
-    """Indica si una entrada cacheada corresponde al nombre solicitado."""
-    objetivo = (
-        (nombre[:-3] if nombre.endswith(".co") else nombre)
-        .strip()
-        .lower()
-        .replace(" ", "-")
-    )
-    stem = path.stem
-    return stem == objetivo or stem.startswith(f"{objetivo}-")
+    return CobraHubService().listar_cache()
 
 
 def limpiar_cache(nombre: str | None = None) -> int:
@@ -54,34 +36,12 @@ def limpiar_cache(nombre: str | None = None) -> int:
     indica un nombre, se borran tanto ``<nombre>.co`` como variantes
     versionadas ``<nombre>-<version>.co``.
     """
-    borrados = 0
-    for path in listar_cache():
-        if nombre is not None and not _coincide_nombre_cache(path, nombre):
-            continue
-        path.unlink()
-        borrados += 1
-    return borrados
+    return CobraHubService().limpiar_cache(nombre)
 
 
 def validar_cache() -> list[tuple[Path, bool, str | None]]:
     """Valida cada paquete ``.co`` cacheado con los validadores de empaquetado."""
-    from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
-
-    resultados: list[tuple[Path, bool, str | None]] = []
-    for path in listar_cache():
-        try:
-            if not es_paquete_cobra(path):
-                raise PackageIntegrityError(
-                    "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
-                )
-            validar_paquete(path)
-        except CobraHubError as exc:
-            resultados.append((path, False, _(str(exc))))
-        except Exception as exc:
-            resultados.append((path, False, str(exc)))
-        else:
-            resultados.append((path, True, None))
-    return resultados
+    return CobraHubService().validar_cache()
 
 
 class CobraHubPackages:

--- a/src/pcobra/cobra/cli/commands/hub_cmd.py
+++ b/src/pcobra/cobra/cli/commands/hub_cmd.py
@@ -2,17 +2,15 @@ from argparse import Namespace, SUPPRESS
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.cli.cobrahub_client import CobraHubClient
-from pcobra.cobra.cli.cobrahub_packages import (
-    CobraHubPackages,
-    limpiar_cache,
-    listar_cache,
-    validar_cache,
-)
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.cobrahub_service import CobraHubService
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+
+# Compatibilidad para instrumentación que parcheaba este nombre en el módulo.
+# El alias apunta al contrato de servicio y no atraviesa la fachada histórica.
+CobraHubPackages = CobraHubService
 
 
 class HubCommand(BaseCommand):
@@ -62,11 +60,11 @@ class HubCommand(BaseCommand):
         return self.register_subparser(subparsers, hidden=True)
 
     def run(self, args: Namespace) -> int:
-        packages = CobraHubPackages(CobraHubClient())
+        service = CobraHubService()
         if args.accion == "publicar":
-            return 0 if packages.publicar_paquete(str(args.paquete)) else 1
+            return 0 if service.publicar_paquete(str(args.paquete)) else 1
         if args.accion == "buscar":
-            results = packages.buscar_paquetes(args.consulta)
+            results = service.buscar_paquetes(args.consulta)
             for item in results:
                 nombre = item.get("name", item.get("nombre", "paquete"))
                 mostrar_info(f"{nombre} {item.get('version', '')}".strip())
@@ -75,23 +73,23 @@ class HubCommand(BaseCommand):
             destino = str(args.destino) if args.destino else None
             return (
                 0
-                if packages.instalar_paquete(args.nombre, destino, args.version)
+                if service.instalar_paquete(args.nombre, destino, args.version)
                 else 1
             )
         if args.accion == "cache":
-            return self._run_cache(args)
+            return self._run_cache(args, service)
         mostrar_error(_("Acción de hub no reconocida"))
         return 1
 
-    def _run_cache(self, args: Namespace) -> int:
+    def _run_cache(self, args: Namespace, service: CobraHubService) -> int:
         """Ejecuta las acciones locales de caché sin contactar con CobraHub."""
         if args.cache_accion == "listar":
-            for path in listar_cache():
+            for path in service.listar_cache():
                 mostrar_info(str(path))
             return 0
         if args.cache_accion == "limpiar":
             try:
-                borrados = limpiar_cache(args.nombre)
+                borrados = service.limpiar_cache(args.nombre)
             except ValueError as exc:
                 mostrar_error(str(exc))
                 return 1
@@ -100,7 +98,7 @@ class HubCommand(BaseCommand):
             )
             return 0
         if args.cache_accion == "validar":
-            resultados = validar_cache()
+            resultados = service.validar_cache()
             for path, ok, error in resultados:
                 estado = _("válido") if ok else _("inválido")
                 detalle = f": {error}" if error else ""

--- a/src/pcobra/cobra/cli/services/cobrahub_service.py
+++ b/src/pcobra/cobra/cli/services/cobrahub_service.py
@@ -29,11 +29,19 @@ class CobraHubService:
 
     def __init__(
         self,
-        provider: CobraHubProvider,
-        repository: PackageRepository,
+        provider: CobraHubProvider | None = None,
+        repository: PackageRepository | None = None,
         error_handler: Callable[[str], None] = mostrar_error,
         info_handler: Callable[[str], None] = mostrar_info,
     ) -> None:
+        if provider is None:
+            from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+
+            provider = CobraHubClient()
+        if repository is None:
+            from pcobra.cobra.hub.repository import HttpCobraHubRepository
+
+            repository = HttpCobraHubRepository(provider)
         self.provider = provider
         self.repository = repository
         self._mostrar_error = error_handler
@@ -120,6 +128,55 @@ class CobraHubService:
         if cache_path is not None:
             cache_path.unlink(missing_ok=True)
         return False
+
+    def listar_cache(self) -> list[Path]:
+        """Lista los paquetes ``.co`` presentes en la caché local."""
+        from pcobra.cobra.hub.repository import package_cache_dir
+
+        return sorted(
+            path
+            for path in package_cache_dir().iterdir()
+            if path.is_file() and path.suffix == ".co"
+        )
+
+    @staticmethod
+    def _coincide_nombre_cache(path: Path, nombre: str) -> bool:
+        """Indica si una entrada cacheada corresponde al nombre solicitado."""
+        objetivo = (
+            (nombre[:-3] if nombre.endswith(".co") else nombre)
+            .strip()
+            .lower()
+            .replace(" ", "-")
+        )
+        return path.stem == objetivo or path.stem.startswith(f"{objetivo}-")
+
+    def limpiar_cache(self, nombre: str | None = None) -> int:
+        """Elimina paquetes cacheados y devuelve el número de borrados."""
+        borrados = 0
+        for path in self.listar_cache():
+            if nombre is not None and not self._coincide_nombre_cache(path, nombre):
+                continue
+            path.unlink()
+            borrados += 1
+        return borrados
+
+    def validar_cache(self) -> list[tuple[Path, bool, str | None]]:
+        """Valida los paquetes cacheados con los validadores de empaquetado."""
+        resultados: list[tuple[Path, bool, str | None]] = []
+        for path in self.listar_cache():
+            try:
+                if not packaging.es_paquete_cobra(path):
+                    raise PackageIntegrityError(
+                        "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                    )
+                packaging.validar_paquete(path)
+            except CobraHubError as exc:
+                resultados.append((path, False, _(str(exc))))
+            except Exception as exc:
+                resultados.append((path, False, str(exc)))
+            else:
+                resultados.append((path, True, None))
+        return resultados
 
 
 __all__ = ["CobraHubProvider", "CobraHubService"]


### PR DESCRIPTION
### Motivation
- Centralizar la lógica de publicación, búsqueda, instalación y gestión de caché de CobraHub en un único servicio reutilizable para evitar que `hub_cmd.py` atraviese fachadas o clientes específicos.
- Mantener compatibilidad con la API histórica y con instrumentación/pruebas existentes sin tocar Lexer ni Parser.
- Hacer un cambio mínimo y localizado que facilite inyección de dependencias y pruebas.

### Description
- Amplié `CobraHubService` (`src/pcobra/cobra/cli/services/cobrahub_service.py`) para construir por defecto `CobraHubClient` y `HttpCobraHubRepository` cuando no se inyectan, y así centralizar la coordinación de las operaciones de red.
- Añadí al servicio las operaciones de caché `listar_cache`, `limpiar_cache` y `validar_cache` implementando el mismo comportamiento y mensajes históricos (filtrado `.co`, coincidencia por nombre y resultados de validación).
- Modifiqué `hub_cmd.py` para importar únicamente `CobraHubService` y usarlo para `publicar`, `buscar`, `instalar` y `cache`, manteniendo argumentos, textos y códigos de salida; además añadí el alias `CobraHubPackages = CobraHubService` en el módulo para compatibilidad con parches/instrumentación que esperaban ese nombre.
- Dejé la fachada pública `cobrahub_packages.py` compatible delegando ahora en `CobraHubService` en lugar de duplicar la implementación, sin exponer `hub_cmd.py` a la fachada histórica.

### Testing
- Ejecutado `python -m pytest -q tests/unit/test_cobrahub_cache.py tests/unit/test_hub_provider_contracts.py`; las pruebas dirigidas pasaron (`28 passed`).
- Ejecutado `python -m pytest -q tests/unit/test_cli_cobrahub.py tests/unit/test_cobrahub_cache.py tests/unit/test_hub_provider_contracts.py tests/cli/test_public_v2_commands_contract.py`; toda la suite relevante pasó (`71 passed, 1 warning`).
- Ejecutado `python -m compileall -q` sobre los módulos modificados y `git diff --check`, ambos sin errores, y verifiqué que no se modificaron archivos de Lexer o Parser.
- Cambios confirmados en commit `a31bf23` con mensaje `refactor(cli): centralizar operaciones de CobraHub`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bb82a38f88327a520df0c25af6418)