### PR TITLE
Update CLI unit tests to call main with `repl` argument

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,7 +12,7 @@ def test_cli_interactive():
             patch("sys.stdout", new_callable=StringIO) as mock_stdout, \
             patch("cobra.cli.cli.messages.mostrar_logo"):
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert output[0] == expected_outputs[0], f"Expected: {expected_outputs}, but got: {output}"
@@ -27,7 +27,7 @@ def test_cli_transpilador():
             patch("sys.stdout", new_callable=StringIO) as mock_stdout, \
             patch("cobra.cli.cli.messages.mostrar_logo"):
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert output[0] == expected_outputs[0], f"Expected: {expected_outputs}, but got: {output}"

--- a/tests/unit/test_cli2.py
+++ b/tests/unit/test_cli2.py
@@ -11,7 +11,7 @@ def test_cli_interactive():
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert expected_outputs == output[-len(expected_outputs):]
@@ -25,7 +25,7 @@ def test_cli_transpilador():
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert expected_outputs == output[-len(expected_outputs):]
@@ -39,7 +39,7 @@ def test_cli_with_holobit():
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert expected_outputs == output[-len(expected_outputs):]


### PR DESCRIPTION
### Motivation

- The CLI entrypoint was adjusted to require an explicit subcommand for the REPL, so tests that invoked `main()` without arguments needed updating to launch the interactive mode correctly.

### Description

- Replaced calls to `main()` with `main(["repl"])` in `tests/unit/test_cli.py` and `tests/unit/test_cli2.py` so the tests start the REPL mode.
- Kept existing input mocking and stdout capture logic unchanged to preserve test behavior and expectations.

### Testing

- Ran the unit test suite for the CLI tests with `pytest tests/unit` and the updated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c7b3491448327a74f06abbebc73da)