### PR TITLE
Eliminar aliases obsoletos al importar AGIX

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -1,37 +1,11 @@
 """Módulo que analiza código Cobra usando agix y genera sugerencias."""
 
-import sys
-import types
-
 try:
-    import agix
-
-    # El paquete ``agix`` está pensado para importarse como ``src.agix`` en
-    # algunos entornos. Registramos este alias para mantener compatibilidad
-    # sin modificar la librería original.
-    sys.modules.setdefault("src", types.ModuleType("src"))
-    sys.modules["src.agix"] = agix
-
-    # Nuevas dependencias internas en agix>=1.4 requieren mapear otros
-    # submódulos con el prefijo ``src.agix`` para mantener compatibilidad.
-    # Estos ``imports`` pueden fallar si el paquete cambia en versiones
-    # futuras, por lo que se ignoran las excepciones.
-    try:  # pragma: no cover - solo se ejecuta si existen los módulos
-        import agix.memory as _agix_memory
-        import agix.memory.experiential as _agix_memory_experiential
-
-        sys.modules["src.agix.memory"] = _agix_memory
-        sys.modules["src.agix.memory.experiential"] = _agix_memory_experiential
-    except Exception:  # pragma: no cover - alias opcionales
-        pass
-
     from agix.emotion.emotion_simulator import PADState
-
-    # Alias similar para los módulos de simulación emocional.
-    sys.modules["src.agix.emotion.emotion_simulator"] = agix.emotion.emotion_simulator
-
     from agix.reasoning.basic import Reasoner
-except ImportError:  # pragma: no cover - depende de agix instalado
+except ModuleNotFoundError as exc:  # pragma: no cover - depende de agix instalado
+    if exc.name != "agix":
+        raise
     Reasoner = None
     PADState = None
 from typing import List

--- a/tests/integration/test_agix_reasoner.py
+++ b/tests/integration/test_agix_reasoner.py
@@ -1,33 +1,82 @@
-"""Pruebas de integración para ``agix`` y el razonador básico.
+"""Pruebas de integración para ``agix`` y el razonador básico."""
 
-agix>=1.4 importa internamente módulos bajo el prefijo ``src.agix``. Para
-que las pruebas puedan ejecutarse sin modificar la librería original se
-registran alias equivalentes antes de importar :class:`Reasoner`.
-"""
-
-import importlib
+import os
+from pathlib import Path
+import subprocess
 import sys
-import types
+import textwrap
 
 import pytest
 
-agix = pytest.importorskip("agix")
-
-sys.modules.setdefault("src", types.ModuleType("src"))
-sys.modules["src.agix"] = agix
-
-try:  # pragma: no cover - depende de submódulos opcionales
-    sys.modules["src.agix.memory"] = importlib.import_module("agix.memory")
-    sys.modules["src.agix.memory.experiential"] = importlib.import_module(
-        "agix.memory.experiential"
-    )
-    sys.modules["src.agix.emotion.emotion_simulator"] = importlib.import_module(
-        "agix.emotion.emotion_simulator"
-    )
-except Exception:  # pragma: no cover
-    pass
-
+pytest.importorskip("agix")
 from agix.reasoning.basic import Reasoner
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _ejecutar_python(codigo: str) -> subprocess.CompletedProcess[str]:
+    entorno = os.environ.copy()
+    entorno["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(ROOT / "src"), entorno.get("PYTHONPATH")))
+    )
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(codigo)],
+        cwd=ROOT,
+        env=entorno,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_analizador_importa_distribucion_real_sin_aliases_ficticios():
+    resultado = _ejecutar_python(
+        """
+        import sys
+
+        assert "src.agix" not in sys.modules
+        from pcobra.ia import analizador_agix
+
+        assert analizador_agix.Reasoner.__module__ == "agix.reasoning.basic"
+        assert analizador_agix.PADState.__module__ == "agix.emotion.emotion_simulator"
+        assert "src.agix" not in sys.modules
+        """
+    )
+
+    assert resultado.returncode == 0, resultado.stderr
+
+
+def test_analizador_sin_paquete_agix_mantiene_mensaje_estable():
+    resultado = _ejecutar_python(
+        """
+        import importlib.abc
+        import sys
+
+        class BloquearAgix(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "agix" or fullname.startswith("agix."):
+                    raise ModuleNotFoundError(
+                        "No module named 'agix'", name="agix"
+                    )
+                return None
+
+        sys.meta_path.insert(0, BloquearAgix())
+        from pcobra.ia.analizador_agix import (
+            MENSAJE_DEPENDENCIA_AGIX,
+            generar_sugerencias,
+        )
+
+        try:
+            generar_sugerencias("var x = 5")
+        except ImportError as exc:
+            assert str(exc) == MENSAJE_DEPENDENCIA_AGIX
+        else:
+            raise AssertionError("Se esperaba ImportError sin la distribución agix")
+        """
+    )
+
+    assert resultado.returncode == 0, resultado.stderr
 
 
 def test_agix_reasoner_selects_best_model():

--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -49,7 +49,7 @@ def test_import_opcional_sin_agix_muestra_mensaje_claro(monkeypatch):
 
     def bloquear_agix(nombre, *args, **kwargs):
         if nombre == "agix" or nombre.startswith("agix."):
-            raise ImportError("agix bloqueado para la prueba")
+            raise ModuleNotFoundError("No module named 'agix'", name="agix")
         return import_original(nombre, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", bloquear_agix)
@@ -61,6 +61,31 @@ def test_import_opcional_sin_agix_muestra_mensaje_claro(monkeypatch):
             ImportError, match="dependencia opcional 'agix'.*pip install agix"
         ):
             recargado.generar_sugerencias("var x = 5")
+    finally:
+        monkeypatch.setattr(builtins, "__import__", import_original)
+        importlib.reload(analizador_agix)
+
+
+def test_import_agix_no_oculta_fallos_inesperados(monkeypatch):
+    """Un error interno de la distribución conserva su causa original."""
+    import builtins
+    import importlib
+
+    import_original = builtins.__import__
+    fallo_interno = ModuleNotFoundError(
+        "No module named 'dependencia_interna'", name="dependencia_interna"
+    )
+
+    def romper_dependencia_interna(nombre, *args, **kwargs):
+        if nombre == "agix.emotion.emotion_simulator":
+            raise fallo_interno
+        return import_original(nombre, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", romper_dependencia_interna)
+    try:
+        with pytest.raises(ModuleNotFoundError) as capturado:
+            importlib.reload(analizador_agix)
+        assert capturado.value is fallo_interno
     finally:
         monkeypatch.setattr(builtins, "__import__", import_original)
         importlib.reload(analizador_agix)


### PR DESCRIPTION
### Motivation
- Evitar el preinyectado de aliases `src.agix` que ya no son necesarios con las versiones modernas de la distribución `agix`.
- Hacer el manejo de la dependencia opcional más preciso para no ocultar fallos internos de la librería y preservar la causa original cuando ocurra.
- Añadir pruebas que verifiquen la importación real de la distribución y que el mensaje de ayuda siga siendo estable cuando `agix` no esté presente.

### Description
- Elimina el registro de aliases en `sys.modules` y las importaciones auxiliares relacionadas, importando directamente `PADState` y `Reasoner` desde `agix` en `src/pcobra/ia/analizador_agix.py`.
- Cambia el bloque de excepción para detectar únicamente `ModuleNotFoundError` y comprueba que `exc.name == "agix"`; si la excepción no corresponde a `agix` se re-lanza para preservar la causa original.
- Actualiza la prueba de integración `tests/integration/test_agix_reasoner.py` para no preinyectar módulos ficticios y añade dos tests que se ejecutan en procesos aislados: uno que comprueba la importación desde la distribución real y otro que valida el mensaje estable cuando `agix` no existe.
- Ajusta `tests/unit/test_analizador_agix.py` para simular correctamente la ausencia de `agix` con `ModuleNotFoundError` y añade una prueba que confirma que un fallo interno en la dependencia se propaga como la misma excepción.

### Testing
- Se comprobó la distribución `agix` con `python -m pip install --no-deps --upgrade 'agix==1.11.0'` antes de las pruebas.
- Ejecutado `pytest -q tests/integration/test_agix_reasoner.py tests/unit/test_analizador_agix.py` — todas las pruebas dirigidas pasaron (`19 passed`).
- Ejecutado `pytest -q tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_dep.py tests/unit/test_analizador_sugerencias.py` — pruebas relacionadas pasaron (`4 passed`).
- Ejecutado `ruff check src/pcobra/ia/analizador_agix.py tests/integration/test_agix_reasoner.py tests/unit/test_analizador_agix.py` — sin errores.
- `git diff --check` y comprobaciones sobre `lexer`/`parser` confirmaron que no se modificaron archivos de Lexer/Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f4c6c8ce483278a9644ab25be7edb)