### PR TITLE
test: parchear `subprocess.run` en módulos de comandos CLI

### DIFF
--- a/tests/unit/test_cli_container.py
+++ b/tests/unit/test_cli_container.py
@@ -3,13 +3,14 @@ from io import StringIO
 from unittest.mock import patch, call
 
 from pcobra.cobra.cli import cli as cli_module
+from pcobra.cobra.cli.commands import container_cmd
 from pcobra.cobra.cli.commands.container_cmd import ContainerCommand
 
 
 def test_cli_contenedor_invoca_docker():
     with patch.object(cli_module, "resolve_command_profile", return_value="development"), \
          patch.object(cli_module.AppConfig, "BASE_COMMAND_CLASSES", [ContainerCommand]), \
-         patch("subprocess.run") as mock_run:
+         patch.object(container_cmd.subprocess, "run") as mock_run:
         cli_module.main(["contenedor"])
         raiz = Path(__file__).resolve().parents[2]
         assert mock_run.call_args_list == [
@@ -25,7 +26,7 @@ def test_cli_contenedor_invoca_docker():
 def test_cli_contenedor_sin_docker():
     with patch.object(cli_module, "resolve_command_profile", return_value="development"), \
             patch.object(cli_module.AppConfig, "BASE_COMMAND_CLASSES", [ContainerCommand]), \
-            patch("subprocess.run", side_effect=FileNotFoundError), \
+            patch.object(container_cmd.subprocess, "run", side_effect=FileNotFoundError), \
             patch("sys.stdout", new_callable=StringIO) as out:
         cli_module.main(["contenedor"])
     assert "Docker no está instalado" in out.getvalue()

--- a/tests/unit/test_cli_docs.py
+++ b/tests/unit/test_cli_docs.py
@@ -4,6 +4,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import call, patch
 
+from pcobra.cobra.cli.commands import docs_cmd
 from pcobra.cobra.cli.commands.docs_cmd import DocsCommand
 
 
@@ -14,7 +15,7 @@ def test_cli_docs_invokes_sphinx():
     api = source / "api"
     codigo = raiz / "src"
 
-    with patch("subprocess.run") as mock_run:
+    with patch.object(docs_cmd.subprocess, "run") as mock_run:
         with patch.object(DocsCommand, "_obtener_raiz", return_value=raiz):
             DocsCommand().run(argparse.Namespace())
         mock_run.assert_has_calls([

--- a/tests/unit/test_cli_empaquetar.py
+++ b/tests/unit/test_cli_empaquetar.py
@@ -3,6 +3,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from pcobra.cobra.cli import cli as cli_module
+from pcobra.cobra.cli.commands import empaquetar_cmd
 from pcobra.cobra.cli.commands.empaquetar_cmd import EmpaquetarCommand
 
 
@@ -15,7 +16,7 @@ def _cli_context():
 
 def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
     profile, commands = _cli_context()
-    with profile, commands, patch("subprocess.run") as mock_run:
+    with profile, commands, patch.object(empaquetar_cmd.subprocess, "run") as mock_run:
         cli_module.main(["empaquetar", f"--output={tmp_path}", "--name", "cobra"])
         raiz = Path(__file__).resolve().parents[2]
         cli_path = raiz / "src" / "cli" / "cli.py"
@@ -37,7 +38,8 @@ def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
 
 def test_cli_empaquetar_sin_pyinstaller(tmp_path):
     profile, commands = _cli_context()
-    with profile, commands, patch("subprocess.run", side_effect=FileNotFoundError), \
+    with profile, commands, \
+            patch.object(empaquetar_cmd.subprocess, "run", side_effect=FileNotFoundError), \
             patch("sys.stdout", new_callable=StringIO) as out:
         cli_module.main(["empaquetar", f"--output={tmp_path}", "--name", "cobra"])
     assert "No se encontró PyInstaller" in out.getvalue()
@@ -47,7 +49,7 @@ def test_cli_empaquetar_con_spec(tmp_path):
     spec = tmp_path / "cobra.spec"
     spec.touch()
     profile, commands = _cli_context()
-    with profile, commands, patch("subprocess.run") as mock_run:
+    with profile, commands, patch.object(empaquetar_cmd.subprocess, "run") as mock_run:
         cli_module.main(["empaquetar", f"--output={tmp_path}", "--spec", str(spec)])
         mock_run.assert_called_once_with(
             [
@@ -68,7 +70,7 @@ def test_cli_empaquetar_con_datos(tmp_path):
     foo.touch()
     spam.touch()
     profile, commands = _cli_context()
-    with profile, commands, patch("subprocess.run") as mock_run:
+    with profile, commands, patch.object(empaquetar_cmd.subprocess, "run") as mock_run:
         cli_module.main([
             "empaquetar",
             f"--output={tmp_path}",


### PR DESCRIPTION
### Motivation
- Evitar que las pruebas unitarias lancen procesos reales de Docker, Sphinx o PyInstaller al parchear `subprocess.run` en el módulo correcto del comando.
- Conservar todas las aserciones existentes sobre argumentos, códigos de salida y mensajes sin modificar el código de producción.
- Preservar la integridad de Lexer y Parser y efectuar un cambio mínimo y localizado en las pruebas.

### Description
- Importé `container_cmd`, `docs_cmd` y `empaquetar_cmd` en `tests/unit/test_cli_container.py`, `tests/unit/test_cli_docs.py` y `tests/unit/test_cli_empaquetar.py` respectivamente.
- Reemplacé los parches globales `patch("subprocess.run")` por `patch.object(<modulo>.subprocess, "run")` en cada prueba y apliqué `side_effect=FileNotFoundError` donde se simula la ausencia de la herramienta.
- No se editaron Lexer, Parser ni código de producción; los cambios son únicamente en los tests y mantienen las mismas aserciones y flujos de prueba.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_container.py tests/unit/test_cli_docs.py tests/unit/test_cli_empaquetar.py` y todas las pruebas pasaron (`8 passed`).
- Ejecuté `git diff --check` y no reportó problemas.
- Verifiqué que no hubo cambios en Lexer ni Parser usando la búsqueda de archivos modificados, sin coincidencias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c9d5e5c3c832784e2ce1b902288ae)