### PR TITLE
test: validar salida UTF-8 de configure_encoding en proceso

### DIFF
--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -1,9 +1,8 @@
+import io
 import logging
 import os
-import subprocess
 import sys
 import types
-from pathlib import Path
 
 
 yaml_stub = types.ModuleType("yaml")
@@ -172,22 +171,19 @@ def test_main_devuelve_exit_code_1_si_falla_configuracion_entorno(monkeypatch, c
     assert "Falta SQLITE_DB_KEY en el entorno" in caplog.text
 
 
-def test_smoke_cli_unicode_salida_bytes_utf8():
-    env = os.environ.copy()
-    env.pop("PYTHONIOENCODING", None)
+def test_configure_encoding_unicode_salida_bytes_utf8(monkeypatch):
+    stdout_bytes = io.BytesIO()
+    stderr_bytes = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_bytes, encoding="latin-1")
+    stderr = io.TextIOWrapper(stderr_bytes, encoding="latin-1")
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "from pcobra.cli import configure_encoding; "
-            "configure_encoding(); print('después')",
-        ],
-        env=env,
-        capture_output=True,
-        check=True,
-        cwd=str(Path(__file__).resolve().parents[2]),
-    )
+    configure_encoding()
+    print("después")
+    stdout.flush()
 
-    assert result.stdout == "después\n".encode("utf-8")
-    assert result.stdout.decode("utf-8") == "después\n"
+    salida = stdout_bytes.getvalue()
+    assert salida == "después\n".encode("utf-8")
+    assert salida.decode("utf-8") == "después\n"


### PR DESCRIPTION
### Motivation
- Evitar lanzar un subproceso en la prueba y comprobar la frontera binaria de salida dentro del mismo proceso usando objetos en memoria.
- Garantizar que `configure_encoding()` produzca salida en UTF-8 sin depender de `subprocess.run` ni rutas en disco externas.

### Description
- Reemplaza la prueba basada en `subprocess.run` por `test_configure_encoding_unicode_salida_bytes_utf8` que usa `io.BytesIO` e `io.TextIOWrapper` y sustituye `sys.stdout`/`sys.stderr` con `monkeypatch` para verificar la frontera binaria en memoria.
- Llama a `configure_encoding()`, escribe `print("después")`, y comprueba que los bytes resultantes son exactamente `"después\n"` codificados en UTF-8 y que se decodifican correctamente.
- Elimina los imports ya innecesarios de `subprocess` y `Path` y añade `io` para los streams en memoria.
- No se tocan archivos de Lexer ni Parser y los cambios se limitan exclusivamente a la prueba indicada.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_configurar_entorno.py` y todas las pruebas de ese archivo pasaron (`7 passed`).
- Ejecuté `git diff --check` y no se reportaron problemas en el diff.
- Verifiqué con `git diff --name-only | rg -i '(^|/)(lexer|parser)(/|\.|$)'` que no se modificaron archivos de Lexer ni Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c9e8ca7d48327ad56ad25122be0dc)