### PR TITLE
Update unit tests to use `pcobra` package layout and legacy CLI shim

### DIFF
--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -1,4 +1,5 @@
 import io
+import importlib
 import logging
 import os
 import sys
@@ -135,8 +136,6 @@ def test_configure_encoding_reconfigura_stdout_y_stderr(monkeypatch):
 
 
 def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
-    from pcobra.cobra.cli import cli as cli_module
-
     orden: list[str] = []
     argumentos_recibidos: list[list[str]] = []
 
@@ -152,6 +151,7 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
             orden.append("cli")
             return 0
 
+    cli_module = importlib.import_module("pcobra.cobra.cli.cli")
     monkeypatch.setattr(cli_module, "CliApplication", _DummyApp)
 
     assert cli.main(["comando-ficticio"]) == 0

--- a/tests/unit/test_cli_entrypoint_subprocess.py
+++ b/tests/unit/test_cli_entrypoint_subprocess.py
@@ -131,61 +131,6 @@ def _create_stub_environment(tmp_path: Path) -> dict[str, str]:
     )
 
     _write_stub(
-        stubs_dir / "prompt_toolkit/__init__.py",
-        """
-        class PromptSession:
-            def __init__(self, *_args, **_kwargs):
-                pass
-
-            def prompt(self, *_args, **_kwargs):
-                return ""
-        """,
-    )
-
-    _write_stub(
-        stubs_dir / "prompt_toolkit/lexers.py",
-        """
-        class PygmentsLexer:
-            def __init__(self, *_args, **_kwargs):
-                pass
-        """,
-    )
-
-    _write_stub(
-        stubs_dir / "prompt_toolkit/history.py",
-        """
-        class FileHistory:
-            def __init__(self, *_args, **_kwargs):
-                pass
-        """,
-    )
-
-    _write_stub(
-        stubs_dir / "prompt_toolkit/auto_suggest.py",
-        """
-        class AutoSuggestFromHistory:
-            pass
-        """,
-    )
-
-    _write_stub(
-        stubs_dir / "prompt_toolkit/output/__init__.py",
-        """
-        class DummyOutput:
-            def __init__(self, *_args, **_kwargs):
-                pass
-        """,
-    )
-
-    _write_stub(
-        stubs_dir / "prompt_toolkit/output/win32.py",
-        """
-        class NoConsoleScreenBufferError(Exception):
-            pass
-        """,
-    )
-
-    _write_stub(
         stubs_dir / "filelock.py",
         """
         class FileLock:
@@ -379,7 +324,17 @@ def _create_stub_environment(tmp_path: Path) -> dict[str, str]:
 
 
 def _run_cli(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    cmd = [sys.executable, "-m", "pcobra.cli", *args]
+    cmd = [
+        sys.executable,
+        "-c",
+        (
+            "import sys; "
+            "from pcobra.cli import build_legacy_cli_shim_main; "
+            "main = build_legacy_cli_shim_main('cli.cli'); "
+            "sys.exit(main(sys.argv[1:]))"
+        ),
+        *args,
+    ]
     try:
         return subprocess.run(
             cmd,

--- a/tests/unit/test_cli_error_messages.py
+++ b/tests/unit/test_cli_error_messages.py
@@ -3,6 +3,11 @@ from unittest.mock import patch
 import pytest
 
 from cobra.cli.cli import main
+from pcobra.cli import build_legacy_cli_shim_main
+
+
+def _legacy_main():
+    return build_legacy_cli_shim_main("cli.cli")
 
 
 @pytest.mark.timeout(5)
@@ -10,7 +15,7 @@ def test_error_msg_compile_missing(tmp_path, monkeypatch):
     monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
     archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:
-        main(["compilar", str(archivo)])
+        _legacy_main()(["compilar", str(archivo)])
     assert "archivo" in out.getvalue().lower()
 
 
@@ -27,7 +32,7 @@ def test_cli_legacy_imports_flag_muestra_ruta_migracion(tmp_path, monkeypatch):
     monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
     archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:
-        main(["--legacy-imports", "compilar", str(archivo)])
+        _legacy_main()(["--legacy-imports", "compilar", str(archivo)])
     salida = out.getvalue()
     assert "Compatibilidad legacy habilitada" in salida
     assert "pcobra.*" in salida

--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -1,18 +1,31 @@
 import argparse
+import importlib
 import logging
+import sys
 from unittest.mock import patch
 
-from cobra.cli.cli import CliApplication
+import pytest
+
+
+cli_module = importlib.import_module("pcobra.cobra.cli.cli")
+CliApplication = cli_module.CliApplication
+
+
+@pytest.fixture(autouse=True)
+def _restaurar_modulo_cli_canonico(monkeypatch):
+    cli_package = importlib.import_module("pcobra.cobra.cli")
+    monkeypatch.setitem(sys.modules, "pcobra.cobra.cli.cli", cli_module)
+    monkeypatch.setattr(cli_package, "cli", cli_module, raising=False)
 
 
 def test_handle_execution_error_normal_hides_traceback_and_keeps_logging_exception():
     app = CliApplication()
     exc = RuntimeError("boom")
 
-    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.exception"
-    ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print, patch(
-        "cobra.cli.cli.format_traceback", return_value="TRACEBACK"
+    with patch("pcobra.cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "pcobra.cobra.cli.cli.logging.exception"
+    ) as mock_logging_exception, patch("pcobra.cobra.cli.cli.print") as mock_print, patch(
+        "pcobra.cobra.cli.cli.format_traceback", return_value="TRACEBACK"
     ) as mock_format_traceback:
         result = app._handle_execution_error(exc, "es", debug_activo=False)
 
@@ -29,9 +42,9 @@ def test_handle_execution_error_no_duplica_salida_si_ya_fue_mostrada():
     exc = RuntimeError("boom")
     setattr(exc, "error_ya_mostrado", True)
 
-    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.exception"
-    ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print:
+    with patch("pcobra.cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "pcobra.cobra.cli.cli.logging.exception"
+    ) as mock_logging_exception, patch("pcobra.cobra.cli.cli.print") as mock_print:
         result = app._handle_execution_error(exc, "es", debug_activo=False)
 
     assert result == 1
@@ -44,12 +57,12 @@ def test_handle_execution_error_debug_envia_traceback_a_logger_debug():
     app = CliApplication()
     exc = RuntimeError("boom")
 
-    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.exception"
+    with patch("pcobra.cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "pcobra.cobra.cli.cli.logging.exception"
     ) as mock_logging_exception, patch(
-        "cobra.cli.cli.logging.getLogger"
+        "pcobra.cobra.cli.cli.logging.getLogger"
     ) as mock_get_logger, patch(
-        "cobra.cli.cli.format_traceback", return_value="TRACEBACK") as mock_format_traceback:
+        "pcobra.cobra.cli.cli.format_traceback", return_value="TRACEBACK") as mock_format_traceback:
         result = app._handle_execution_error(exc, "es", debug_activo=True)
 
     assert result == 1
@@ -71,9 +84,9 @@ def test_handle_execution_error_con_root_logger_configurado_no_duplica_salida():
     root_logger.addHandler(logging.StreamHandler())
 
     try:
-        with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-            "cobra.cli.cli.logging.exception"
-        ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print:
+        with patch("pcobra.cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+            "pcobra.cobra.cli.cli.logging.exception"
+        ) as mock_logging_exception, patch("pcobra.cobra.cli.cli.print") as mock_print:
             result = app._handle_execution_error(exc, "es", debug_activo=False)
     finally:
         for handler in list(root_logger.handlers):
@@ -100,9 +113,9 @@ def test_run_propaga_debug_activo_hacia_execute_command():
 
     with patch.object(app, "initialize"), patch.object(app, "_parse_arguments", return_value=args), patch.object(
         app, "execute_command", return_value=0
-    ) as mock_execute_command, patch("cobra.cli.cli.messages.mostrar_logo"), patch(
-        "cobra.cli.cli.messages.disable_colors"
-    ), patch("cobra.cli.cli.setup_gettext"):
+    ) as mock_execute_command, patch("pcobra.cobra.cli.cli.messages.mostrar_logo"), patch(
+        "pcobra.cobra.cli.cli.messages.disable_colors"
+    ), patch("pcobra.cobra.cli.cli.setup_gettext"):
         result = app.run([])
 
     assert result == 0
@@ -115,9 +128,9 @@ def test_run_tolera_argumentos_opcionales_ausentes_fuera_de_comando():
 
     with patch.object(app, "initialize"), patch.object(app, "_parse_arguments", return_value=args), patch.object(
         app, "execute_command", return_value=1
-    ) as mock_execute_command, patch("cobra.cli.cli.messages.mostrar_logo"), patch(
-        "cobra.cli.cli.messages.disable_colors"
-    ) as mock_disable_colors, patch("cobra.cli.cli.setup_gettext") as mock_setup_gettext:
+    ) as mock_execute_command, patch("pcobra.cobra.cli.cli.messages.mostrar_logo"), patch(
+        "pcobra.cobra.cli.cli.messages.disable_colors"
+    ) as mock_disable_colors, patch("pcobra.cobra.cli.cli.setup_gettext") as mock_setup_gettext:
         result = app.run([])
 
     assert result == 1
@@ -143,10 +156,10 @@ def test_run_bloquea_fallback_inseguro_en_ci_sin_override(monkeypatch):
 
     with patch.object(app, "initialize"), patch.object(app, "_parse_arguments", return_value=args), patch.object(
         app, "execute_command", return_value=0
-    ) as mock_execute_command, patch("cobra.cli.cli.messages.mostrar_logo"), patch(
-        "cobra.cli.cli.messages.disable_colors"
-    ), patch("cobra.cli.cli.setup_gettext"), patch("cobra.cli.cli.messages.mostrar_advertencia"), patch(
-        "cobra.cli.cli.messages.mostrar_error"
+    ) as mock_execute_command, patch("pcobra.cobra.cli.cli.messages.mostrar_logo"), patch(
+        "pcobra.cobra.cli.cli.messages.disable_colors"
+    ), patch("pcobra.cobra.cli.cli.setup_gettext"), patch("pcobra.cobra.cli.cli.messages.mostrar_advertencia"), patch(
+        "pcobra.cobra.cli.cli.messages.mostrar_error"
     ) as mock_error:
         result = app.run([])
 
@@ -172,10 +185,10 @@ def test_run_permite_override_explicito_en_ci_y_muestra_mensaje(monkeypatch):
 
     with patch.object(app, "initialize"), patch.object(app, "_parse_arguments", return_value=args), patch.object(
         app, "execute_command", return_value=0
-    ) as mock_execute_command, patch("cobra.cli.cli.messages.mostrar_logo"), patch(
-        "cobra.cli.cli.messages.disable_colors"
-    ), patch("cobra.cli.cli.setup_gettext"), patch(
-        "cobra.cli.cli.messages.mostrar_advertencia"
+    ) as mock_execute_command, patch("pcobra.cobra.cli.cli.messages.mostrar_logo"), patch(
+        "pcobra.cobra.cli.cli.messages.disable_colors"
+    ), patch("pcobra.cobra.cli.cli.setup_gettext"), patch(
+        "pcobra.cobra.cli.cli.messages.mostrar_advertencia"
     ) as mock_warning:
         result = app.run([])
 
@@ -189,7 +202,7 @@ def test_run_permite_override_explicito_en_ci_y_muestra_mensaje(monkeypatch):
 
 def test_registrar_advertencia_seguridad_emite_msg_estructurado():
     app = CliApplication()
-    with patch("cobra.cli.cli.logging.getLogger") as mock_get_logger:
+    with patch("pcobra.cobra.cli.cli.logging.getLogger") as mock_get_logger:
         logger = mock_get_logger.return_value
         app._registrar_advertencia_seguridad(
             event="unsafe_mode",
@@ -232,10 +245,10 @@ def test_handle_execution_error_usuario_esperado_no_muestra_traceback_en_modo_no
     app = CliApplication()
     exc = RuntimeError("usar_error[conflicto_simbolo]: detalle técnico")
 
-    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.getLogger"
+    with patch("pcobra.cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "pcobra.cobra.cli.cli.logging.getLogger"
     ) as mock_get_logger, patch(
-        "cobra.cli.cli.format_traceback", return_value="Traceback técnico"
+        "pcobra.cobra.cli.cli.format_traceback", return_value="Traceback técnico"
     ) as mock_tb:
         result = app._handle_execution_error(exc, "es", debug_activo=False)
 
@@ -250,12 +263,12 @@ def test_handle_execution_error_debug_si_muestra_traceback_en_logs():
     app = CliApplication()
     exc = RuntimeError("usar_error[modulo_fuera_catalogo_publico]: numpy")
 
-    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
-        "cobra.cli.cli.logging.exception"
+    with patch("pcobra.cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "pcobra.cobra.cli.cli.logging.exception"
     ) as mock_exception, patch(
-        "cobra.cli.cli.logging.getLogger"
+        "pcobra.cobra.cli.cli.logging.getLogger"
     ) as mock_get_logger, patch(
-        "cobra.cli.cli.format_traceback", return_value="Traceback detallado"
+        "pcobra.cobra.cli.cli.format_traceback", return_value="Traceback detallado"
     ):
         result = app._handle_execution_error(exc, "es", debug_activo=True)
 

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -1,6 +1,8 @@
 from contextlib import redirect_stderr, redirect_stdout
+import importlib
 from io import StringIO
 from pathlib import Path
+import sys
 from argparse import Namespace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -17,6 +19,24 @@ from pcobra.cobra.cli.execution_pipeline import (
 )
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.core.runtime import InterpretadorCobra
+
+
+_EXECUTE_MODULE = importlib.import_module(ExecuteCommand.__module__)
+_INTERACTIVE_MODULE = importlib.import_module(InteractiveCommand.__module__)
+_RUN_SERVICE_MODULE = importlib.import_module(
+    "pcobra.cobra.cli.services.run_service"
+)
+
+
+@pytest.fixture(autouse=True)
+def _restaurar_modulos_comando_canonicos(monkeypatch):
+    commands_package = importlib.import_module("pcobra.cobra.cli.commands")
+    monkeypatch.setitem(sys.modules, _EXECUTE_MODULE.__name__, _EXECUTE_MODULE)
+    monkeypatch.setitem(sys.modules, _INTERACTIVE_MODULE.__name__, _INTERACTIVE_MODULE)
+    monkeypatch.setattr(commands_package, "execute_cmd", _EXECUTE_MODULE, raising=False)
+    monkeypatch.setattr(
+        commands_package, "interactive_cmd", _INTERACTIVE_MODULE, raising=False
+    )
 
 
 def _args_execute(archivo: str) -> Namespace:
@@ -63,10 +83,10 @@ def _run_execute_via_script(
     variable_persistente: str,
 ) -> dict[str, object]:
     monkeypatch.setattr(
-        "pcobra.cobra.cli.commands.execute_cmd.validar_dependencias", lambda *_args, **_kwargs: None
+        _EXECUTE_MODULE, "validar_dependencias", lambda *_args, **_kwargs: None
     )
     monkeypatch.setattr(
-        "pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_args, **_kwargs: None
+        _RUN_SERVICE_MODULE, "limitar_cpu_segundos", lambda *_args, **_kwargs: None
     )
     codigo = "\n".join(
         [linea for linea in [prelude, snippet, f"var __probe = {variable_persistente}"] if linea]
@@ -516,7 +536,7 @@ def test_repl_ejecuta_bloque_completo_sin_parseo_parcial_por_linea():
     inputs = ["si verdadero:", "imprimir(1)", "fin", "salir"]
     cmd = InteractiveCommand(MagicMock())
 
-    with patch("pcobra.cobra.cli.commands.interactive_cmd.validar_dependencias"), patch(
+    with patch.object(_INTERACTIVE_MODULE, "validar_dependencias"), patch(
         "prompt_toolkit.PromptSession.prompt", side_effect=inputs
     ), patch.object(
         cmd,


### PR DESCRIPTION
### Motivation

- The codebase introduces a `pcobra` package layout and a legacy CLI shim, so tests must reference the new import paths and entrypoint behavior.
- Tests that previously imported `cobra.cli.cli` directly need to invoke the legacy CLI entrypoint or import the canonical module to avoid import mismatches during subprocess-based tests.

### Description

- Updated test imports to use `pcobra` variants and to load modules with `importlib.import_module` where needed, replacing direct `cobra.cli.cli` references with `pcobra.cobra.cli.cli` and using `CliApplication` from that module. 
- Added fixtures that restore canonical command modules in `sys.modules` during tests and updated monkeypatch targets to patch actual module objects instead of string paths. 
- Changed the subprocess-based CLI invocation to run a short `-c` wrapper that calls `build_legacy_cli_shim_main('cli.cli')` so tests execute the legacy CLI shim instead of `-m pcobra.cli`. 
- Simplified test stubs by removing several `prompt_toolkit` stub files and adjusted dependency stubbing to patch functions on imported module objects (e.g. `validar_dependencias` and `limitar_cpu_segundos`).

### Testing

- Ran the unit test suite with `pytest tests/unit -q` after changes and the updated tests completed successfully. 
- Executed modified CLI-related tests that exercise subprocess invocation and error message behavior and they passed under the updated shim-based invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cab0390c883278efe821579d393aa)