### PR TITLE
fix(deps): alinear AGIX 1.11 con Flet 0.86

### DIFF
--- a/docs/compatibility/agix_1_11_0.md
+++ b/docs/compatibility/agix_1_11_0.md
@@ -1,0 +1,82 @@
+# Auditoría de compatibilidad de AGIX 1.11.0
+
+Fecha de consulta: 21 de julio de 2026.
+
+## Versiones publicadas y decisión
+
+Se consultó el índice JSON de PyPI (`/pypi/agix/json`) y el JSON específico de
+cada versión. Entre las versiones publicadas posteriores a `1.9.0`, PyPI solo
+enumera `1.11.0` (wheel universal y sdist); no existe una publicación `1.10.x`
+en el índice. Ambos artefactos de `1.11.0` declaran `Requires-Python: >=3.10`.
+
+`1.9.0` exigía `flet>=0.28,<0.29`. La primera versión posterior, `1.11.0`,
+corrige esa restricción y exige `flet~=0.86.1`, que equivale a
+`>=0.86.1,<0.87`. Por ello pCobra adopta `agix>=1.11.0,<1.12`: el mínimo es la
+primera corrección comprobada y el máximo impide incorporar una futura serie
+menor cuya API y metadatos todavía no se han auditado.
+
+## Metadatos de distribución de 1.11.0
+
+Las dependencias obligatorias declaradas en el wheel son:
+
+| Dependencia | `Requires-Dist` |
+|---|---|
+| NumPy | `numpy>=2.2.6,<2.3` |
+| SciPy | `scipy>=1.15.3,<1.16` |
+| Matplotlib | `matplotlib>=3.10.9,<3.11` |
+| NetworkX | `networkx>=3.4.2,<3.5` |
+| Requests | `requests>=2.34.2,<3.0` |
+| FastAPI | `fastapi>=0.139.2,<0.140` |
+| Starlette | `starlette>=1.3.1,<1.4` |
+| Pydantic | `pydantic>=2.13.4,<3.0` |
+| HTTPX | `httpx>=0.28.1,<0.29` |
+| Uvicorn | `uvicorn>=0.51,<0.52` |
+| Flet | `flet~=0.86.1` (`>=0.86.1,<0.87`) |
+
+También declara dependencias condicionadas por extras: `scikit-learn>=1.7.2,<1.8`
+(`ml`), `pandas>=2.3.3,<2.4` (`data`), `torch>=2.13,<2.14` (`neuro`),
+`jax>=0.6.2,<0.7` (`neuro-jax`), `scikit-fuzzy>=0.5,<0.6` (`fuzzy`) y
+`nashpy>=0.0.43,<0.1` (`game-theory`). Los extras de desarrollo declaran
+FastAPI y HTTPX con los rangos anteriores, `pytest>=9.1.1,<10` y
+`pytest-cov>=7.1,<8` para `test`, y `ruff>=0.15.22,<0.16` y
+`mypy>=2.3,<2.4` para `dev`.
+
+Los rangos directos de pCobra para NumPy, SciPy y Flet se sincronizaron con
+estos metadatos. Pydantic no necesita una restricción directa: AGIX lo instala
+como dependencia transitiva con el rango indicado.
+
+## Superficie pública usada por pCobra
+
+La comparación directa de los módulos públicos del wheel de `1.11.0` con los
+de `1.9.0` no mostró cambios en los dos archivos relevantes. La integración de
+`src/pcobra/ia/analizador_agix.py` continúa siendo compatible y usa esta
+superficie, toda ella **síncrona**:
+
+* `Reasoner() -> None`: constructor sin argumentos; inicializa internamente un
+  `PADState()` neutro. Pasar argumentos produce el `TypeError` normal de Python.
+* `PADState(placer: float = 0.0, activacion: float = 0.0,
+  dominancia: float = 0.0)`: dataclass mutable. El constructor no valida tipos
+  ni limita valores. Su método `clamp(minimo: float = -1.0,
+  maximo: float = 1.0) -> None` modifica el objeto.
+* `Reasoner.modular_por_emocion(pad: PADState) -> None`: guarda la referencia
+  recibida; no valida el tipo, no hace copia y no lanza excepciones propias.
+* `Reasoner.select_best_model(evaluations: List[Dict]) ->
+  Dict[str, Optional[str | float]]`: devuelve exactamente un diccionario con
+  las claves `name`, `accuracy` y `reason`. Para una lista vacía devuelve
+  `{"name": None, "accuracy": 0.0, "reason": "No se proporcionaron modelos
+  para evaluar."}`. Para entradas válidas devuelve el nombre y precisión del
+  candidato elegido y un `reason` multilínea formateado. Primero modula y
+  limita `accuracy` a `[0.0, 1.0]`, ordena por precisión descendente y resuelve
+  empates por `interpretability` descendente. No muta la lista original.
+
+AGIX no define excepciones específicas para estas operaciones. Diccionarios
+mal formados o valores de tipos incompatibles propagan excepciones estándar
+(`KeyError` al formatear campos obligatorios y `TypeError` en operaciones o
+formatos numéricos). Ninguno de esos métodos es coroutine ni devuelve un
+awaitable.
+
+## Reproducción
+
+La auditoría se realizó descargando los wheels sin dependencias, leyendo
+`*.dist-info/METADATA`, comparando `agix/reasoning/basic.py` y
+`agix/emotion/emotion_simulator.py`, e inspeccionando sus firmas y retornos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,14 @@ classifiers = [
 ]
 
 # Política Python >=3.11: dependencias compatibles con el ecosistema actual
-# y con agix>=1.9.0,<2. Evitamos rangos inexistentes o demasiado futuros.
+# y con agix 1.11.x. Esta es la primera serie publicada posterior a 1.9.0
+# compatible con Flet 0.86.1; no admitimos otra serie menor sin auditar su API.
 dependencies = [
-    "numpy>=1.26,<2.2",
-    "scipy>=1.14.1,<1.15",
+    "numpy>=2.2.6,<2.3",
+    "scipy>=1.15.3,<1.16",
     "matplotlib>=3.10,<4",
     "pandas>=3.0.3,<4",
-    "agix>=1.9.0,<2",
+    "agix>=1.11.0,<1.12",
     "chardet>=7.4.3,<8",
     "holobit-sdk>=1.0.8,<2",
     "smooth-criminal>=0.8.0,<1",
@@ -36,7 +37,7 @@ dependencies = [
     "python-dotenv>=1.0,<2",
     "pexpect>=4.9,<5",
     "requests>=2.32,<3",
-    "flet>=0.28.3,!=0.29.*,<0.86",
+    "flet>=0.86.1,<0.87",
     "packaging>=26.2,<27",
     "pybind11>=3.0.4,<4",
     "tree-sitter>=0.25,<0.26",


### PR DESCRIPTION
### Motivation

- Resolver la incompatibilidad detectada entre la serie `agix>=1.9.0` usada por el proyecto y la versión de `flet` requerida por las versiones publicadas posteriores a `1.9.0`.
- Evitar rangos amplios inseguros para `agix` y sincronizar las restricciones directas de `numpy`, `scipy` y `flet` con los metadatos verificados en PyPI.

### Description

- Actualiza `pyproject.toml` para fijar `agix>=1.11.0,<1.12`, y alinea `numpy` a `>=2.2.6,<2.3`, `scipy` a `>=1.15.3,<1.16` y `flet` a `>=0.86.1,<0.87`.
- Añade `docs/compatibility/agix_1_11_0.md` con la auditoría que documenta `Requires-Python`, `Requires-Dist` y la comprobación de la superficie pública usada (`Reasoner`, `PADState`, `modular_por_emocion`, `select_best_model`).
- La auditoría confirma que las firmas relevantes son síncronas, no introducen nuevas excepciones específicas y devuelven el formato documentado (por ejemplo `select_best_model` devuelve `{'name', 'accuracy', 'reason'}` y maneja lista vacía con `name: None`).
- No se modificaron el Lexer, el Parser ni `src/pcobra/ia/analizador_agix.py` y el cambio es únicamente de resolución de dependencias y documentación de compatibilidad.

### Testing

- Ejecutado `python -m pytest tests/unit/test_analizador_agix.py tests/integration/test_agix_reasoner.py -q` y obtuvo `16 passed` (salida: `16 passed, 1 warning`).
- Ejecutado `python -m pip install --dry-run --ignore-installed .` y la resolución fue satisfactoria con `agix-1.11.0` y `flet-0.86.1` sin conflictos de resolución.
- Ejecutado `git diff --check` y `git diff` sobre los archivos de lexer/parser para verificar que no hubo cambios, ambos OK.
- Los cambios quedaron registrados en el commit `795c327` y la nueva documentación quedó en `docs/compatibility/agix_1_11_0.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f4ade2b38832797b7fae282802ed7)