### PR TITLE
Expandir lint de imports cruzados para incluir commands_v2

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -2,8 +2,8 @@
 """Lint interno para comandos CLI.
 
 Reglas:
-1) Construye el grafo de imports Python bajo ``cli/commands``.
-2) Prohíbe edges ``commands.X -> commands.Y`` (salvo ``commands.base``).
+1) Construye el grafo de imports Python bajo ``cli/commands{,_v2}``.
+2) Prohíbe edges entre comandos concretos (salvo ``commands.base``).
 3) En imports internos de ``pcobra.cobra.cli.*`` permite solo:
    ``commands.base``, ``services/*``, ``utils/*``, ``i18n``,
    ``target_policies`` y registries dedicados.
@@ -20,12 +20,28 @@ import ast
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-COMMANDS_PACKAGE_PREFIXES = ("pcobra.cobra.cli.commands", "cobra.cli.commands")
+COMMANDS_PACKAGE_PREFIXES = (
+    "pcobra.cobra.cli.commands",
+    "pcobra.cobra.cli.commands_v2",
+    "cobra.cli.commands",
+    "cobra.cli.commands_v2",
+)
 CLI_PACKAGE_PREFIXES = ("pcobra.cobra.cli", "cobra.cli")
 ALLOWED_BASE_IMPORT_MODULES = {
     "pcobra.cobra.cli.commands.base",
     "cobra.cli.commands.base",
 }
+# Debe mantenerse alineado con ALLOWED_LAYER_EDGES de check_import_cycles.py.
+# Esta excepción es una arista contractual concreta, no un permiso general entre
+# los dos paquetes de comandos.
+ALLOWED_COMMAND_EDGES = frozenset(
+    {
+        (
+            "pcobra.cobra.cli.commands_v2.repl_cmd",
+            "pcobra.cobra.cli.commands.interactive_cmd",
+        ),
+    }
+)
 ALLOWED_CLI_IMPORT_PREFIXES = (
     "pcobra.cobra.cli.commands.base",
     "pcobra.cobra.cli.services.",
@@ -104,8 +120,9 @@ def _node_import_targets(path: Path, node: ast.AST, root: Path) -> list[str]:
 
 
 def _build_import_graph(path: Path, root: Path) -> dict[str, set[str]]:
-    source_module = _resolve_relative_module(path, None, 0, root)
-    if not source_module:
+    try:
+        source_module = ".".join(path.relative_to(root / "src").with_suffix("").parts)
+    except ValueError:
         return {}
     graph: dict[str, set[str]] = {source_module: set()}
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -113,6 +130,14 @@ def _build_import_graph(path: Path, root: Path) -> dict[str, set[str]]:
         for target in _node_import_targets(path, node, root):
             graph[source_module].add(target)
     return graph
+
+
+def _is_allowed_command_edge(path: Path, target: str, root: Path) -> bool:
+    try:
+        source = ".".join(path.relative_to(root / "src").with_suffix("").parts)
+    except ValueError:
+        return False
+    return (source, target) in ALLOWED_COMMAND_EDGES
 
 
 def _scan_restricted_command_imports(path: Path, root: Path) -> list[tuple[int, str]]:
@@ -192,7 +217,10 @@ def _is_allowed_cli_dependency(module: str) -> bool:
         return True
     if _is_allowed_cli_registry_module(module):
         return True
-    return any(module == prefix or module.startswith(prefix) for prefix in ALLOWED_CLI_IMPORT_PREFIXES)
+    return any(
+        module == prefix.rstrip(".") or module.startswith(prefix)
+        for prefix in ALLOWED_CLI_IMPORT_PREFIXES
+    )
 
 
 def _scan_cli_dependency_boundaries(path: Path, root: Path) -> list[tuple[int, str]]:
@@ -274,7 +302,10 @@ def _scan_backend_constant_violations(path: Path) -> list[tuple[int, str]]:
 
 def find_violations(root: Path = ROOT) -> list[str]:
     failures: list[str] = []
-    scopes = (root / "src/pcobra/cobra/cli/commands",)
+    scopes = (
+        root / "src/pcobra/cobra/cli/commands",
+        root / "src/pcobra/cobra/cli/commands_v2",
+    )
     for scope in scopes:
         if not scope.exists():
             continue
@@ -283,6 +314,8 @@ def find_violations(root: Path = ROOT) -> list[str]:
             graph = _build_import_graph(path, root)
             if path.name != "__init__.py":
                 for line, target in _scan_restricted_command_imports(path, root):
+                    if _is_allowed_command_edge(path, target, root):
+                        continue
                     failures.append(
                         f"{rel}:{line}: import entre comandos no permitido ({target}); "
                         "solo se permite importar desde `...commands.base`"
@@ -291,21 +324,29 @@ def find_violations(root: Path = ROOT) -> list[str]:
                     for target in sorted(edges):
                         if not _is_forbidden_module_name(target):
                             continue
+                        if (source, target) in ALLOWED_COMMAND_EDGES:
+                            continue
                         failures.append(
                             f"{rel}: edge no permitido en grafo de imports ({source} -> {target}); "
                             "los comandos no deben depender de comandos concretos"
                         )
                 for line, target in _scan_cross_cmd_pattern_imports(path, root):
+                    if _is_allowed_command_edge(path, target, root):
+                        continue
                     failures.append(
                         f"{rel}:{line}: patrón *_cmd no permitido ({target}); "
                         "los comandos no deben importar otros *_cmd.py (solo BaseCommand desde commands.base)"
                     )
                 for line, target in _scan_explicit_cross_command_from_imports(path, root):
+                    if _is_allowed_command_edge(path, target, root):
+                        continue
                     failures.append(
                         f"{rel}:{line}: import explícito from ...commands.<otro_comando> no permitido ({target}); "
                         "los comandos CLI no deben depender de otros comandos (solo commands.base)"
                     )
                 for line, target in _scan_cli_dependency_boundaries(path, root):
+                    if _is_allowed_command_edge(path, target, root):
+                        continue
                     failures.append(
                         f"{rel}:{line}: dependencia CLI no permitida ({target}); "
                         "en commands solo se permite base/services/utils/i18n/target_policies/registries"

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -39,7 +39,7 @@ def test_detecta_import_entre_comandos(tmp_path: Path) -> None:
     assert any("src/pcobra/cobra/cli/commands/a.py:1" in item for item in violations)
 
 
-def test_no_aplica_regla_en_commands_v2(tmp_path: Path) -> None:
+def test_detecta_import_entre_comandos_en_commands_v2(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands_v2" / "run_cmd.py",
         "from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2\n",
@@ -47,7 +47,8 @@ def test_no_aplica_regla_en_commands_v2(tmp_path: Path) -> None:
 
     violations = find_violations(tmp_path)
 
-    assert violations == []
+    assert any("import entre comandos no permitido" in item for item in violations)
+    assert any("commands_v2.build_cmd" in item for item in violations)
 
 
 def test_permite_import_desde_base(tmp_path: Path) -> None:

--- a/tests/unit/test_ci_lint_no_cross_command_imports_guard.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports_guard.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scripts.ci.lint_no_cross_command_imports import find_violations
+
 
 def test_ci_lint_no_cross_command_imports_guard_passes_on_repo() -> None:
     repo_root = Path(__file__).resolve().parents[2]
@@ -14,3 +16,26 @@ def test_ci_lint_no_cross_command_imports_guard_passes_on_repo() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ci_lint_reports_temporary_commands_v2_violation(tmp_path: Path) -> None:
+    command = (
+        tmp_path
+        / "src"
+        / "pcobra"
+        / "cobra"
+        / "cli"
+        / "commands_v2"
+        / "run_cmd.py"
+    )
+    command.parent.mkdir(parents=True)
+    command.write_text(
+        "from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2\n",
+        encoding="utf-8",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert any("import entre comandos no permitido" in item for item in violations)
+    assert any("commands_v2.build_cmd" in item for item in violations)
+    assert any("src/pcobra/cobra/cli/commands_v2/run_cmd.py:1" in item for item in violations)


### PR DESCRIPTION
### Motivation

- Evitar dependencias cruzadas prohibidas entre módulos de comandos también dentro del nuevo árbol `commands_v2` usando las mismas reglas y escáneres que aplican a `commands`.
- Mantener las excepciones contractuales existentes (por ejemplo `commands.base`) y permitir solo la arista concreta ya acordada entre `commands_v2.repl_cmd` y `commands.interactive_cmd`, sin abrir permisos genéricos entre comandos.

### Description

- Amplía `COMMANDS_PACKAGE_PREFIXES` para incluir `commands_v2` y hace que `find_violations()` recorra ambos directorios `src/.../cli/commands` y `src/.../cli/commands_v2`.
- Corrige la resolución del nombre de módulo fuente en el grafo de imports para que las aristas detectadas en ambos árboles se asocien correctamente al módulo origen.
- Añade `ALLOWED_COMMAND_EDGES` y la función `_is_allowed_command_edge()` para tratar la excepción contractual concreta (alineada con `check_import_cycles`) sin convertirla en una excepción global entre comandos; se usan estas guardas en los escaneos relevantes (`_scan_restricted_command_imports`, grafo, patrones *_cmd, imports explícitos y fronteras CLI).
- Ajusta la comprobación de fronteras CLI para reconocer correctamente prefijos y sufijos permitidos (mejora en la verificación de prefijos con `rstrip`), y mantiene las reglas existentes para transpiladores y constantes compartidas.
- Añade un test guard `test_ci_lint_reports_temporary_commands_v2_violation` que crea una infracción temporal en `commands_v2` y comprueba que el lint la informa, y adapta un test existente para que ahora espere la detección en `commands_v2`.

### Testing

- Ejecuté `pytest -q tests/unit/test_ci_lint_no_cross_command_imports_guard.py tests/unit/test_ci_lint_no_cross_command_imports.py` y todas las pruebas unitarias relevantes pasaron (`15 passed`, 1 warning).
- Ejecuté `python scripts/ci/lint_no_cross_command_imports.py` y el script devolvió estado OK (no fallos reportados en el árbol real del repo).
- Ejecuté `python scripts/ci/check_import_cycles.py` y el gate de arquitectura pasó (sin ciclos ni violaciones de capas).
- Verifiqué que la excepción aplicada por el lint está alineada con las reglas de `check_import_cycles` comprobando que `ALLOWED_COMMAND_EDGES` es subconjunto de `ALLOWED_LAYER_EDGES` (comprobación automática satisfactoria).
- Hice una comprobación de diff para confirmar que `Lexer` y `Parser` no fueron modificados y `git diff --check` no arrojó problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c78abfa70832781bc98c70c1dcb61)