### PR TITLE
Clasifica y limita el manejo de errores de AGIX

### DIFF
--- a/src/pcobra/cobra/cli/commands/agix_cmd.py
+++ b/src/pcobra/cobra/cli/commands/agix_cmd.py
@@ -1,15 +1,22 @@
-from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, Optional, NoReturn
+from typing import Any
+from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
-from pcobra.ia.analizador_agix import generar_sugerencias
+from pcobra.ia.analizador_agix import (
+    DependenciaAGIXNoDisponibleError,
+    FalloMotorAGIXError,
+    RespuestaAGIXInvalidaError,
+    generar_sugerencias,
+)
+
 
 class AgixCommand(BaseCommand):
     """Genera sugerencias para código Cobra usando la dependencia opcional agix."""
+
     name = "agix"
 
     def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
@@ -27,24 +34,20 @@ class AgixCommand(BaseCommand):
                 "Analiza un archivo Cobra, sugiere mejoras y permite modulación emocional"
             ),
         )
-        parser.add_argument(
-            "archivo", 
-            help=_("Ruta al archivo a analizar"),
-            type=Path
-        )
+        parser.add_argument("archivo", help=_("Ruta al archivo a analizar"), type=Path)
         parser.add_argument(
             "--peso-precision",
             type=float,
             default=None,
             help=_("Factor de ponderación para la precisión (debe ser positivo)"),
-            metavar="PESO"
+            metavar="PESO",
         )
         parser.add_argument(
             "--peso-interpretabilidad",
             type=float,
             default=None,
             help=_("Factor para la interpretabilidad (debe ser positivo)"),
-            metavar="PESO"
+            metavar="PESO",
         )
         parser.add_argument(
             "--placer",
@@ -124,8 +127,25 @@ class AgixCommand(BaseCommand):
             for sugerencia in sugerencias:
                 mostrar_info(str(sugerencia))
             return 0
-        except Exception as e:
-            mostrar_error(_("Error al generar sugerencias: {error}").format(error=str(e)))
+        except DependenciaAGIXNoDisponibleError as e:
+            mostrar_error(_("AGIX no está disponible: {error}").format(error=str(e)))
+            return 1
+        except RespuestaAGIXInvalidaError as e:
+            mostrar_error(
+                _("AGIX devolvió una respuesta inválida: {error}").format(error=str(e))
+            )
+            return 1
+        except (LexerError, ParserError, ValueError) as e:
+            mostrar_error(
+                _("El código o los parámetros no son válidos: {error}").format(
+                    error=str(e)
+                )
+            )
+            return 1
+        except FalloMotorAGIXError as e:
+            mostrar_error(
+                _("No se pudo ejecutar el motor AGIX: {error}").format(error=str(e))
+            )
             return 1
 
     def _leer_archivo(self, archivo: Path) -> str:
@@ -155,9 +175,13 @@ class AgixCommand(BaseCommand):
             str: Mensaje de error localizado
         """
         if isinstance(error, PermissionError):
-            return _("No hay permisos para leer el archivo '{archivo}'").format(archivo=archivo)
+            return _("No hay permisos para leer el archivo '{archivo}'").format(
+                archivo=archivo
+            )
         elif isinstance(error, UnicodeDecodeError):
-            return _("Error al decodificar el archivo '{archivo}'").format(archivo=archivo)
+            return _("Error al decodificar el archivo '{archivo}'").format(
+                archivo=archivo
+            )
         return _("Error al leer el archivo '{archivo}': {error}").format(
             archivo=archivo, error=str(error)
         )

--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -19,6 +19,18 @@ MENSAJE_DEPENDENCIA_AGIX = (
 )
 
 
+class DependenciaAGIXNoDisponibleError(ImportError):
+    """Indica que la dependencia opcional AGIX no está disponible.
+
+    Hereda de :class:`ImportError` para conservar el contrato histórico de
+    :func:`generar_sugerencias` con sus consumidores.
+    """
+
+
+class FalloMotorAGIXError(RuntimeError):
+    """Indica que AGIX rechazó una invocación válida del analizador."""
+
+
 class RespuestaAGIXInvalidaError(ValueError):
     """Indica que AGIX devolvió una respuesta incompatible con su contrato."""
 
@@ -72,7 +84,7 @@ def generar_sugerencias(
     proporcionan, usando valores en el rango ``[-1.0, 1.0]``.
     """
     if Reasoner is None:
-        raise ImportError(MENSAJE_DEPENDENCIA_AGIX)
+        raise DependenciaAGIXNoDisponibleError(MENSAJE_DEPENDENCIA_AGIX)
 
     # Las reglas internas validan primero la entrada con Lexer/Parser y solo
     # producen candidatos respaldados por fragmentos que el Parser acepta.
@@ -93,10 +105,13 @@ def generar_sugerencias(
         if valor is not None and not -1.0 <= valor <= 1.0:
             raise ValueError(f"{nombre} debe estar en el rango [-1.0, 1.0]")
 
-    razonador = Reasoner()
-    if all(v is not None for v in (placer, activacion, dominancia)):
-        pad = PADState(placer, activacion, dominancia)
-        razonador.modular_por_emocion(pad)
+    try:
+        razonador = Reasoner()
+        if all(v is not None for v in (placer, activacion, dominancia)):
+            pad = PADState(placer, activacion, dominancia)
+            razonador.modular_por_emocion(pad)
 
-    mejor = razonador.select_best_model(evaluaciones)
+        mejor = razonador.select_best_model(evaluaciones)
+    except (RuntimeError, ValueError) as exc:
+        raise FalloMotorAGIXError(f"Falló el motor AGIX: {exc}") from exc
     return _normalizar_respuesta_agix(mejor)

--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -240,19 +240,19 @@ def test_sugerencia_principal_referencia_regla_interna_trazable():
     assert "§3." in sugerencias[0]
 
 
-def test_generar_sugerencias_pasa_argumentos_y_propaga_excepcion_oficial_agix():
-    """Los pesos llegan a AGIX y ``ValueError`` del motor no se transforma."""
+def test_generar_sugerencias_pasa_argumentos_y_clasifica_fallo_oficial_agix():
+    """Los pesos llegan a AGIX y su rechazo se clasifica como fallo del motor."""
     reasoner_cls, instancia = _doble_reasoner()
     error_agix = ValueError("evaluaciones rechazadas por AGIX")
     instancia.select_best_model.side_effect = error_agix
 
     with patch.object(analizador_agix, "Reasoner", reasoner_cls):
-        with pytest.raises(ValueError) as capturado:
+        with pytest.raises(analizador_agix.FalloMotorAGIXError) as capturado:
             analizador_agix.generar_sugerencias(
                 "var x = 5", peso_precision=0.5, peso_interpretabilidad=2.0
             )
 
-    assert capturado.value is error_agix
+    assert capturado.value.__cause__ is error_agix
     evaluaciones = instancia.select_best_model.call_args.args[0]
     assert all(0.0 <= evaluacion["accuracy"] <= 0.5 for evaluacion in evaluaciones)
     assert all(

--- a/tests/unit/test_cli_agix.py
+++ b/tests/unit/test_cli_agix.py
@@ -1,9 +1,12 @@
 from argparse import Namespace
 from unittest.mock import create_autospec, patch
 
+import pytest
+
 from pcobra.ia import analizador_agix
 from pcobra.cobra.cli import cli as cli_module
 from pcobra.cobra.cli.commands.agix_cmd import AgixCommand
+from pcobra.ia.analizador_agix import FalloMotorAGIXError
 
 
 def _doble_reasoner():
@@ -107,6 +110,46 @@ def test_cli_agix_pasa_argumentos_de_seleccion_y_muestra_error_concreto(
     assert "evaluaciones rechazadas por AGIX" in salida
     evaluaciones = instancia.select_best_model.call_args.args[0]
     assert all(0.0 <= evaluacion["accuracy"] <= 0.75 for evaluacion in evaluaciones)
-    assert all(
-        evaluacion["interpretability"] >= 0.0 for evaluacion in evaluaciones
+    assert all(evaluacion["interpretability"] >= 0.0 for evaluacion in evaluaciones)
+
+
+def test_cli_agix_muestra_fallo_previsto_del_motor(tmp_path, capsys):
+    archivo = tmp_path / "ejemplo.co"
+    archivo.write_text("var x = 5")
+    args = Namespace(
+        archivo=str(archivo),
+        peso_precision=None,
+        peso_interpretabilidad=None,
+        placer=None,
+        activacion=None,
+        dominancia=None,
     )
+
+    with patch(
+        "pcobra.cobra.cli.commands.agix_cmd.generar_sugerencias",
+        side_effect=FalloMotorAGIXError("servicio temporalmente ocupado"),
+    ):
+        resultado = AgixCommand().run(args)
+
+    assert resultado == 1
+    assert "No se pudo ejecutar el motor AGIX" in capsys.readouterr().out
+
+
+def test_cli_agix_no_oculta_errores_de_programacion(tmp_path):
+    archivo = tmp_path / "ejemplo.co"
+    archivo.write_text("var x = 5")
+    args = Namespace(
+        archivo=str(archivo),
+        peso_precision=None,
+        peso_interpretabilidad=None,
+        placer=None,
+        activacion=None,
+        dominancia=None,
+    )
+
+    with patch(
+        "pcobra.cobra.cli.commands.agix_cmd.generar_sugerencias",
+        side_effect=TypeError("fallo de programación"),
+    ):
+        with pytest.raises(TypeError, match="fallo de programación"):
+            AgixCommand().run(args)

--- a/tests/unit/test_cli_agix_missing_dep.py
+++ b/tests/unit/test_cli_agix_missing_dep.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 from unittest.mock import patch
 
 from cobra.cli.commands.agix_cmd import AgixCommand
+from pcobra.ia.analizador_agix import DependenciaAGIXNoDisponibleError
 
 
 def test_cli_agix_sin_agix(tmp_path, capsys):
@@ -22,3 +23,24 @@ def test_cli_agix_sin_agix(tmp_path, capsys):
     assert exit_code == 1
     assert "dependencia oficial 'agix'" in salida
     assert "pip install agix" in salida
+
+
+def test_cli_agix_captura_solo_excepcion_especifica_de_dependencia(tmp_path, capsys):
+    archivo = tmp_path / "ejemplo.co"
+    archivo.write_text("var x = 5")
+    args = Namespace(
+        archivo=str(archivo),
+        peso_precision=None,
+        peso_interpretabilidad=None,
+        placer=None,
+        activacion=None,
+        dominancia=None,
+    )
+    with patch(
+        "pcobra.cobra.cli.commands.agix_cmd.generar_sugerencias",
+        side_effect=DependenciaAGIXNoDisponibleError("instala AGIX"),
+    ):
+        exit_code = AgixCommand().run(args)
+
+    assert exit_code == 1
+    assert "AGIX no está disponible: instala AGIX" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Definir excepciones más específicas para distinguir ausencia de la dependencia, fallos del motor AGIX y respuestas inválidas sin romper compatibilidad con consumidores existentes. 
- Evitar que el comando CLI oculte errores de programación al capturar `Exception` de forma indiscriminada. 
- Hacer cambios mínimos y localizados que permitan a tests y desarrolladores distinguir errores previstos de errores de programación. 

### Description
- Añade `DependenciaAGIXNoDisponibleError(ImportError)`, `FalloMotorAGIXError(RuntimeError)` y mantiene `RespuestaAGIXInvalidaError(ValueError)` en `src/pcobra/ia/analizador_agix.py`. 
- `generar_sugerencias` ahora lanza `DependenciaAGIXNoDisponibleError` cuando `Reasoner` no está disponible y captura `RuntimeError`/`ValueError` del motor para envolverlos en `FalloMotorAGIXError` preservando la causa original. 
- Actualiza `src/pcobra/cobra/cli/commands/agix_cmd.py` para capturar solo las excepciones esperadas (`DependenciaAGIXNoDisponibleError`, `RespuestaAGIXInvalidaError`, `LexerError`, `ParserError`, `ValueError`, `FalloMotorAGIXError`) y mostrar mensajes claros en español, dejando que errores inesperados (p. ej. `TypeError`) se propaguen. 
- Añade pruebas que verifican la presentación de fallos previstos y la no ocultación de errores de programación en `tests/unit/test_cli_agix.py` y `tests/unit/test_cli_agix_missing_dep.py`, y adapta una prueba del analizador para esperar `FalloMotorAGIXError` con su `__cause__`. 

### Testing
- `python -m pytest -q tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_dep.py tests/unit/test_analizador_agix.py` — todas las pruebas unitarias relevantes pasaron (`25 passed`).
- `ruff check src/pcobra/ia/analizador_agix.py src/pcobra/cobra/cli/commands/agix_cmd.py tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_dep.py tests/unit/test_analizador_agix.py` — comprobación de estilo exitosa.
- `git diff --check` y comprobación de que no se modificaron archivos de Lexer ni Parser — verificado y sin cambios en `lexer`/`parser`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f57af09488327a28486ca1a10f506)