### PR TITLE
Integrar mejoras de AGIX en master y estabilizar excepciones del adaptador

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -10,6 +10,11 @@ except ModuleNotFoundError as exc:  # pragma: no cover - depende de agix instala
     PADState = None
 from typing import Dict, List, Optional
 
+from pcobra.ia.excepciones_agix import (
+    DependenciaAGIXNoDisponibleError,
+    FalloMotorAGIXError,
+    RespuestaAGIXInvalidaError,
+)
 from pcobra.ia.reglas_libro_programacion import construir_candidatos_desde_reglas
 
 MENSAJE_DEPENDENCIA_AGIX = (
@@ -17,22 +22,6 @@ MENSAJE_DEPENDENCIA_AGIX = (
     "Instala la distribución completa de pcobra o ejecuta 'pip install agix' "
     "para activar las sugerencias de IA."
 )
-
-
-class DependenciaAGIXNoDisponibleError(ImportError):
-    """Indica que la dependencia opcional AGIX no está disponible.
-
-    Hereda de :class:`ImportError` para conservar el contrato histórico de
-    :func:`generar_sugerencias` con sus consumidores.
-    """
-
-
-class FalloMotorAGIXError(RuntimeError):
-    """Indica que AGIX rechazó una invocación válida del analizador."""
-
-
-class RespuestaAGIXInvalidaError(ValueError):
-    """Indica que AGIX devolvió una respuesta incompatible con su contrato."""
 
 
 def _normalizar_respuesta_agix(

--- a/src/pcobra/ia/excepciones_agix.py
+++ b/src/pcobra/ia/excepciones_agix.py
@@ -1,0 +1,13 @@
+"""Excepciones estables del adaptador oficial de AGIX."""
+
+
+class DependenciaAGIXNoDisponibleError(ImportError):
+    """Indica que la dependencia opcional AGIX no está disponible."""
+
+
+class FalloMotorAGIXError(RuntimeError):
+    """Indica que AGIX rechazó una invocación válida del analizador."""
+
+
+class RespuestaAGIXInvalidaError(ValueError):
+    """Indica que AGIX devolvió una respuesta incompatible con su contrato."""


### PR DESCRIPTION
### Motivation
- Integrar las mejoras acumuladas del adaptador AGIX manteniendo compatibilidad con la fachada pública de sugerencias y sin tocar Lexer/Parser. 
- Resolver un fallo detectado en el CLI donde las recargas del analizador rompían la captura de excepciones específicas de AGIX.

### Description
- Añade `src/pcobra/ia/excepciones_agix.py` con las tres excepciones públicas estables: `DependenciaAGIXNoDisponibleError`, `FalloMotorAGIXError` y `RespuestaAGIXInvalidaError`.
- Refactoriza `src/pcobra/ia/analizador_agix.py` para importar esas excepciones desde el nuevo módulo y mantiene la normalización de respuestas de AGIX 1.11, la ponderación de `accuracy`/`interpretability` y la modulación emocional por `PADState`.
- Actualiza `src/pcobra/cobra/cli/commands/agix_cmd.py` para capturar explícitamente las excepciones públicas desde `pcobra.ia.analizador_agix`, preservando el manejo diferenciado de dependencia ausente, respuesta inválida, errores léxicos/sintácticos/parámetros y fallos del motor.
- No se modificaron archivos de Lexer/Parser, ni se añadieron tokens, reglas o sintaxis nuevas; los cambios son mínimos y localizados al adaptador y al CLI.

### Testing
- Ejecutado: `python -m pytest -q tests/unit/test_analizador_agix.py tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_dep.py tests/integration/test_agix_reasoner.py` y la suite relevante resultó en `28 passed` tras la corrección. 
- Ejecutado: `python -m compileall -q src/pcobra/ia src/pcobra/cobra/cli/commands/agix_cmd.py` y la compilación fue correcta. 
- Verificaciones adicionales: `git diff --check` sobre el intervalo afectado y comprobación por nombre de ficheros para asegurar que no se modificaron `lexer`/`parser`, y árbol de trabajo limpio tras la integración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f5a89a27c8327913efb5dfd65131a)