### PR TITLE
Actualizar resumen_conversacion.json: documentar migración a Flet 0.86 y hallazgos asociados

### DIFF
--- a/resumen_conversacion.json
+++ b/resumen_conversacion.json
@@ -1,139 +1,225 @@
 {
-  "archivo": "resumen_conversacion.json",
+  "archivo_sugerido": "resumen_conversacion.json",
+  "fecha_contexto": "2026-07-20",
   "proyecto": {
     "nombre": "pCobra",
-    "lenguaje": "Cobra",
     "repositorio_local": "C:/Users/Adolfo/PycharmProjects/pCobra",
-    "rama_principal": "master",
-    "interfaz": "IDLE gráfico basado en Flet",
-    "version_flet_validada": "0.28.3"
+    "repositorio_remoto": "https://github.com/Alphonsus411/pCobra.git",
+    "rama_actual": "feat/flet-0.86-editor",
+    "rama_principal": "master"
   },
-  "objetivo_inicial": "Comenzar un proyecto conjunto en Cobra y limpiar los proyectos existentes desde el IDLE.",
-  "hallazgo_principal": {
-    "tipo": "Fallo de interfaz y seguridad en una operación destructiva",
-    "accion_afectada": "Eliminar proyecto",
-    "comportamiento_observado": "El IDLE solicitaba escribir el nombre exacto del proyecto, pero no mostraba un campo de confirmación claro y la eliminación no reaccionaba como esperaba el usuario.",
-    "causa_raiz": [
-      "El handler eliminar_proyecto_handler leía la confirmación desde ruta_input.value.",
-      "El campo Ruta estaba diseñado para abrir archivos y usar Guardar como, no para confirmar eliminaciones.",
-      "La confirmación destructiva dependía de forma oculta de un control no relacionado.",
-      "La primera implementación del diálogo utilizó page.dialog y dialog.open.",
-      "Flet 0.28.3 no expone Page.dialog y requiere Page.open(control) y Page.close(control).",
-      "El fake de Flet de las pruebas no reproducía inicialmente la API real de Flet 0.28.3."
-    ]
+  "preferencias_del_usuario": {
+    "idioma": "español",
+    "nombre_usuario": "Adolfo",
+    "asistente": "Bella",
+    "formato_de_trabajo": "Presentar como máximo tres comandos o pruebas por respuesta para evitar sobrecarga.",
+    "estilo": "Técnico, claro, cercano y estructurado."
   },
-  "archivos_localizados": {
-    "handler_gui": "src/pcobra/gui/idle.py",
-    "runtime_eliminacion": "src/pcobra/gui/runtime.py",
-    "pruebas_gui": "tests/unit/test_gui_idle.py",
-    "pruebas_seguridad_runtime": "tests/gui/test_runtime_delete_safe.py"
-  },
-  "comportamiento_anterior": {
-    "fuente_confirmacion": "ruta_input.value",
-    "mensaje": "Para eliminar este proyecto escribe su nombre exacto: <nombre>",
-    "problema_ux": "La interfaz no indicaba que el nombre debía introducirse en el campo Ruta.",
-    "riesgo": "Una operación destructiva reutilizaba silenciosamente un campo de propósito distinto."
-  },
-  "solucion_implementada": {
-    "interfaz": [
-      "Se añadió un AlertDialog modal específico para eliminar proyectos.",
-      "El diálogo muestra la ruta completa del proyecto.",
-      "El diálogo incluye un campo llamado Nombre exacto del proyecto.",
-      "Se añadieron los botones Cancelar y Eliminar definitivamente.",
-      "Un nombre incorrecto conserva el proyecto y mantiene abierto el diálogo.",
-      "El nombre exacto ejecuta la eliminación, cierra el diálogo y devuelve el IDLE al workspace."
+  "incidencia_nodo_para": {
+    "estado": "resuelta, validada, fusionada y publicada",
+    "problema_original": "El parser generaba NodoPara, pero el intérprete producía: Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoPara'>.",
+    "rama": "fix/interpreter-nodo-para",
+    "commit_correccion": {
+      "hash": "3e988828",
+      "mensaje": "fix(runtime): ejecutar bucles para en el intérprete"
+    },
+    "commit_merge": {
+      "hash": "ee86154d",
+      "mensaje": "merge: soportar bucles para en el intérprete"
+    },
+    "cambios": [
+      "Se importó NodoPara en src/pcobra/core/interpreter.py.",
+      "Se añadió NodoPara al despachador del intérprete.",
+      "Se implementó ejecutar_para.",
+      "Se materializa el iterable antes de recorrerlo.",
+      "Se valida que el valor sea iterable.",
+      "La variable del bucle se declara o actualiza según el entorno.",
+      "Se implementó soporte de romper y continuar.",
+      "Se añadieron pruebas unitarias y una prueba de ejecución GUI."
     ],
-    "integracion_flet": [
-      "El diálogo se abre mediante page.open(dialog).",
-      "El diálogo se cierra mediante page.close(dialog).",
-      "La implementación fue validada con Flet 0.28.3."
+    "archivos_modificados": [
+      "src/pcobra/core/interpreter.py",
+      "tests/gui/test_gui_runtime_execution_scope.py",
+      "tests/unit/test_interpreter_para.py"
     ],
-    "seguridad": [
-      "Se mantiene runtime.eliminar_proyecto_validado.",
-      "No se permite eliminar la raíz completa del workspace.",
-      "El proyecto debe ser hijo directo del workspace.",
-      "La ruta debe existir y ser un directorio.",
-      "La confirmación exige coincidencia exacta del nombre."
-    ],
-    "pruebas": [
-      "Se añadió AlertDialog al fake de Flet.",
-      "El fake Page implementa open(control) y close(control).",
-      "Las pruebas validan que el diálogo se abre.",
-      "Las pruebas validan el rechazo de un nombre incorrecto.",
-      "Las pruebas validan la eliminación con el nombre exacto.",
-      "Las pruebas validan que el diálogo se cierra tras la eliminación."
-    ]
-  },
-  "validacion_manual": {
-    "proyecto_prueba": "prueba_borrado",
-    "resultado": "correcto",
-    "dialogo_visible": true,
-    "eliminacion_exitosa": true,
-    "retorno_al_workspace": true
-  },
-  "validacion_automatica": {
-    "pruebas_focalizadas_eliminacion": {
-      "resultado": "3 passed",
-      "comando": "pytest -q tests/unit/test_gui_idle.py -k 'eliminar_proyecto'"
+    "validacion_automatica": {
+      "resultado": "28 passed, 1 warning",
+      "codigo_salida": 0,
+      "warning": "Advertencia no relacionada de Hypothesis sobre norecursedirs."
     },
-    "pruebas_seguridad_runtime": {
-      "resultado": "11 passed",
-      "comando": "pytest -q tests/gui/test_runtime_delete_safe.py"
+    "validacion_manual": {
+      "codigo": "para valor en [1, 2, 3]:\n    imprimir(valor)\nfin",
+      "salida": [
+        "1",
+        "2",
+        "3"
+      ],
+      "resultado": "correcto"
     },
-    "validacion_conjunta_final": {
-      "resultado": "52 passed, 1 warning",
-      "comando": "pytest -q tests/unit/test_gui_idle.py tests/gui/test_runtime_delete_safe.py"
-    },
-    "diff_check": "limpio",
-    "warning_no_relacionado": "Hypothesis informó que se omitía la colección del directorio .hypothesis por la configuración norecursedirs."
-  },
-  "control_versiones": {
-    "rama_trabajo": "fix/idle-eliminar-proyecto-confirmacion",
-    "commit_funcional": {
-      "hash": "6e853cf5",
-      "mensaje": "fix(gui): usar diálogo seguro al eliminar proyectos"
-    },
-    "merge": {
-      "hash": "b5f1f542",
-      "mensaje": "merge: corregir confirmación al eliminar proyectos",
-      "estrategia": "ort",
-      "conflictos": false
-    },
-    "estado_final": {
-      "rama_actual": "master",
-      "master_local": "b5f1f542",
-      "origin_master": "b5f1f542",
-      "sincronizado": true
+    "sincronizacion": {
+      "master_local": "ee86154d",
+      "origin_master": "ee86154d",
+      "estado": "sincronizados"
     }
   },
-  "estadisticas_del_cambio": {
-    "archivos_modificados": 2,
-    "archivos": [
-      "src/pcobra/gui/idle.py",
-      "tests/unit/test_gui_idle.py"
-    ],
-    "lineas_insertadas": 152,
-    "lineas_eliminadas": 31
+  "incidencia_tabulador": {
+    "estado": "abierta",
+    "problema": "La tecla Tab no introduce indentación en la superficie de escritura del IDLE.",
+    "superficie_actual": {
+      "archivo": "src/pcobra/gui/idle.py",
+      "creacion": "entrada = runtime.crear_editor_codigo(ft)",
+      "implementacion": "src/pcobra/gui/runtime.py",
+      "control": "ft.TextField",
+      "opciones": {
+        "multiline": true,
+        "expand": true
+      }
+    },
+    "hallazgos_en_flet_0_28_3": {
+      "version": "0.28.3",
+      "TextField_selection": false,
+      "TextField_cursor_position": false,
+      "TextField_on_selection_change": false,
+      "TextField_on_key_down": false,
+      "TextField_on_keyboard_event": false,
+      "Page_on_keyboard_event": true,
+      "KeyboardListener": false,
+      "CodeEditor": false,
+      "conclusion": "Page puede detectar Tab, pero TextField no permite conocer ni modificar la posición del cursor o la selección. Un parche correcto de indentación no es viable con esa API."
+    },
+    "investigacion_interna": {
+      "TextSelection": "Existe, pero se usa en controles de texto seleccionable y no proporciona edición de TextField.",
+      "invoke_method": "Existe como transporte genérico, pero no se encontraron métodos cliente de TextField para obtener selección, mover cursor o insertar texto.",
+      "controles_personalizados_en_repositorio": "No se encontró infraestructura existente.",
+      "conclusion": "La solución correcta es migrar Flet y usar un editor especializado, en lugar de aplicar un parche privado y frágil."
+    }
   },
-  "decisiones_tecnicas": [
-    "No usar el editor de código como entrada de confirmación.",
-    "No reutilizar el campo Ruta para una acción destructiva.",
-    "Usar un diálogo modal dedicado.",
-    "Mantener la eliminación física dentro de la capa runtime.",
-    "Alinear los dobles de prueba con la API real de Flet.",
-    "Validar tanto el comportamiento automatizado como la interfaz real."
+  "migracion_flet": {
+    "rama": "feat/flet-0.86-editor",
+    "objetivo": "Actualizar Flet y reemplazar la superficie de escritura por un editor con soporte real de selección, cursor e indentación con Tab.",
+    "linea_base_antes_de_actualizar": {
+      "suite": [
+        "tests/unit/test_gui_idle.py",
+        "tests/gui",
+        "tests/unit/test_cli_gui.py",
+        "tests/unit/test_cli_gui_without_flet.py"
+      ],
+      "resultado": "140 passed, 1 warning",
+      "codigo_salida": 0,
+      "duracion": "1.65s"
+    },
+    "paquetes_instalados": {
+      "flet": "0.86.1",
+      "flet-code-editor": "0.86.1",
+      "flet-desktop": "0.86.1",
+      "msgpack": "1.2.1"
+    },
+    "conflictos_actuales_de_dependencias": [
+      {
+        "paquete": "agix 1.9.0",
+        "restriccion": "flet>=0.28,<0.29",
+        "conflicto": "Flet instalado es 0.86.1."
+      },
+      {
+        "paquete": "pcobra 10.1.1",
+        "restriccion": "flet>=0.28.3,!=0.29.*,<0.86",
+        "conflicto": "Flet instalado es 0.86.1."
+      }
+    ],
+    "conflicto_resuelto": {
+      "paquete": "flet-desktop",
+      "version_anterior": "0.28.3",
+      "version_actual": "0.86.1"
+    },
+    "agix": {
+      "version_instalada": "1.9.0",
+      "ultima_version_disponible": "1.9.0",
+      "uso_real_en_pcobra": [
+        "src/pcobra/cobra/cli/commands/agix_cmd.py",
+        "src/pcobra/ia/analizador_agix.py",
+        "tests/integration/test_agix_reasoner.py",
+        "tests/unit/test_analizador_agix.py",
+        "tests/unit/test_cli_agix.py",
+        "tests/unit/test_cli_agix_missing_dep.py"
+      ],
+      "observacion": "El código describe AGIX como dependencia opcional, pero pyproject.toml todavía lo declara como dependencia obligatoria.",
+      "decision_provisional": "Mover AGIX a un extra opcional, por ejemplo pcobra[ai], para desacoplarlo de la GUI basada en Flet 0.86.1."
+    }
+  },
+  "estado_de_pyproject": {
+    "version_proyecto": "10.1.1",
+    "python": ">=3.11",
+    "dependencia_agix_actual": "agix>=1.9.0,<2",
+    "dependencia_flet_actual": "flet>=0.28.3,!=0.29.*,<0.86",
+    "cambios_propuestos_no_confirmados": [
+      "Eliminar agix de project.dependencies.",
+      "Añadir ai = [\"agix>=1.9.0,<2\"] en project.optional-dependencies.",
+      "Cambiar Flet a flet[desktop]==0.86.1.",
+      "Añadir flet-code-editor==0.86.1.",
+      "Regenerar requirements.txt, requirements-dev.txt y docs/requirements.txt después de estabilizar la migración."
+    ]
+  },
+  "estado_actual_confirmado": {
+    "rama": "feat/flet-0.86-editor",
+    "flet_instalado": "0.86.1",
+    "flet_code_editor_instalado": "0.86.1",
+    "flet_desktop_instalado": "0.86.1",
+    "agix_instalado": "1.9.0",
+    "pip_check": [
+      "agix 1.9.0 es incompatible con Flet 0.86.1.",
+      "Los metadatos instalados de pcobra 10.1.1 todavía restringen Flet a una versión menor que 0.86."
+    ],
+    "cambios_git_de_la_migracion": "No se ha confirmado todavía ningún cambio de código ni commit en esta rama.",
+    "suite_gui_despues_de_actualizar": "Todavía no ejecutada, porque primero se estaba resolviendo la coherencia de dependencias."
+  },
+  "siguiente_secuencia_recomendada": [
+    {
+      "paso": 1,
+      "accion": "Modificar pyproject.toml para actualizar Flet, añadir flet-code-editor y mover AGIX al extra opcional ai."
+    },
+    {
+      "paso": 2,
+      "accion": "Desinstalar AGIX del entorno GUI principal, reinstalar pCobra en modo editable y ejecutar pip check."
+    },
+    {
+      "paso": 3,
+      "accion": "Ejecutar la suite GUI para obtener el mapa real de incompatibilidades con Flet 0.86.1."
+    }
   ],
-  "errores_de_diagnostico_corregidos": [
-    "Inicialmente se indicó erróneamente que el nombre debía escribirse en el editor central.",
-    "Después se detectó que el código realmente leía el campo Ruta.",
-    "La primera versión del parche usó page.dialog, incompatible con Flet 0.28.3.",
-    "La incompatibilidad se corrigió tras inspeccionar Page.open y Page.close."
+  "comandos_propuestos_anteriormente_pero_no_confirmados": {
+    "actualizar_pyproject": "Editar pyproject.toml para sustituir la restricción antigua de Flet, añadir flet-code-editor y mover AGIX a project.optional-dependencies.ai.",
+    "limpiar_entorno": "python -m pip uninstall -y agix && python -m pip install -e . && python -m pip check",
+    "medir_migracion": "python -m pytest -q tests/unit/test_gui_idle.py tests/gui tests/unit/test_cli_gui.py tests/unit/test_cli_gui_without_flet.py --tb=short"
+  },
+  "riesgos_y_precauciones": [
+    "No asumir que CodeEditor gestiona Tab exactamente como se necesita hasta validarlo manualmente.",
+    "No mezclar la migración de Flet con incidencias antiguas no relacionadas.",
+    "No reinstalar pcobra[ai] junto con Flet 0.86.1 mientras AGIX mantenga su restricción flet<0.29.",
+    "Mantener commits separados para dependencias, adaptación de API y sustitución del editor.",
+    "Actualizar los archivos de requisitos bloqueados solo después de estabilizar pyproject.toml."
   ],
-  "resultado_final": "El fallo de eliminación de proyectos quedó reproducido, diagnosticado, corregido, probado, validado manualmente, integrado en master y sincronizado con origin/master.",
-  "posibles_siguientes_tareas": [
-    "Auditar los diálogos de empaquetado que todavía usan page.dialog y dialog.open.",
-    "Eliminar la rama de trabajo local y remota después de confirmar que el CI de master está verde.",
-    "Revisar la duplicación visual del botón Eliminar proyecto.",
-    "Continuar con el proyecto conjunto en Cobra desde un workspace limpio."
+  "incidencias_independientes_detectadas": [
+    {
+      "archivo": "tests/unit/test_parser_consistencia_ast.py",
+      "problema": "Usa la sintaxis antigua para i in x.",
+      "sintaxis_actual": "para i en x"
+    },
+    {
+      "archivo": "tests/unit/test_romper_continuar.py",
+      "problema": "Contiene expectativas antiguas de parser y transpiladores."
+    },
+    {
+      "suite": "tests/unit/test_interpreter.py",
+      "problema": "Existen fallos previos no relacionados con NodoPara."
+    },
+    {
+      "problema": "Hay una duplicación histórica potencial entre imports core.interpreter y pcobra.core.interpreter.",
+      "decision": "No mezclar esta incidencia con la migración actual."
+    }
+  ],
+  "plan_de_commits_sugerido": [
+    "chore(deps): actualizar Flet y desacoplar AGIX",
+    "refactor(gui): adaptar wrappers y pruebas a Flet 0.86.1",
+    "feat(gui): usar CodeEditor y soportar indentación con Tab"
   ]
 }


### PR DESCRIPTION
### Motivation
- Registrar de forma estructurada el estado del proyecto y las investigaciones realizadas para la migración a Flet 0.86, dependencias y hallazgos relacionados con el intérprete y la GUI. 
- Conservar un histórico claro de incidencias y recomendaciones antes de modificar código o dependencias críticas. 

### Description
- Se renombró y reestructuró el contenido del archivo `resumen_conversacion.json`, añadiendo campos de metadatos del proyecto, estado de ramas y secciones detalladas sobre la migración a Flet 0.86, conflictos de dependencias y propuestas de pasos siguientes. 
- Se añadieron secciones que documentan incidencias específicas reproducidas y resueltas (`incidencia_nodo_para`) y una investigación abierta sobre el comportamiento de Tab en el editor (`incidencia_tabulador`). 
- Se incluyeron recomendaciones técnicas y un plan de commits sugerido para separar cambios de dependencias, adaptaciones de API y la sustitución del editor por `CodeEditor`. 
- Se documentaron propuestas de cambios en `pyproject.toml` y el inventario de paquetes/compatibilidades detectadas (p. ej. conflicto entre AGIX y Flet 0.86). 

### Testing
- No se ejecutaron pruebas automatizadas nuevas como parte de esta modificación del archivo JSON; la actualización es puramente documental. 
- Se realizó una inspección del árbol de trabajo y comparación contra la rama principal recuperada para confirmar que no hay cambios de código en `pyproject.toml`, `src/pcobra/ia/`, componentes GUI/Flet ni en las pruebas AGIX como consecuencia de esta edición. 
- El archivo actualizado contiene referencias a ejecuciones de pruebas previas (por ejemplo, mensajes de "28 passed, 1 warning" o suites pre-migración), pero esos resultados no fueron re-ejecutados ni verificados durante este cambio documental. 
- Se verificó explícitamente que no se modificaron archivos de Lexer ni Parser en esta diferencia.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f49aa86e88327bbb6ef7d8d2ef7ed)