### PR TITLE
Desacopla CobraHubService del cliente HTTP

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -376,13 +376,19 @@ class CobraHubClient:
     def publicar_paquete(self, ruta: str) -> bool:
         """Publica un paquete .co usando la API separada de paquetes."""
         return CobraHubService(
-            self, HttpCobraHubRepository(self), mostrar_error, mostrar_info
+            provider=self,
+            repository=HttpCobraHubRepository(self),
+            error_handler=mostrar_error,
+            info_handler=mostrar_info,
         ).publicar_paquete(ruta)
 
     def buscar_paquetes(self, consulta: str) -> list[dict]:
         """Busca paquetes usando la API separada de paquetes."""
         return CobraHubService(
-            self, HttpCobraHubRepository(self), mostrar_error, mostrar_info
+            provider=self,
+            repository=HttpCobraHubRepository(self),
+            error_handler=mostrar_error,
+            info_handler=mostrar_info,
         ).buscar_paquetes(consulta)
 
     def instalar_paquete(
@@ -390,7 +396,10 @@ class CobraHubClient:
     ) -> bool:
         """Instala un paquete usando la API separada de paquetes."""
         return CobraHubService(
-            self, HttpCobraHubRepository(self), mostrar_error, mostrar_info
+            provider=self,
+            repository=HttpCobraHubRepository(self),
+            error_handler=mostrar_error,
+            info_handler=mostrar_info,
         ).instalar_paquete(nombre, destino, version)
 
 

--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -61,7 +61,10 @@ class CobraHubPackages:
         self.client = client
         self.repository = repository or HttpCobraHubRepository(client)
         self.service = CobraHubService(
-            client, self.repository, mostrar_error, mostrar_info
+            provider=client,
+            repository=self.repository,
+            error_handler=mostrar_error,
+            info_handler=mostrar_info,
         )
 
     def publicar_paquete(self, ruta: str) -> bool:

--- a/src/pcobra/cobra/cli/commands/hub_cmd.py
+++ b/src/pcobra/cobra/cli/commands/hub_cmd.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.cobrahub_factory import crear_servicio_cobrahub
 from pcobra.cobra.cli.services.cobrahub_service import CobraHubService
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
@@ -60,7 +61,11 @@ class HubCommand(BaseCommand):
         return self.register_subparser(subparsers, hidden=True)
 
     def run(self, args: Namespace) -> int:
-        service = CobraHubService()
+        service = (
+            CobraHubService()
+            if args.accion == "cache"
+            else crear_servicio_cobrahub()
+        )
         if args.accion == "publicar":
             return 0 if service.publicar_paquete(str(args.paquete)) else 1
         if args.accion == "buscar":

--- a/src/pcobra/cobra/cli/services/cobrahub_factory.py
+++ b/src/pcobra/cobra/cli/services/cobrahub_factory.py
@@ -1,0 +1,15 @@
+"""Composición predeterminada de las dependencias remotas de CobraHub."""
+
+from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+from pcobra.cobra.cli.services.cobrahub_service import CobraHubService
+from pcobra.cobra.hub.repository import HttpCobraHubRepository
+
+
+def crear_servicio_cobrahub() -> CobraHubService:
+    """Crea el servicio remoto con un cliente y repositorio HTTP compartidos."""
+    provider = CobraHubClient()
+    repository = HttpCobraHubRepository(provider)
+    return CobraHubService(provider=provider, repository=repository)
+
+
+__all__ = ["crear_servicio_cobrahub"]

--- a/src/pcobra/cobra/cli/services/cobrahub_service.py
+++ b/src/pcobra/cobra/cli/services/cobrahub_service.py
@@ -34,22 +34,24 @@ class CobraHubService:
         error_handler: Callable[[str], None] = mostrar_error,
         info_handler: Callable[[str], None] = mostrar_info,
     ) -> None:
-        if provider is None:
-            from pcobra.cobra.cli.cobrahub_client import CobraHubClient
-
-            provider = CobraHubClient()
-        if repository is None:
-            from pcobra.cobra.hub.repository import HttpCobraHubRepository
-
-            repository = HttpCobraHubRepository(provider)
         self.provider = provider
         self.repository = repository
         self._mostrar_error = error_handler
         self._mostrar_info = info_handler
 
+    def _dependencias_remotas(self) -> tuple[CobraHubProvider, PackageRepository]:
+        """Devuelve las dependencias requeridas por las operaciones HTTP."""
+        if self.provider is None or self.repository is None:
+            raise RuntimeError(
+                "Las operaciones remotas de CobraHub requieren un proveedor "
+                "y un repositorio"
+            )
+        return self.provider, self.repository
+
     def publicar_paquete(self, ruta: str) -> bool:
         """Publica un paquete validado en el repositorio."""
-        if not self.provider._validar_url():
+        provider, repository = self._dependencias_remotas()
+        if not provider._validar_url():
             return False
         try:
             if not packaging.es_paquete_cobra(ruta):
@@ -57,7 +59,7 @@ class CobraHubService:
                     "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
                 )
             info = packaging.validar_paquete(ruta)
-            self.repository.publish(ruta, dict(info.manifest), info.checksum)
+            repository.publish(ruta, dict(info.manifest), info.checksum)
             self._mostrar_info(_("Paquete publicado correctamente"))
             return True
         except CobraHubError as exc:
@@ -74,10 +76,11 @@ class CobraHubService:
 
     def buscar_paquetes(self, consulta: str) -> list[dict]:
         """Busca paquetes y adapta los resultados al contrato histórico."""
-        if not self.provider._validar_url():
+        provider, repository = self._dependencias_remotas()
+        if not provider._validar_url():
             return []
         try:
-            return [result.as_dict() for result in self.repository.search(consulta)]
+            return [result.as_dict() for result in repository.search(consulta)]
         except CobraHubError as exc:
             logger.error("Error buscando paquetes: %s", exc)
             self._mostrar_error(
@@ -95,12 +98,13 @@ class CobraHubService:
     ) -> bool:
         """Descarga, valida e instala un paquete desde el repositorio."""
         cache_path: Path | None = None
-        if not self.provider._validar_url():
+        provider, repository = self._dependencias_remotas()
+        if not provider._validar_url():
             return False
         try:
-            downloaded = self.repository.download(nombre, version)
+            downloaded = repository.download(nombre, version)
             cache_path = downloaded.path
-            if not self.provider._validar_nombre_modulo(downloaded.name):
+            if not provider._validar_nombre_modulo(downloaded.name):
                 cache_path.unlink(missing_ok=True)
                 return False
             if not packaging.es_paquete_cobra(cache_path):

--- a/tests/unit/test_cobrahub_cache.py
+++ b/tests/unit/test_cobrahub_cache.py
@@ -11,6 +11,7 @@ from pcobra.cobra.cli.cobrahub_packages import (
     validar_cache,
 )
 from pcobra.cobra.cli.commands.hub_cmd import HubCommand
+from pcobra.cobra.cli.services.cobrahub_service import CobraHubService
 from pcobra.cobra.packaging import construir_paquete, crear_paquete
 
 
@@ -24,6 +25,21 @@ def _crear_paquete_valido(tmp_path: Path, nombre: str = "demo") -> Path:
     crear_paquete(proyecto, nombre=nombre, version="1.0.0")
     (proyecto / "src" / "main.cobra").write_text("imprimir('hola')\n", encoding="utf-8")
     return construir_paquete(proyecto, tmp_path / f"{nombre}.co")
+
+
+@pytest.mark.parametrize(
+    ("metodo", "argumentos"),
+    [
+        ("publicar_paquete", ("demo.co",)),
+        ("buscar_paquetes", ("demo",)),
+        ("instalar_paquete", ("demo",)),
+    ],
+)
+def test_operaciones_remotas_requieren_dependencias_explicitas(metodo, argumentos):
+    service = CobraHubService()
+
+    with pytest.raises(RuntimeError, match="proveedor y un repositorio"):
+        getattr(service, metodo)(*argumentos)
 
 
 def test_listar_cache_devuelve_solo_paquetes_co_ordenados(tmp_path: Path, monkeypatch):

--- a/tests/unit/test_hub_import_boundaries.py
+++ b/tests/unit/test_hub_import_boundaries.py
@@ -42,3 +42,33 @@ def test_hub_conserva_exports_publicos_del_repositorio():
 
 def test_error_de_dependencias_pertenece_al_dominio_hub():
     assert issubclass(CobraDependencyError, PackageResolutionError)
+
+
+def test_servicio_cobrahub_no_importa_cliente_directa_ni_indirectamente():
+    """La coordinación no debe regresar a la implementación HTTP del cliente."""
+    source_root = Path(__file__).parents[2] / "src"
+    graph: dict[str, set[str]] = {}
+    for source_path in source_root.rglob("*.py"):
+        module = ".".join(source_path.relative_to(source_root).with_suffix("").parts)
+        if module.endswith(".__init__"):
+            module = module.removesuffix(".__init__")
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        imports: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module)
+                imports.update(f"{node.module}.{alias.name}" for alias in node.names)
+        graph[module] = imports
+
+    pendientes = ["pcobra.cobra.cli.services.cobrahub_service"]
+    alcanzables: set[str] = set()
+    while pendientes:
+        module = pendientes.pop()
+        if module in alcanzables:
+            continue
+        alcanzables.add(module)
+        pendientes.extend(graph.get(module, set()) - alcanzables)
+
+    assert "pcobra.cobra.cli.cobrahub_client" not in alcanzables


### PR DESCRIPTION
### Motivation
- Evitar que `CobraHubService` importe y construya implícitamente el cliente HTTP para mantener la capa de coordinación independiente de la implementación de transporte.
- Permitir que las operaciones locales de caché funcionen sin requerir `CobraHubProvider` ni `PackageRepository` porque no necesitan HTTP.
- Exigir explícitamente proveedor y repositorio antes de ejecutar operaciones remotas (`publicar_paquete`, `buscar_paquetes`, `instalar_paquete`) para evitar dependencias ocultas y rutas de importación indeseadas.
- Centralizar la composición por defecto del cliente+repositorio+servicio en una pequeña fábrica autorizada para uso por la CLI y otras capas autorizadas.

### Description
- Eliminado el import y construcción local de `CobraHubClient` y `HttpCobraHubRepository` dentro de `CobraHubService.__init__` y añadido el método `_dependencias_remotas()` que lanza `RuntimeError` si faltan `provider` o `repository`.
- Reemplacé las referencias directas a `self.provider`/`self.repository` en las operaciones remotas por variables locales obtenidas de `_dependencias_remotas()` y delegué llamadas a `provider` y `repository` cuando procede.
- Añadida la fábrica `crear_servicio_cobrahub()` en `src/pcobra/cobra/cli/services/cobrahub_factory.py` que compone `CobraHubClient`, `HttpCobraHubRepository` y `CobraHubService` por defecto.
- Modificado `src/pcobra/cobra/cli/commands/hub_cmd.py` para usar `CobraHubService()` sin proveedor para acciones de `cache` y `crear_servicio_cobrahub()` para operaciones remotas.
- Hice explícita la inyección de `provider`, `repository`, `error_handler` e `info_handler` en las fachadas existentes actualizando `src/pcobra/cobra/cli/cobrahub_packages.py` y las llamadas en `src/pcobra/cobra/cli/cobrahub_client.py`.
- Añadidos tests que verifican que las operaciones remotas fallan si el servicio no tiene dependencias explícitas y que no existe una ruta estática de imports desde `cobrahub_service` hacia `cobrahub_client` (`tests/unit/test_cobrahub_cache.py` y `tests/unit/test_hub_import_boundaries.py`).

### Testing
- Ejecutado `ruff check` sobre los módulos modificados (`src/pcobra/cobra/cli/...`) y la verificación estática pasó sin errores.
- Ejecutado `pytest` sobre las suites relevantes incluyendo `tests/unit/test_cli_cobrahub.py`, `tests/unit/test_cobrahub_cache.py`, `tests/unit/test_hub_import_boundaries.py`, `tests/unit/test_hub_provider_contracts.py`, `tests/unit/test_cobrahub_close.py` y `tests/unit/test_cobrahub_retry.py`, resultando en `73 passed, 1 warning`.
- Verificado que `git diff --check` no reporta problemas y que no se realizaron cambios en Lexer ni Parser por vía de imports o modificaciones de archivos de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bc5dddc8c8327a88ce866c24e0bd2)