### PR TITLE
test: añadir stub mínimo de prompt_toolkit.auto_suggest

### DIFF
--- a/tests/unit/test_cli_entrypoint_subprocess.py
+++ b/tests/unit/test_cli_entrypoint_subprocess.py
@@ -161,6 +161,14 @@ def _create_stub_environment(tmp_path: Path) -> dict[str, str]:
     )
 
     _write_stub(
+        stubs_dir / "prompt_toolkit/auto_suggest.py",
+        """
+        class AutoSuggestFromHistory:
+            pass
+        """,
+    )
+
+    _write_stub(
         stubs_dir / "prompt_toolkit/output/__init__.py",
         """
         class DummyOutput:


### PR DESCRIPTION
### Motivation
- Añadir un stub mínimo `prompt_toolkit/auto_suggest.py` al entorno temporal de pruebas para satisfacer la importación esperada por `pcobra.jupyter_kernel` sin emular la distribución completa ni introducir efectos laterales.

### Description
- En `_create_stub_environment` de `tests/unit/test_cli_entrypoint_subprocess.py` se añadió `stubs/prompt_toolkit/auto_suggest.py` que expone únicamente la clase `AutoSuggestFromHistory` (implementación vacía), sin tocar código de producción ni los módulos `Lexer` o `Parser`.

### Testing
- Se ejecutaron `python -m py_compile tests/unit/test_cli_entrypoint_subprocess.py` (OK), una comprobación aislada que carga el stub y verifica que `AutoSuggestFromHistory` está definido (OK), `git diff --check` (OK) y la verificación de que `Lexer`/`Parser` no cambiaron (OK); el `pytest -q tests/unit/test_cli_entrypoint_subprocess.py::test_cli_y_kernel_arrancan_con_namespace_canonico_en_entorno_minimo` falló porque la instalación local de IPython sigue importando `prompt_toolkit.enums`, módulo que no se simuló intencionadamente para mantener el stub mínimo solicitado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca996f90483278757cd2979859177)