### PR TITLE
Canonicaliza imports y parches de las pruebas CLI

### DIFF
--- a/tests/unit/test_cli_commands_extra.py
+++ b/tests/unit/test_cli_commands_extra.py
@@ -9,9 +9,9 @@ import pytest
 import yaml
 
 from pcobra.cobra.cli import cli as cli_module
-from cobra.cli.commands import modules_cmd
-from cobra.cli.commands.crear_cmd import CrearCommand
-from cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.commands import modules_cmd
+from pcobra.cobra.cli.commands.crear_cmd import CrearCommand
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 
 
 def _load_mapping(source):

--- a/tests/unit/test_cli_double_dash.py
+++ b/tests/unit/test_cli_double_dash.py
@@ -10,8 +10,8 @@ from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 def test_cli_accepts_positional_argument_with_leading_dash():
     with patch.object(cli_module, "resolve_command_profile", return_value="development"), \
          patch.object(cli_module.AppConfig, "BASE_COMMAND_CLASSES", [ExecuteCommand]), \
-         patch("cobra.cli.cli.messages.mostrar_logo"), \
-         patch("cobra.cli.commands.execute_cmd.ExecuteCommand.run", return_value=0) as mock_run:
+         patch.object(cli_module.messages, "mostrar_logo"), \
+         patch.object(ExecuteCommand, "run", return_value=0) as mock_run:
         result = cli_module.main(["ejecutar", "--", "-archivo.co"])
     assert result == 0
     args_passed = mock_run.call_args[0][0]


### PR DESCRIPTION
### Motivation

- Corregir referencias legacy en las pruebas unitarias para que apunten al árbol de módulos canónico `pcobra.cobra.cli.commands`.
- Asegurar que los parches (`patch`) se aplican sobre los objetos donde la CLI realmente consulta las dependencias y evitar rutas textuales frágiles.
- Limitar el cambio solo a las pruebas indicadas sin alterar Lexer, Parser, sintaxis o comportamiento del runtime.

### Description

- Reemplacé los imports en `tests/unit/test_cli_commands_extra.py` de `cobra.cli.commands` por `pcobra.cobra.cli.commands` y actualicé las importaciones de `CrearCommand` y `ExecuteCommand` al mismo árbol canónico.
- En `tests/unit/test_cli_double_dash.py` sustituí `patch("cobra.cli.cli.messages.mostrar_logo")` por `patch.object(cli_module.messages, "mostrar_logo")` para parchar la dependencia en el módulo donde se consulta.
- En `tests/unit/test_cli_double_dash.py` cambié `patch("cobra.cli.commands.execute_cmd.ExecuteCommand.run", ...)` por `patch.object(ExecuteCommand, "run", ...)` para parchar el método sobre la clase ya importada.
- Limitado a los dos archivos de prueba modificados y sin introducir migraciones generales ni cambios en el código productivo ni en Lexer/Parser.

### Testing

- Ejecuté `pytest -q tests/unit/test_cli_commands_extra.py tests/unit/test_cli_double_dash.py` y las pruebas pasaron (`10 passed`).
- Compilé los archivos de prueba con `python -m compileall -q tests/unit/test_cli_commands_extra.py tests/unit/test_cli_double_dash.py` sin errores.
- Verifiqué con `rg` que no quedan los imports ni objetivos textuales legacy especificados y que los parches se aplican en los módulos canónicos.
- Ejecuté `git diff --check` y comprobé que no se modificaron archivos de Lexer o Parser ni otros archivos fuera de los dos tests cambiados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c9c35ecbc8327976a8fc63ec1aede)