### PR TITLE
Ajustar los dobles de pruebas al contrato público de AGIX 1.11

### DIFF
--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -1,6 +1,6 @@
 import pcobra  # garantiza rutas para submódulos
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import create_autospec, patch
 import tomllib
 
 import pytest
@@ -9,22 +9,37 @@ from pcobra.ia import analizador_agix, analizador_sugerencias
 from pcobra.ia.reglas_libro_programacion import construir_candidatos_desde_reglas
 
 
+def _doble_reasoner():
+    """Crea clase e instancia que respetan el contrato público de AGIX 1.11."""
+    clase = create_autospec(analizador_agix.Reasoner, spec_set=True)
+    return clase, clase.return_value
+
+
+def _doble_pad_state():
+    """Crea un constructor limitado a la firma pública de ``PADState``."""
+    return create_autospec(analizador_agix.PADState, spec_set=True)
+
+
 def test_generar_sugerencias_variable_descriptiva():
     """Verifica que se retorne la sugerencia adecuada."""
-    instancia_falsa = MagicMock()
+    reasoner_cls, instancia_falsa = _doble_reasoner()
     instancia_falsa.select_best_model.return_value = {
         "reason": "Usar nombres descriptivos para variables"
     }
-    with patch.object(analizador_agix, "Reasoner", return_value=instancia_falsa):
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         sugerencias = analizador_agix.generar_sugerencias("var x = 5")
+    reasoner_cls.assert_called_once_with()
+    instancia_falsa.select_best_model.assert_called_once()
+    assert isinstance(sugerencias, list)
     assert sugerencias == ["Usar nombres descriptivos para variables"]
 
 
 def test_generar_sugerencias_modulacion_emocional():
-    instancia = MagicMock()
+    reasoner_cls, instancia = _doble_reasoner()
+    pad_mock = _doble_pad_state()
     instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
-    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
-        with patch.object(analizador_agix, "PADState") as pad_mock:
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
+        with patch.object(analizador_agix, "PADState", pad_mock):
             analizador_agix.generar_sugerencias(
                 "var x = 5", placer=0.1, activacion=0.2, dominancia=-0.3
             )
@@ -100,17 +115,16 @@ def test_import_agix_no_oculta_fallos_inesperados(monkeypatch):
     ],
 )
 def test_generar_sugerencias_valores_fuera_de_rango(param, valor):
-    with patch.object(analizador_agix, "Reasoner", MagicMock()):
+    reasoner_cls, _ = _doble_reasoner()
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         with pytest.raises(ValueError, match=rf"{param} debe estar en el rango"):
             analizador_agix.generar_sugerencias("var x = 5", **{param: valor})
 
 
 def test_error_lexico_o_sintactico_impide_sugerencias_aplicables():
     """No se invoca agix si Lexer/Parser rechazan el fragmento."""
-    razonador = MagicMock()
-    with patch.object(
-        analizador_agix, "Reasoner", return_value=razonador
-    ) as razonador_cls:
+    razonador_cls, razonador = _doble_reasoner()
+    with patch.object(analizador_agix, "Reasoner", razonador_cls):
         with pytest.raises(Exception):
             analizador_agix.generar_sugerencias(
                 "funcion saludar(nombre): retornar nombre"
@@ -129,10 +143,8 @@ def test_error_lexico_o_sintactico_impide_sugerencias_aplicables():
 def test_generar_sugerencias_rechaza_codigo_invalido_antes_de_agix(codigo_invalido):
     """Lexer/Parser deben bloquear Agix tanto para errores léxicos como sintácticos."""
 
-    razonador = MagicMock()
-    with patch.object(
-        analizador_agix, "Reasoner", return_value=razonador
-    ) as razonador_cls:
+    razonador_cls, razonador = _doble_reasoner()
+    with patch.object(analizador_agix, "Reasoner", razonador_cls):
         with pytest.raises(Exception):
             analizador_agix.generar_sugerencias(codigo_invalido)
 
@@ -143,14 +155,14 @@ def test_generar_sugerencias_rechaza_codigo_invalido_antes_de_agix(codigo_invali
 def test_generar_sugerencias_codigo_valido_expone_regla_nombres_descriptivos():
     """Un programa Cobra válido puede activar LP-3.1 tras pasar Lexer/Parser."""
 
-    instancia = MagicMock()
+    reasoner_cls, instancia = _doble_reasoner()
     instancia.select_best_model.side_effect = lambda evaluaciones: next(
         ev
         for ev in evaluaciones
         if ev["rule_id"] == "LP-3.1-NOMBRES-DESCRIPTIVOS"
     )
 
-    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         sugerencias = analizador_agix.generar_sugerencias("var x = 5")
 
     assert sugerencias == [
@@ -172,13 +184,13 @@ def test_reglas_libro_programacion_validan_entrada_antes_de_candidatos():
 
 def test_sugerencias_no_inventan_construcciones_fuera_del_parser():
     """Los candidatos salen de reglas validadas y evitan formas no aceptadas."""
-    instancia = MagicMock()
+    reasoner_cls, instancia = _doble_reasoner()
 
     def seleccionar_primero(evaluaciones):
         return evaluaciones[0]
 
     instancia.select_best_model.side_effect = seleccionar_primero
-    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         sugerencias = analizador_agix.generar_sugerencias("var x = 5")
 
     texto = "\n".join(sugerencias)
@@ -190,18 +202,38 @@ def test_sugerencias_no_inventan_construcciones_fuera_del_parser():
 
 
 def test_sugerencia_principal_referencia_regla_interna_trazable():
-    instancia = MagicMock()
+    reasoner_cls, instancia = _doble_reasoner()
 
     def seleccionar_primero(evaluaciones):
         return evaluaciones[0]
 
     instancia.select_best_model.side_effect = seleccionar_primero
-    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         sugerencias = analizador_agix.generar_sugerencias("var x = 5")
 
     assert len(sugerencias) == 1
     assert "[regla: LP-" in sugerencias[0]
     assert "§3." in sugerencias[0]
+
+
+def test_generar_sugerencias_pasa_argumentos_de_seleccion_y_propaga_error_agix():
+    """Los pesos llegan a AGIX y un fallo concreto del motor no se transforma."""
+    reasoner_cls, instancia = _doble_reasoner()
+    error_agix = ValueError("evaluaciones rechazadas por AGIX")
+    instancia.select_best_model.side_effect = error_agix
+
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
+        with pytest.raises(ValueError) as capturado:
+            analizador_agix.generar_sugerencias(
+                "var x = 5", peso_precision=0.5, peso_interpretabilidad=2.0
+            )
+
+    assert capturado.value is error_agix
+    evaluaciones = instancia.select_best_model.call_args.args[0]
+    assert all(0.0 <= evaluacion["accuracy"] <= 0.5 for evaluacion in evaluaciones)
+    assert all(
+        evaluacion["interpretability"] >= 0.0 for evaluacion in evaluaciones
+    )
 
 
 def test_motor_canonico_es_agix_y_no_agi_core():

--- a/tests/unit/test_cli_agix.py
+++ b/tests/unit/test_cli_agix.py
@@ -1,8 +1,14 @@
 from argparse import Namespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import create_autospec, patch
 
+from pcobra.ia import analizador_agix
 from pcobra.cobra.cli import cli as cli_module
 from pcobra.cobra.cli.commands.agix_cmd import AgixCommand
+
+
+def _doble_reasoner():
+    clase = create_autospec(analizador_agix.Reasoner, spec_set=True)
+    return clase, clase.return_value
 
 
 def test_cli_agix_generates_suggestion(tmp_path, capsys):
@@ -17,21 +23,25 @@ def test_cli_agix_generates_suggestion(tmp_path, capsys):
         activacion=None,
         dominancia=None,
     )
-    instancia = MagicMock()
+    reasoner_cls, instancia = _doble_reasoner()
     instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
-    with patch("pcobra.ia.analizador_agix.Reasoner", return_value=instancia):
-        cmd.run(args)
+    with patch("pcobra.ia.analizador_agix.Reasoner", reasoner_cls):
+        resultado = cmd.run(args)
     salida = capsys.readouterr().out.strip()
     assert "Usar nombres descriptivos" in salida
+    assert resultado == 0
+    reasoner_cls.assert_called_once_with()
+    instancia.select_best_model.assert_called_once()
 
 
 def test_cli_agix_pad_values(tmp_path, capsys):
     archivo = tmp_path / "ejemplo.co"
     archivo.write_text("var x = 5")
-    instancia = MagicMock()
+    reasoner_cls, instancia = _doble_reasoner()
+    pad_mock = create_autospec(analizador_agix.PADState, spec_set=True)
     instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
-    with patch("pcobra.ia.analizador_agix.Reasoner", return_value=instancia):
-        with patch("pcobra.ia.analizador_agix.PADState") as pad_mock:
+    with patch("pcobra.ia.analizador_agix.Reasoner", reasoner_cls):
+        with patch("pcobra.ia.analizador_agix.PADState", pad_mock):
             with patch.object(cli_module, "setup_gettext", return_value=lambda s: s):
                 with (
                     patch.object(
@@ -61,3 +71,34 @@ def test_cli_agix_pad_values(tmp_path, capsys):
     assert "Usar nombres descriptivos" in salida
     pad_mock.assert_called_once_with(0.1, 0.2, -0.3)
     instancia.modular_por_emocion.assert_called_once_with(pad_mock.return_value)
+
+
+def test_cli_agix_pasa_argumentos_de_seleccion_y_muestra_error_concreto(
+    tmp_path, capsys
+):
+    archivo = tmp_path / "ejemplo.co"
+    archivo.write_text("var x = 5")
+    args = Namespace(
+        archivo=str(archivo),
+        peso_precision=0.75,
+        peso_interpretabilidad=1.25,
+        placer=None,
+        activacion=None,
+        dominancia=None,
+    )
+    reasoner_cls, instancia = _doble_reasoner()
+    instancia.select_best_model.side_effect = ValueError(
+        "evaluaciones rechazadas por AGIX"
+    )
+
+    with patch("pcobra.ia.analizador_agix.Reasoner", reasoner_cls):
+        resultado = AgixCommand().run(args)
+
+    salida = capsys.readouterr().out
+    assert resultado == 1
+    assert "evaluaciones rechazadas por AGIX" in salida
+    evaluaciones = instancia.select_best_model.call_args.args[0]
+    assert all(0.0 <= evaluacion["accuracy"] <= 0.75 for evaluacion in evaluaciones)
+    assert all(
+        evaluacion["interpretability"] >= 0.0 for evaluacion in evaluaciones
+    )


### PR DESCRIPTION
### Motivation
- Forzar que los dobles en pruebas unitarias respeten la API pública de AGIX 1.11 y evitar mocks demasiado permisivos que oculten incompatibilidades con `Reasoner` y `PADState`.
- Asegurar que la inicialización, los argumentos de selección, la modulación emocional, el tipo de retorno y la propagación de excepciones concretas de AGIX estén cubiertos por las pruebas.
- Mantener la garantía existente de que errores de Lexer/Parser impiden instanciar o invocar el razonador.

### Description
- Reemplacé usos de `MagicMock` por dobles creados con `create_autospec(..., spec_set=True)` y añadí los helpers `_doble_reasoner()` y `_doble_pad_state()` en `tests/unit/test_analizador_agix.py` y `tests/unit/test_cli_agix.py`.
- Añadí aserciones explícitas que verifican `Reasoner()` se inicializa sin argumentos, que `select_best_model` es invocado con evaluaciones ponderadas y que `PADState(...)` es construido y pasado a `modular_por_emocion`.
- Añadí cobertura para la propagación de un `ValueError` lanzado por AGIX y comprobé que la CLI presenta el mensaje y devuelve código de error `1` en ese caso.
- Conservé y endurecí las pruebas que aseguran que fragmentos rechazados por Lexer/Parser no instancian `Reasoner` ni llaman a `select_best_model`.

### Testing
- Verificación de la dependencia y firmas públicas de AGIX con `python -m pip install 'agix>=1.11.0,<1.12'` y comprobación de firmas de `Reasoner`/`select_best_model`/`modular_por_emocion`/`PADState` (OK).
- Ejecutadas las pruebas unitarias con `python -m pytest -q tests/unit/test_analizador_agix.py tests/unit/test_cli_agix.py` (20 passed).
- Ejecutadas pruebas relacionadas con la integración y casos de fichero/depencia con `python -m pytest -q tests/integration/test_agix_reasoner.py tests/unit/test_cli_agix_missing_dep.py tests/unit/test_cli_agix_missing_file.py` (5 passed).
- Ejecutado `python -m ruff check tests/unit/test_analizador_agix.py tests/unit/test_cli_agix.py` y `git diff --check` para verificar formato y diffs (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f4df796f88327a812fa5297d63685)