### PR TITLE
Normaliza el contrato de respuesta de AGIX 1.11

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - depende de agix instala
         raise
     Reasoner = None
     PADState = None
-from typing import List
+from typing import Dict, List, Optional
 
 from pcobra.ia.reglas_libro_programacion import construir_candidatos_desde_reglas
 
@@ -16,6 +16,42 @@ MENSAJE_DEPENDENCIA_AGIX = (
     "La dependencia opcional 'agix' no está instalada o no se pudo importar. "
     "Instálala con 'pip install agix' para activar las sugerencias de IA."
 )
+
+
+class RespuestaAGIXInvalidaError(ValueError):
+    """Indica que AGIX devolvió una respuesta incompatible con su contrato."""
+
+
+def _normalizar_respuesta_agix(
+    respuesta: Dict[str, Optional[str | float]],
+) -> List[str]:
+    """Convierte el resultado documentado por AGIX 1.11 al contrato de Cobra."""
+    try:
+        if not isinstance(respuesta, dict):
+            raise TypeError("la respuesta no es un diccionario")
+
+        faltantes = {"name", "accuracy", "reason"} - respuesta.keys()
+        if faltantes:
+            raise KeyError(", ".join(sorted(faltantes)))
+
+        nombre = respuesta["name"]
+        precision = respuesta["accuracy"]
+        razon = respuesta["reason"]
+        if nombre is not None and not isinstance(nombre, str):
+            raise TypeError("'name' debe ser texto o None")
+        if precision is not None and (
+            isinstance(precision, bool) or not isinstance(precision, (int, float))
+        ):
+            raise TypeError("'accuracy' debe ser un número o None")
+        if not isinstance(razon, str):
+            raise TypeError("'reason' debe ser texto")
+    except (KeyError, TypeError) as exc:
+        raise RespuestaAGIXInvalidaError(
+            "AGIX devolvió una respuesta inválida: faltan campos obligatorios "
+            "o sus tipos no coinciden con el contrato de AGIX 1.11."
+        ) from exc
+
+    return [razon]
 
 
 def generar_sugerencias(
@@ -62,4 +98,4 @@ def generar_sugerencias(
         razonador.modular_por_emocion(pad)
 
     mejor = razonador.select_best_model(evaluaciones)
-    return [mejor["reason"]]
+    return _normalizar_respuesta_agix(mejor)

--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -21,10 +21,12 @@ def _doble_pad_state():
 
 
 def test_generar_sugerencias_variable_descriptiva():
-    """Verifica que se retorne la sugerencia adecuada."""
+    """Normaliza la respuesta real documentada por AGIX 1.11 a ``list[str]``."""
     reasoner_cls, instancia_falsa = _doble_reasoner()
     instancia_falsa.select_best_model.return_value = {
-        "reason": "Usar nombres descriptivos para variables"
+        "name": "nombres descriptivos",
+        "accuracy": 0.9,
+        "reason": "Usar nombres descriptivos para variables",
     }
     with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         sugerencias = analizador_agix.generar_sugerencias("var x = 5")
@@ -34,10 +36,32 @@ def test_generar_sugerencias_variable_descriptiva():
     assert sugerencias == ["Usar nombres descriptivos para variables"]
 
 
+def test_generar_sugerencias_rechaza_respuesta_agix_incompleta():
+    """Una respuesta sin campos obligatorios se traduce sin filtrar el objeto."""
+    reasoner_cls, instancia = _doble_reasoner()
+    instancia.select_best_model.return_value = {
+        "name": "nombres descriptivos",
+        "accuracy": 0.9,
+    }
+
+    with patch.object(analizador_agix, "Reasoner", reasoner_cls):
+        with pytest.raises(
+            analizador_agix.RespuestaAGIXInvalidaError,
+            match="AGIX devolvió una respuesta inválida.*campos obligatorios",
+        ) as capturado:
+            analizador_agix.generar_sugerencias("var x = 5")
+
+    assert isinstance(capturado.value.__cause__, KeyError)
+
+
 def test_generar_sugerencias_modulacion_emocional():
     reasoner_cls, instancia = _doble_reasoner()
     pad_mock = _doble_pad_state()
-    instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
+    instancia.select_best_model.return_value = {
+        "name": "nombres descriptivos",
+        "accuracy": 0.9,
+        "reason": "Usar nombres descriptivos",
+    }
     with patch.object(analizador_agix, "Reasoner", reasoner_cls):
         with patch.object(analizador_agix, "PADState", pad_mock):
             analizador_agix.generar_sugerencias(
@@ -216,8 +240,8 @@ def test_sugerencia_principal_referencia_regla_interna_trazable():
     assert "§3." in sugerencias[0]
 
 
-def test_generar_sugerencias_pasa_argumentos_de_seleccion_y_propaga_error_agix():
-    """Los pesos llegan a AGIX y un fallo concreto del motor no se transforma."""
+def test_generar_sugerencias_pasa_argumentos_y_propaga_excepcion_oficial_agix():
+    """Los pesos llegan a AGIX y ``ValueError`` del motor no se transforma."""
     reasoner_cls, instancia = _doble_reasoner()
     error_agix = ValueError("evaluaciones rechazadas por AGIX")
     instancia.select_best_model.side_effect = error_agix

--- a/tests/unit/test_cli_agix.py
+++ b/tests/unit/test_cli_agix.py
@@ -24,7 +24,11 @@ def test_cli_agix_generates_suggestion(tmp_path, capsys):
         dominancia=None,
     )
     reasoner_cls, instancia = _doble_reasoner()
-    instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
+    instancia.select_best_model.return_value = {
+        "name": "nombres descriptivos",
+        "accuracy": 0.9,
+        "reason": "Usar nombres descriptivos",
+    }
     with patch("pcobra.ia.analizador_agix.Reasoner", reasoner_cls):
         resultado = cmd.run(args)
     salida = capsys.readouterr().out.strip()
@@ -39,7 +43,11 @@ def test_cli_agix_pad_values(tmp_path, capsys):
     archivo.write_text("var x = 5")
     reasoner_cls, instancia = _doble_reasoner()
     pad_mock = create_autospec(analizador_agix.PADState, spec_set=True)
-    instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
+    instancia.select_best_model.return_value = {
+        "name": "nombres descriptivos",
+        "accuracy": 0.9,
+        "reason": "Usar nombres descriptivos",
+    }
     with patch("pcobra.ia.analizador_agix.Reasoner", reasoner_cls):
         with patch("pcobra.ia.analizador_agix.PADState", pad_mock):
             with patch.object(cli_module, "setup_gettext", return_value=lambda s: s):


### PR DESCRIPTION
### Motivation
- Asegurar que las respuestas del motor AGIX (serie 1.11) se traduzcan al contrato público establecido por el proyecto (`list[str]`), validando campos obligatorios y evitando que objetos internos de AGIX lleguen a la fachada de sugerencias, CLI o GUI.

### Description
- Añade la función privada `_normalizar_respuesta_agix(respuesta: Dict[str, Optional[str | float]]) -> List[str]` que valida que la respuesta sea un `dict` con los campos `name`, `accuracy` y `reason`, comprueba tipos y devuelve únicamente `list[str]` con el texto de `reason`.
- Introduce la excepción específica `RespuestaAGIXInvalidaError` con mensaje claro en español y encadenamiento de la causa original (`raise ... from ...`) cuando la respuesta no cumple el contrato.
- Integra la normalización inmediatamente después de `Reasoner.select_best_model` para impedir que diccionarios u objetos de AGIX se propaguen fuera del módulo, manteniendo intactas las excepciones lanzadas por el propio motor (por ejemplo `ValueError`).
- Actualiza pruebas y dobles relevantes para reflejar el retorno documentado de AGIX y añade un caso dirigido que verifica la conversión de una respuesta incompleta a `RespuestaAGIXInvalidaError`, sin modificar Lexer ni Parser.

### Testing
- `pytest -q tests/unit/test_analizador_agix.py` — pasó (18 tests superados).
- `pytest -q tests/unit/test_cli_agix.py tests/unit/test_analizador_sugerencias.py tests/integration/test_agix_reasoner.py` — pasó (7 tests superados).
- `ruff check src/pcobra/ia/analizador_agix.py tests/unit/test_analizador_agix.py tests/unit/test_cli_agix.py` — comprobación de estilo pasada.
- `git diff --check` y verificación explícita de ausencia de cambios en Lexer/Parser — sin problemas detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f548914048327a4bfc1cfd974606c)