### PR TITLE
test: aislar importación de Sphinx en la prueba del comando docs

### DIFF
--- a/tests/unit/test_cli_docs.py
+++ b/tests/unit/test_cli_docs.py
@@ -1,5 +1,7 @@
 import argparse
 import builtins
+import sys
+import types
 from io import StringIO
 from pathlib import Path
 from unittest.mock import call, patch
@@ -8,12 +10,14 @@ from pcobra.cobra.cli.commands import docs_cmd
 from pcobra.cobra.cli.commands.docs_cmd import DocsCommand
 
 
-def test_cli_docs_invokes_sphinx():
+def test_cli_docs_invokes_sphinx(monkeypatch):
     raiz = Path(__file__).resolve().parents[2]
     source = raiz / "docs" / "frontend"
     build = raiz / "docs" / "build" / "html"
     api = source / "api"
     codigo = raiz / "src"
+    sphinx_stub = types.ModuleType("sphinx")
+    monkeypatch.setitem(sys.modules, "sphinx", sphinx_stub)
 
     with patch.object(docs_cmd.subprocess, "run") as mock_run:
         with patch.object(DocsCommand, "_obtener_raiz", return_value=raiz):


### PR DESCRIPTION
### Motivation
- Evitar que la prueba `test_cli_docs_invokes_sphinx` dependa de la presencia real de `sphinx` en el entorno y permitir que las aserciones sobre las llamadas a `sphinx-apidoc` y `sphinx-build` sigan ejecutándose de forma controlada.

### Description
- Se añadieron los imports `sys` y `types`, se recibió la fixture `monkeypatch` en `test_cli_docs_invokes_sphinx` y antes de invocar `DocsCommand.run` se creó e inyectó un `types.ModuleType("sphinx")` en `sys.modules` mediante `monkeypatch.setitem(sys.modules, "sphinx", sphinx_stub)`; las aserciones existentes sobre las llamadas a `sphinx-apidoc` y `sphinx-build` permanecen intactas.

### Testing
- Se ejecutó `pytest -q tests/unit/test_cli_docs.py` y ambas pruebas pasaron; además se verificó con `git diff --check` y comprobaciones de diff que no se modificaron archivos de Lexer/Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca335f9cc83279ecd001d098b706c)