### PR TITLE
test(cli): ajusta mocks de errores internos de la CLI

### DIFF
--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -10,8 +10,8 @@ def test_handle_execution_error_normal_hides_traceback_and_keeps_logging_excepti
     exc = RuntimeError("boom")
 
     with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.error"
-    ) as mock_logging_error, patch("cobra.cli.cli.print") as mock_print, patch(
+        "cobra.cli.cli.logging.exception"
+    ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print, patch(
         "cobra.cli.cli.format_traceback", return_value="TRACEBACK"
     ) as mock_format_traceback:
         result = app._handle_execution_error(exc, "es", debug_activo=False)
@@ -19,7 +19,7 @@ def test_handle_execution_error_normal_hides_traceback_and_keeps_logging_excepti
     assert result == 1
     assert mock_error.call_count == 1
     assert mock_error.call_args[0][0] == "boom"
-    mock_logging_error.assert_called_once_with("Error interno inesperado en ejecución de comando", exc_info=True)
+    mock_logging_exception.assert_called_once_with("Error interno inesperado en ejecución de comando")
     mock_print.assert_not_called()
     mock_format_traceback.assert_not_called()
 
@@ -30,13 +30,13 @@ def test_handle_execution_error_no_duplica_salida_si_ya_fue_mostrada():
     setattr(exc, "error_ya_mostrado", True)
 
     with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.error"
-    ) as mock_logging_error, patch("cobra.cli.cli.print") as mock_print:
+        "cobra.cli.cli.logging.exception"
+    ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print:
         result = app._handle_execution_error(exc, "es", debug_activo=False)
 
     assert result == 1
     mock_error.assert_not_called()
-    mock_logging_error.assert_called_once_with("Error interno inesperado en ejecución de comando", exc_info=True)
+    mock_logging_exception.assert_called_once_with("Error interno inesperado en ejecución de comando")
     mock_print.assert_not_called()
 
 
@@ -72,8 +72,8 @@ def test_handle_execution_error_con_root_logger_configurado_no_duplica_salida():
 
     try:
         with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-            "cobra.cli.cli.logging.error"
-        ) as mock_logging_error, patch("cobra.cli.cli.print") as mock_print:
+            "cobra.cli.cli.logging.exception"
+        ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print:
             result = app._handle_execution_error(exc, "es", debug_activo=False)
     finally:
         for handler in list(root_logger.handlers):
@@ -83,7 +83,7 @@ def test_handle_execution_error_con_root_logger_configurado_no_duplica_salida():
 
     assert result == 1
     mock_error.assert_called_once_with("boom", registrar_log=False)
-    mock_logging_error.assert_called_once_with("Error interno inesperado en ejecución de comando", exc_info=True)
+    mock_logging_exception.assert_called_once_with("Error interno inesperado en ejecución de comando")
     mock_print.assert_not_called()
 
 


### PR DESCRIPTION
### Motivation
- Corregir los casos de prueba que esperan el manejo de errores internos en modo normal para que verifiquen el símbolo actualmente usado por `CliApplication._handle_execution_error`.

### Description
- Actualiza tres tests en `tests/unit/test_cli_execution_error_output.py` para parchar el mock hacia `cobra.cli.cli.logging.exception` y comprobar la llamada exacta con el mensaje "Error interno inesperado en ejecución de comando", manteniendo el caso debug sin cambios.

### Testing
- Ejecutado `python -m pytest tests/unit/test_cli_execution_error_output.py -q` y todas las pruebas pasaron (`12 passed`), y se verificó con `git diff --check` que no hay cambios en Lexer ni Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca8841758832790a23a4fb3e65ab1)