### PR TITLE
test: aislar el perfil de desarrollo en el arranque CLI

### DIFF
--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -138,14 +138,17 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
     from pcobra.cobra.cli import cli as cli_module
 
     orden: list[str] = []
+    argumentos_recibidos: list[list[str]] = []
 
+    monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
     monkeypatch.setattr(cli, "configure_encoding", lambda: orden.append("utf8"))
     monkeypatch.setattr(cli, "_bootstrap_dev_path_si_opt_in", lambda: orden.append("bootstrap"))
     monkeypatch.setattr(cli, "configure_logging", lambda debug, verbose=0: orden.append("logging"))
     monkeypatch.setattr(cli, "configurar_entorno", lambda: orden.append("entorno"))
 
     class _DummyApp:
-        def run(self, _argv):
+        def run(self, argv):
+            argumentos_recibidos.append(argv)
             orden.append("cli")
             return 0
 
@@ -154,6 +157,7 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
     assert cli.main(["comando-ficticio"]) == 0
     assert orden[:3] == ["utf8", "bootstrap", "logging"]
     assert "cli" in orden
+    assert argumentos_recibidos == [["comando-ficticio"]]
 
 
 def test_main_devuelve_exit_code_1_si_falla_configuracion_entorno(monkeypatch, caplog):


### PR DESCRIPTION
### Motivation
- Asegurar que `pcobra.cli.main` use explícitamente el perfil de comandos de desarrollo cuando corresponde y que la prueba doble de la aplicación CLI sea instalada en el módulo exacto importado por `pcobra.cli.main`, sin depender de registros reales. Los cambios respetan la regla de no tocar Lexer/Parser.

### Description
- En la prueba `test_main_reconfigura_consola_antes_de_logging_y_cli` se añade `monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")`, se introduce `argumentos_recibidos` y se adapta el doble `_DummyApp.run` para recibir y registrar `argv`, y se añade una aserción que verifica que el doble recibe `["comando-ficticio"]`.

### Testing
- `pytest -q tests/unit/test_cli_configurar_entorno.py::test_main_reconfigura_consola_antes_de_logging_y_cli` pasó correctamente.
- Ejecutando la prueba objetivo después del resto del módulo y antes del resto (orden inverso) ambas variantes pasaron (`7 passed` en el módulo en esas ejecuciones dirigidas).
- Al intentar ejecutar la suite ampliada de pruebas `tests/unit/test_cli_*.py` la ejecución se detuvo por cinco fallos preexistentes no relacionados con este cambio (uno en limpieza de caché y cuatro sobre una invariante del intérprete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca44a04088327bbf3ea6ed20679e1)