### PR TITLE
test: aislar el perfil de desarrollo en comandos internos de CLI

### DIFF
--- a/tests/unit/test_cli_entrypoint_subprocess.py
+++ b/tests/unit/test_cli_entrypoint_subprocess.py
@@ -431,7 +431,8 @@ def _run_cobra_script(args: list[str], env: dict[str, str], tmp_path: Path) -> s
 
 @pytest.mark.timeout(30)
 def test_cli_dependencias_listar(tmp_path: Path) -> None:
-    env = _create_stub_environment(tmp_path)
+    env = _create_stub_environment(tmp_path).copy()
+    env["COBRA_CLI_COMMAND_PROFILE"] = "development"
     result = _run_cli(["dependencias", "listar"], env)
     assert result.returncode == 0, result.stderr
     stdout = result.stdout
@@ -441,7 +442,8 @@ def test_cli_dependencias_listar(tmp_path: Path) -> None:
 
 @pytest.mark.timeout(30)
 def test_cli_agix_help(tmp_path: Path) -> None:
-    env = _create_stub_environment(tmp_path)
+    env = _create_stub_environment(tmp_path).copy()
+    env["COBRA_CLI_COMMAND_PROFILE"] = "development"
     result = _run_cli(["agix", "--help"], env)
     assert result.returncode == 0, result.stderr
     stdout = result.stdout

--- a/tests/unit/test_cli_error_messages.py
+++ b/tests/unit/test_cli_error_messages.py
@@ -6,7 +6,8 @@ from cobra.cli.cli import main
 
 
 @pytest.mark.timeout(5)
-def test_error_msg_compile_missing(tmp_path):
+def test_error_msg_compile_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
     archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["compilar", str(archivo)])
@@ -22,7 +23,8 @@ def test_error_msg_execute_missing(tmp_path):
 
 
 @pytest.mark.timeout(5)
-def test_cli_legacy_imports_flag_muestra_ruta_migracion(tmp_path):
+def test_cli_legacy_imports_flag_muestra_ruta_migracion(tmp_path, monkeypatch):
+    monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
     archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["--legacy-imports", "compilar", str(archivo)])


### PR DESCRIPTION
### Motivation

- Evitar convertir el entorno stub compartido en perfil `development` por defecto cuando se ejecutan pruebas que arrancan la CLI en subprocesos.
- Activar el perfil `development` solo localmente en las pruebas que ejercitan comandos internos (`dependencias`, `agix`) o que invocan wrappers legacy (`compilar`) para no alterar el comportamiento público por defecto.
- Mantener inalterada la implementación de `_create_stub_environment()` y preservar la compatibilidad de la superficie pública de la CLI.

### Description

- En `tests/unit/test_cli_entrypoint_subprocess.py` las pruebas `test_cli_dependencias_listar` y `test_cli_agix_help` crean ahora una copia local del entorno con `env = _create_stub_environment(tmp_path).copy()` y fijan `env["COBRA_CLI_COMMAND_PROFILE"] = "development"` antes de invocar `_run_cli`.
- En `tests/unit/test_cli_error_messages.py` se añadió la fixture `monkeypatch` a las pruebas que invocan `compilar` y se configura localmente `COBRA_CLI_COMMAND_PROFILE=development` mediante `monkeypatch.setenv` para aislar el cambio al alcance de la prueba.
- Se conservaron los códigos de salida, los mensajes comprobados y la política pública por defecto; `
_create_stub_environment()` sigue basándose en `os.environ.copy()` sin modificaciones.

### Testing

- Ejecutado `pytest -q tests/unit/test_cli_error_messages.py::test_error_msg_compile_missing` y la prueba pasó exitosamente.
- Ejecutado `pytest -q tests/unit/test_cli_entrypoint_subprocess.py tests/unit/test_cli_error_messages.py` como comprobación integrada y se observaron fallos por condiciones de integración existentes (comandos no registrados en UI v2 y un stub faltante de `prompt_toolkit.auto_suggest`), los cuales no fueron introducidos por este cambio.
- Verificaciones administrativas realizadas: `git diff --check` y comprobación de que Lexer/Parser no cambiaron, ambas pasaron; los únicos cambios son los ajustes de prueba descritos arriba.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca5d210cc8327a947ed1e85642a0f)