### PR TITLE
Encapsula el editor principal mediante un adaptador

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -145,7 +145,7 @@ def main(page: "ft.Page"):
         estado.ruta = None
         estado.contenido_cargado = ""
         estado.cambios_sin_guardar = False
-        entrada.value = ""
+        entrada.limpiar()
         ruta_input.value = ""
 
     def actualizar_pagina() -> None:
@@ -179,10 +179,10 @@ def main(page: "ft.Page"):
     ruta_input.on_change = ruta_visible_cambiada
 
     def marcar_cambios(_e=None) -> None:
-        runtime.marcar_cambios_editor(estado, entrada.value)
+        runtime.marcar_cambios_editor(estado, entrada.obtener_contenido())
         actualizar_pagina()
 
-    entrada.on_change = marcar_cambios
+    entrada.registrar_callback_cambios(marcar_cambios)
 
     def mostrar_error_archivo(exc: Exception) -> None:
         salida.value = runtime.formatear_error(exc)
@@ -259,13 +259,14 @@ def main(page: "ft.Page"):
     def cargar_archivo(ruta: Path, *, desde_arbol: bool = False) -> None:
         try:
             if desde_arbol:
-                entrada.value, salida.value = runtime.cargar_archivo_desde_arbol(
+                contenido, salida.value = runtime.cargar_archivo_desde_arbol(
                     ruta, estado
                 )
             else:
-                entrada.value, salida.value = runtime.abrir_archivo_desde_ruta_validada(
+                contenido, salida.value = runtime.abrir_archivo_desde_ruta_validada(
                     ruta, estado
                 )
+            entrada.establecer_contenido(contenido)
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -285,7 +286,7 @@ def main(page: "ft.Page"):
     def guardar_en(ruta: Path) -> bool:
         try:
             _contenido, salida.value = runtime.guardar_archivo_como_validado(
-                ruta, entrada.value, estado
+                ruta, entrada.obtener_contenido(), estado
             )
         except (
             FileNotFoundError,
@@ -503,8 +504,7 @@ def main(page: "ft.Page"):
             confirmacion = confirmacion_input.value or ""
             if confirmacion != nombre_proyecto:
                 salida.value = (
-                    "El nombre no coincide. Escribe exactamente: "
-                    f"{nombre_proyecto}"
+                    "El nombre no coincide. Escribe exactamente: " f"{nombre_proyecto}"
                 )
                 page.update()
                 return
@@ -573,7 +573,8 @@ def main(page: "ft.Page"):
         page.open(dialog)
 
     def nuevo_handler(_e):
-        entrada.value, salida.value = runtime.crear_archivo_nuevo_en_editor(estado)
+        contenido, salida.value = runtime.crear_archivo_nuevo_en_editor(estado)
+        entrada.establecer_contenido(contenido)
         actualizar_pagina()
 
     def abrir_handler(_e):
@@ -600,7 +601,7 @@ def main(page: "ft.Page"):
         estado.ruta = ruta_resuelta
         try:
             _contenido, salida.value = runtime.guardar_archivo_activo_validado(
-                entrada.value, estado
+                entrada.obtener_contenido(), estado
             )
         except (
             FileNotFoundError,
@@ -649,9 +650,8 @@ def main(page: "ft.Page"):
             return
         estado.ruta = ruta_resuelta
         try:
-            entrada.value, salida.value = runtime.recargar_archivo_activo_validado(
-                estado
-            )
+            contenido, salida.value = runtime.recargar_archivo_activo_validado(estado)
+            entrada.establecer_contenido(contenido)
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -864,19 +864,23 @@ def main(page: "ft.Page"):
         return False
 
     ejecutar_runtime_handler = runtime.crear_handler_ejecucion(
-        entrada=entrada, salida=salida, selector=selector, activar=activar, page=page
+        leer_codigo=entrada.obtener_contenido,
+        salida=salida,
+        selector=selector,
+        activar=activar,
+        page=page,
     )
     tokens_runtime_handler = runtime.crear_handler_tokens(
-        entrada=entrada, salida=salida, page=page
+        leer_codigo=entrada.obtener_contenido, salida=salida, page=page
     )
     ast_runtime_handler = runtime.crear_handler_ast(
-        entrada=entrada, salida=salida, page=page
+        leer_codigo=entrada.obtener_contenido, salida=salida, page=page
     )
     sugerencias_runtime_handler = runtime.crear_handler_sugerencias(
-        entrada=entrada, salida=salida, page=page
+        leer_codigo=entrada.obtener_contenido, salida=salida, page=page
     )
     correccion_runtime_handler = runtime.crear_handler_correccion_tipografica(
-        entrada=entrada, salida=salida, page=page
+        leer_codigo=entrada.obtener_contenido, salida=salida, page=page
     )
 
     def ejecutar_handler(e):
@@ -1288,7 +1292,7 @@ def main(page: "ft.Page"):
             estado_archivo,
             ruta_input,
             barra_archivo,
-            entrada,
+            entrada.obtener_control(),
             barra_ejecucion,
             salida,
         ],

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -137,9 +137,7 @@ COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".cobra", ".co")
 
 MARKDOWN_FILE_EXTENSIONS: frozenset[str] = frozenset({".md", ".markdown"})
 TEXT_FILE_EXTENSIONS: frozenset[str] = frozenset({".txt"})
-CONFIG_FILE_EXTENSIONS: frozenset[str] = frozenset(
-    {".json", ".yml", ".yaml", ".toml"}
-)
+CONFIG_FILE_EXTENSIONS: frozenset[str] = frozenset({".json", ".yml", ".yaml", ".toml"})
 IGNORE_FILE_NAMES: frozenset[str] = frozenset({".gitignore", ".dockerignore"})
 ENV_EXAMPLE_FILE_NAMES: frozenset[str] = frozenset({".env.example"})
 """Nombres especiales de archivos de entorno de ejemplo."""
@@ -326,7 +324,11 @@ def detectar_tipo_archivo(path: str | Path) -> str:
     nombre_lower = nombre.lower()
     extension = ruta.suffix.lower()
 
-    if nombre == "Dockerfile" or nombre.startswith("Dockerfile.") or nombre == "docker-compose.yml":
+    if (
+        nombre == "Dockerfile"
+        or nombre.startswith("Dockerfile.")
+        or nombre == "docker-compose.yml"
+    ):
         return TIPO_ARCHIVO_DOCKER
     if extension == ".co" and es_paquete_cobra(ruta):
         return TIPO_ARCHIVO_PAQUETE_COBRA
@@ -783,9 +785,7 @@ def eliminar_proyecto_validado(project_root: Path, workspace_root: Path) -> None
     shutil.rmtree(proyecto)
 
 
-def leer_archivo_texto_validado(
-    path: str | Path, *, encoding: str = "utf-8"
-) -> str:
+def leer_archivo_texto_validado(path: str | Path, *, encoding: str = "utf-8") -> str:
     """Lee una ruta ya validada por el IDLE principal."""
 
     origen = Path(path).expanduser().resolve()
@@ -990,12 +990,54 @@ def flet_dropdown_option(ft: Any, value: str) -> Any:
     return option_factory(value)
 
 
-def crear_editor_codigo(ft: Any, **kwargs: Any) -> Any:
-    """Crea el editor de código compartido por la app mínima y el IDLE."""
+class EditorCodigo:
+    """Adapta el control visual usado como editor de código.
+
+    El resto de la GUI depende de estas operaciones y no de los atributos
+    concretos de ``TextField``, lo que permite sustituir el control visual sin
+    propagar detalles de Flet.
+    """
+
+    def __init__(self, control: Any) -> None:
+        self._control = control
+
+    def obtener_contenido(self) -> str:
+        """Devuelve el texto actual del editor, normalizando valores nulos."""
+
+        return normalizar_codigo(self._control.value)
+
+    def establecer_contenido(self, contenido: str | None) -> None:
+        """Reemplaza el texto mostrado por ``contenido``."""
+
+        self._control.value = normalizar_codigo(contenido)
+
+    def limpiar(self) -> None:
+        """Vacía el contenido del editor."""
+
+        self.establecer_contenido("")
+
+    def solicitar_foco(self) -> Any:
+        """Solicita el foco mediante la API del control visual."""
+
+        return self._control.focus()
+
+    def registrar_callback_cambios(self, callback: Any) -> None:
+        """Registra el callback invocado cuando cambia el contenido."""
+
+        self._control.on_change = callback
+
+    def obtener_control(self) -> Any:
+        """Devuelve el control visual que debe incorporarse al layout."""
+
+        return self._control
+
+
+def crear_editor_codigo(ft: Any, **kwargs: Any) -> EditorCodigo:
+    """Crea el adaptador del editor compartido por la app mínima y el IDLE."""
 
     opciones = {"multiline": True, "expand": True}
     opciones.update(kwargs)
-    return flet_text_field(ft, **opciones)
+    return EditorCodigo(flet_text_field(ft, **opciones))
 
 
 def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
@@ -1101,7 +1143,8 @@ def ejecutar_o_transpilar(
 
 def crear_handler_ejecucion(
     *,
-    entrada: Any,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
     salida: Any,
     selector: Any,
     activar: Any,
@@ -1109,9 +1152,11 @@ def crear_handler_ejecucion(
 ) -> Any:
     """Crea el handler compartido de ejecutar/transpilar para app mínima e IDLE."""
 
+    lector = leer_codigo or (lambda: entrada.value)
+
     def ejecutar_handler(_e: Any) -> None:
         deps = require_gui_dependencies()
-        codigo = normalizar_codigo(entrada.value)
+        codigo = normalizar_codigo(lector())
         try:
             salida.value = ejecutar_o_transpilar(
                 codigo,
@@ -1445,13 +1490,21 @@ def generar_reporte_sugerencias(codigo: str) -> str:
     )
 
 
-def crear_handler_tokens(*, entrada: Any, salida: Any, page: Any) -> Any:
+def crear_handler_tokens(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
     """Crea handler compartido para mostrar tokens Cobra."""
+
+    lector = leer_codigo or (lambda: entrada.value)
 
     def tokens_handler(_e: Any) -> None:
         deps = require_gui_dependencies()
         try:
-            salida.value = mostrar_tokens(normalizar_codigo(entrada.value))
+            salida.value = mostrar_tokens(normalizar_codigo(lector()))
         except Exception as exc:
             salida.value = formatear_error(
                 exc,
@@ -1464,13 +1517,21 @@ def crear_handler_tokens(*, entrada: Any, salida: Any, page: Any) -> Any:
     return tokens_handler
 
 
-def crear_handler_ast(*, entrada: Any, salida: Any, page: Any) -> Any:
+def crear_handler_ast(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
     """Crea handler compartido para mostrar el AST Cobra."""
+
+    lector = leer_codigo or (lambda: entrada.value)
 
     def ast_handler(_e: Any) -> None:
         deps = require_gui_dependencies()
         try:
-            salida.value = mostrar_ast(normalizar_codigo(entrada.value))
+            salida.value = mostrar_ast(normalizar_codigo(lector()))
         except Exception as exc:
             salida.value = formatear_error(
                 exc,
@@ -1484,15 +1545,21 @@ def crear_handler_ast(*, entrada: Any, salida: Any, page: Any) -> Any:
 
 
 def crear_handler_correccion_tipografica(
-    *, entrada: Any, salida: Any, page: Any
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
 ) -> Any:
     """Crea handler para corrección tipográfica validada y no destructiva."""
+
+    lector = leer_codigo or (lambda: entrada.value)
 
     def correccion_handler(_e: Any) -> None:
         deps = require_gui_dependencies()
         try:
             salida.value = generar_reporte_correccion_tipografica(
-                normalizar_codigo(entrada.value)
+                normalizar_codigo(lector())
             )
         except Exception as exc:
             salida.value = formatear_error(
@@ -1506,13 +1573,21 @@ def crear_handler_correccion_tipografica(
     return correccion_handler
 
 
-def crear_handler_sugerencias(*, entrada: Any, salida: Any, page: Any) -> Any:
+def crear_handler_sugerencias(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
     """Crea handler compartido para sugerencias con validación léxica/sintáctica."""
+
+    lector = leer_codigo or (lambda: entrada.value)
 
     def sugerencias_handler(_e: Any) -> None:
         deps = require_gui_dependencies()
         try:
-            salida.value = generar_reporte_sugerencias(normalizar_codigo(entrada.value))
+            salida.value = generar_reporte_sugerencias(normalizar_codigo(lector()))
         except Exception as exc:
             salida.value = formatear_error(
                 exc,
@@ -1663,9 +1738,12 @@ def gui_target_choices() -> tuple[str, ...]:
         )
     return deps["target_cli_choices"](set(PUBLIC_BACKENDS) & set(deps["TRANSPILERS"]))
 
+
 # Acciones de empaquetado CobraHub reutilizadas por CLI e IDLE. Estas funciones
 # son una capa de herramientas sobre archivos, no invocan Lexer ni Parser.
-def idle_crear_paquete(project_root: str | Path, nombre: str, version: str = "0.1.0") -> Path:
+def idle_crear_paquete(
+    project_root: str | Path, nombre: str, version: str = "0.1.0"
+) -> Path:
     from pcobra.cobra.packaging import crear_paquete
 
     root = validar_project_root_idle(project_root)
@@ -1678,7 +1756,9 @@ def idle_validar_paquete(paquete: str | Path):
     return validar_paquete(paquete)
 
 
-def idle_construir_paquete(project_root: str | Path, salida: str | Path | None = None) -> Path:
+def idle_construir_paquete(
+    project_root: str | Path, salida: str | Path | None = None
+) -> Path:
     from pcobra.cobra.packaging import MANIFEST_NAME, construir_paquete
 
     root = validar_project_root_idle(project_root)

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -59,6 +59,39 @@ def _fake_flet_buttons():
     return SimpleNamespace(ElevatedButton=ElevatedButton)
 
 
+def test_crear_editor_codigo_encapsula_el_control_visual() -> None:
+    callback = object()
+
+    class TextField:
+        def __init__(self, **kwargs):
+            self.value = kwargs.get("value")
+            self.multiline = kwargs["multiline"]
+            self.expand = kwargs["expand"]
+            self.on_change = None
+            self.focos = 0
+
+        def focus(self):
+            self.focos += 1
+            return "foco solicitado"
+
+    editor = runtime.crear_editor_codigo(
+        SimpleNamespace(TextField=TextField), value=None
+    )
+    control = editor.obtener_control()
+
+    assert editor.obtener_contenido() == ""
+    editor.establecer_contenido("imprimir('Hola')")
+    assert editor.obtener_contenido() == "imprimir('Hola')"
+    editor.registrar_callback_cambios(callback)
+    assert control.on_change is callback
+    assert editor.solicitar_foco() == "foco solicitado"
+    assert control.focos == 1
+    editor.limpiar()
+    assert editor.obtener_contenido() == ""
+    assert control.multiline is True
+    assert control.expand is True
+
+
 def test_boton_sugerencias_se_habilita_si_motor_canonico_disponible(monkeypatch):
     handler = object()
     monkeypatch.setattr(
@@ -1160,7 +1193,9 @@ def test_idle_abrir_paquete_extrae_proyecto_minimo(tmp_path: Path) -> None:
     ) == "recurso\n"
 
 
-def test_idle_validar_paquete_muestra_error_para_paquete_invalido(tmp_path: Path) -> None:
+def test_idle_validar_paquete_muestra_error_para_paquete_invalido(
+    tmp_path: Path,
+) -> None:
     paquete = tmp_path / "invalido.co"
     paquete.write_text("no es un zip cobra", encoding="utf-8")
 
@@ -1186,6 +1221,7 @@ def test_idle_abrir_paquete_delega_en_extraer_paquete(
     assert runtime.idle_abrir_paquete(paquete, destino) == destino
     assert llamadas == [(paquete, destino)]
 
+
 def test_idle_abrir_paquete_falla_si_destino_no_existe(tmp_path: Path) -> None:
     project_root = _crear_proyecto_cobra_minimo(tmp_path)
     runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
@@ -1199,7 +1235,9 @@ def test_idle_abrir_paquete_falla_si_destino_no_existe(tmp_path: Path) -> None:
 def test_idle_construir_paquete_falla_si_falta_manifest(tmp_path: Path) -> None:
     project_root = _crear_proyecto_cobra_minimo(tmp_path)
 
-    with pytest.raises(FileNotFoundError, match="Usa 'Crear paquete' antes de construir"):
+    with pytest.raises(
+        FileNotFoundError, match="Usa 'Crear paquete' antes de construir"
+    ):
         runtime.idle_construir_paquete(project_root)
 
 
@@ -1326,6 +1364,7 @@ def test_idle_publicar_paquete_no_delega_en_metodo_legacy_del_cliente(
 
     assert runtime.idle_publicar_paquete(paquete) is True
     assert llamadas == [str(paquete)]
+
 
 def test_helpers_idle_de_paquetes_no_importan_lexer_ni_parser_y_delegan_en_packaging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
### Motivation

- Separar la lógica del editor del control visual concreto de Flet para permitir sustituir o adaptar el componente sin propagar referencias a `TextField` por toda la GUI.
- Minimizar cambios visibles en la API pública y mantener compatibilidad con handlers existentes que todavía reciben `entrada`.

### Description

- Añade `EditorCodigo` en `src/pcobra/gui/runtime.py`, un adaptador que envuelve el control visual y expone operaciones públicas: `obtener_contenido`, `establecer_contenido`, `limpiar`, `solicitar_foco`, `registrar_callback_cambios` y `obtener_control`.
- Conserva `crear_editor_codigo()` como factoría pública, ahora devolviendo una instancia de `EditorCodigo` que envuelve el `TextField` creado.
- Modifica los handlers compartidos (`crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast`, `crear_handler_sugerencias`, `crear_handler_correccion_tipografica`) para aceptar un parámetro `leer_codigo` (función) y mantiene `entrada` como opción de compatibilidad; los handlers usan `leer_codigo()` si se proporciona.
- Actualiza `src/pcobra/gui/idle.py` para usar solo las operaciones del adaptador en el editor principal: lectura/escritura de contenido, limpieza, registro de callback y añadir al layout con `entrada.obtener_control()`; los demás campos de formulario (`ruta_input`, `raiz_input`, etc.) siguen siendo `TextField` sin cambios.
- Añade una prueba unitaria `test_crear_editor_codigo_encapsula_el_control_visual` que verifica las operaciones públicas del adaptador y la integración mínima con el control subyacente.

### Testing

- Ejecutado `pytest -q tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py`, resultado: 132 passed, 1 warning (éxito).
- Ejecutados checks estáticos y formateo (`ruff`, `black --fast`) y compilación (`python -m compileall`); se aplicó formateo y los checks finalizaron sin errores relevantes.
- Verificado `git diff --check` y revisión del diff para confirmar que no se modificaron archivos de Lexer ni Parser (ningún cambio en `src/.../lexer` o `src/.../parser`).
- Observación: la suite adicional `tests/unit/test_gui_app.py` y `tests/unit/test_gui_menu.py` muestra 4 fallos (dos expectativas de filtrado de árbol y dos dobles de Flet sin `ScrollMode`) que son anteriores/adyacentes al alcance de este cambio y no provienen de la encapsulación del editor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f5fcbb2888327b5c1df7fd0b610a0)