### PR TITLE
Adapt CLI tests to new entrypoint and command service API

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,7 +12,7 @@ def test_cli_interactive():
             patch("sys.stdout", new_callable=StringIO) as mock_stdout, \
             patch("cobra.cli.cli.messages.mostrar_logo"):
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert output[0] == expected_outputs[0], f"Expected: {expected_outputs}, but got: {output}"
@@ -27,7 +27,7 @@ def test_cli_transpilador():
             patch("sys.stdout", new_callable=StringIO) as mock_stdout, \
             patch("cobra.cli.cli.messages.mostrar_logo"):
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert output[0] == expected_outputs[0], f"Expected: {expected_outputs}, but got: {output}"

--- a/tests/unit/test_cli2.py
+++ b/tests/unit/test_cli2.py
@@ -11,7 +11,7 @@ def test_cli_interactive():
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert expected_outputs == output[-len(expected_outputs):]
@@ -25,7 +25,7 @@ def test_cli_transpilador():
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert expected_outputs == output[-len(expected_outputs):]
@@ -39,7 +39,7 @@ def test_cli_with_holobit():
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
         from cobra.cli.cli import main
-        main()
+        main(["repl"])
 
     output = mock_stdout.getvalue().strip().split("\n")
     assert expected_outputs == output[-len(expected_outputs):]

--- a/tests/unit/test_cli_commands_extra.py
+++ b/tests/unit/test_cli_commands_extra.py
@@ -1,4 +1,5 @@
 import importlib
+from argparse import Namespace
 from pathlib import Path
 from io import StringIO
 from unittest.mock import patch
@@ -8,11 +9,7 @@ import yaml
 
 from cobra.cli.cli import main
 from cobra.cli.commands import modules_cmd
-from pcobra.core.semantic_validators.base import ValidadorBase
-
-
-class _DummyValidator(ValidadorBase):
-    pass
+from cobra.cli.commands.execute_cmd import ExecuteCommand
 
 
 @pytest.mark.timeout(5)
@@ -28,10 +25,16 @@ def test_cli_ejecutar_imprime(tmp_path):
 def test_cli_ejecutar_flag_no_seguro(tmp_path):
     archivo = tmp_path / "p.co"
     archivo.write_text("imprimir(1)")
-    with patch("cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
-        main(["--no-seguro", "ejecutar", str(archivo)])
-        mock_interp.assert_called_once_with(safe_mode=False)
-        mock_interp.return_value.ejecutar_ast.assert_called_once()
+    command = ExecuteCommand()
+    with patch.object(command._service, "run", return_value=0) as run_service:
+        result = command.run(
+            Namespace(archivo=str(archivo), seguro=False, extra_validators=None)
+        )
+
+    assert result == 0
+    request = run_service.call_args.args[0]
+    assert request.archivo == str(archivo)
+    assert request.seguro is False
 
 
 @pytest.mark.timeout(5)
@@ -40,13 +43,17 @@ def test_cli_validadores_extra(tmp_path):
     archivo.write_text("imprimir(1)")
     ruta = tmp_path / "vals.py"
     ruta.write_text("VALIDADORES_EXTRA = []\n")
-    with patch("cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
-        mock_interp._cargar_validadores.return_value = [_DummyValidator()]
-        main([f"--extra-validators={ruta}", "ejecutar", str(archivo)])
-        mock_interp.assert_called_once_with(
-            safe_mode=True, extra_validators=mock_interp._cargar_validadores.return_value
+    command = ExecuteCommand()
+    with patch.object(command._service, "run", return_value=0) as run_service:
+        result = command.run(
+            Namespace(archivo=str(archivo), seguro=True, extra_validators=str(ruta))
         )
-        mock_interp.return_value.ejecutar_ast.assert_called_once()
+
+    assert result == 0
+    request = run_service.call_args.args[0]
+    assert request.archivo == str(archivo)
+    assert request.seguro is True
+    assert request.extra_validators == str(ruta)
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
### Motivation
- Tests were updated to match a changed CLI entrypoint that now expects a subcommand (interactive mode as `repl`).
- Tests were migrated away from tightly mocking the old `InterpretadorCobra` internals toward exercising the `ExecuteCommand` service surface.

### Description
- Updated interactive tests to call the CLI with `main(["repl"])` instead of `main()` to invoke the REPL subcommand.
- Replaced direct mocks of `InterpretadorCobra` with instantiation of `ExecuteCommand` and patching its `_service.run` method to assert request payloads.
- Added `Namespace` and `ExecuteCommand` imports and removed the now-unused `_DummyValidator` test helper.
- Added assertions that the service request contains expected fields `archivo`, `seguro`, and `extra_validators` when applicable.

### Testing
- Ran the modified unit tests for the CLI: `tests/unit/test_cli.py`, `tests/unit/test_cli2.py`, and `tests/unit/test_cli_commands_extra.py` under `pytest` and they completed successfully.
- Verified the interactive and execution-path tests (`test_cli_interactive`, `test_cli_transpilador`, `test_cli_ejecutar_imprime`, `test_cli_ejecutar_flag_no_seguro`, and `test_cli_validadores_extra`) passed with the new assertions.
- Confirmed the modules command test (`test_cli_modulos_comandos`) continued to run under the updated test setup and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c7b3491448327a74f06abbebc73da)