### PR TITLE
docs(gui): documentar contrato del editor, indentación y matriz de validación manual

### DIFF
--- a/docs/gui_idle.md
+++ b/docs/gui_idle.md
@@ -47,6 +47,31 @@ Estos flujos se crean desde helpers de `runtime.py`: `crear_handler_ejecucion`, 
 
 El editor permite modificar código Cobra de forma interactiva. La cabecera muestra el archivo activo o `Archivo nuevo (sin guardar)`, y añade un asterisco cuando el contenido del editor difiere del contenido cargado desde disco. La comparación de cambios se centraliza en `runtime.marcar_cambios_editor` para reflejar el estado de cambios sin guardar de manera consistente.
 
+El control escogido para la edición es `CodeEditor` de `flet-code-editor`
+0.86.1, sobre Flet 0.86.1. `runtime.crear_editor_codigo()` lo construye y lo
+encapsula en `runtime.EditorCodigo`; `idle.py` consume únicamente las operaciones
+del adaptador (contenido, limpieza y registro de callbacks), mientras el mismo
+contrato también expone la solicitud de foco sin filtrar detalles del control.
+Así, `idle.py` no depende de atributos propios de `CodeEditor`. Esta
+separación mantiene en `idle.py` la coordinación de la interfaz y permite probar
+el contrato del editor con dobles sin cargar el control gráfico real.
+
+La indentación del editor usa **cuatro espacios por nivel**:
+
+- Tab sin selección inserta cuatro espacios en la posición del cursor.
+- Tab con una selección multilínea añade cuatro espacios al comienzo de cada
+  línea intersectada; una selección que termina justo al inicio de la línea
+  siguiente no incluye esa línea.
+- Shift+Tab desindenta cada línea intersectada, retirando hasta cuatro espacios
+  iniciales o un tabulador literal, sin borrar texto que no sea indentación.
+- La selección y el cursor se desplazan junto con el texto, incluidas selecciones
+  invertidas y finales de línea LF o CRLF.
+
+Tab y Shift+Tab los procesa localmente `CodeEditor`; el IDLE no registra un
+atajo global en `Page`, porque eso duplicaría la edición. La función pura
+`runtime.ajustar_indentacion_editor()` expresa y prueba el contrato de cuatro
+espacios, pero no se conecta como segundo manejador de teclado.
+
 ## Acciones de archivo y guardado
 
 La barra de archivo expone estas acciones:
@@ -69,8 +94,23 @@ Al seleccionar un archivo visible, el IDLE llama a `runtime.cargar_archivo_desde
 
 ## Disponibilidad de dependencias y degradación
 
-- **Flet:** Flet es una dependencia opcional de la GUI. Importar módulos CLI no debe requerir Flet; abrir el IDLE sí requiere instalarlo. Si Flet no está disponible, la aplicación CLI debe poder seguir funcionando y el intento de iniciar la GUI debe informar la dependencia faltante en lugar de romper flujos no gráficos.
+- **Flet y editor:** `flet==0.86.1` y `flet-code-editor==0.86.1` están declarados
+  como dependencias del proyecto. Sus imports siguen siendo diferidos: importar
+  módulos CLI no debe cargar Flet ni el editor; abrir el IDLE sí los requiere. Si
+  alguno no está disponible en una instalación parcial, el intento de iniciar la
+  GUI debe identificar la dependencia faltante sin romper los flujos no
+  gráficos.
 - **Motor IA de sugerencias:** `agix` es una dependencia oficial declarada en `[project].dependencies`, no un extra opcional. Su ausencia solo se tolera para instalaciones parciales o entornos headless: en ese caso, el botón de sugerencias aparece deshabilitado o muestra el motivo y la forma de instalarla. La ejecución, los tokens, el AST, la transpilación y las acciones de archivo siguen disponibles porque no deben importar el motor hasta que se soliciten sugerencias.
+
+## Plataformas y validación manual
+
+No hay una ejecución manual completa registrada para ninguna plataforma. Por
+tanto, este documento **no afirma compatibilidad** con Linux, Windows ni macOS a
+partir de las pruebas unitarias o de la inspección del control. La matriz
+reproducible y el criterio para registrar una plataforma verificada están en
+[`docs/gui_idle_especificacion.md`](gui_idle_especificacion.md); la evidencia y
+el estado actual se reflejan en
+[`docs/gui_idle_trazabilidad.md`](gui_idle_trazabilidad.md).
 
 ## Empaquetar proyectos desde el IDLE
 

--- a/docs/gui_idle_especificacion.md
+++ b/docs/gui_idle_especificacion.md
@@ -9,6 +9,27 @@ Esta especificación define el alcance funcional del IDLE gráfico Cobra (`pcobr
 - No es un IDE completo: prioriza flujos simples, verificables y seguros para trabajo local con archivos Cobra.
 - El selector de transpilación del IDLE solo puede mostrar los targets públicos canónicos: `python`, `javascript` y `rust`. No debe exponer aliases, targets legacy ni backends experimentales.
 
+## Contrato del editor
+
+- El control visual escogido es `CodeEditor` de `flet-code-editor` 0.86.1 con
+  Flet 0.86.1; ambas versiones están fijadas como dependencias del proyecto.
+- `runtime.EditorCodigo` es la frontera entre el control y el IDLE. `idle.py` no
+  debe leer ni escribir directamente atributos específicos de `CodeEditor`, sino
+  usar el adaptador para contenido, limpieza, foco y callbacks.
+- Un nivel de indentación equivale exactamente a cuatro espacios.
+- Tab sin selección inserta un nivel en el cursor. Con selección multilínea,
+  Tab indenta todas las líneas intersectadas y conserva una selección equivalente
+  sobre el texto resultante. Si el extremo final está justo al comienzo de otra
+  línea, esa última línea queda fuera de la operación.
+- Shift+Tab desindenta todas las líneas intersectadas: elimina hasta cuatro
+  espacios iniciales o un tabulador literal por línea y nunca elimina texto no
+  indentado. Debe conservar el sentido de selecciones invertidas y funcionar con
+  finales LF y CRLF.
+- El control procesa Tab y Shift+Tab localmente. No se debe añadir además un
+  manejador global de teclado en `Page`, pues una pulsación podría aplicarse dos
+  veces. `runtime.ajustar_indentacion_editor()` define el contrato puro para las
+  pruebas, no un segundo manejador conectado al control.
+
 ## Workspace
 
 - El workspace por defecto es `~/CobraProjects`.
@@ -131,6 +152,39 @@ La seguridad de rutas existente se conserva para todos los tipos soportados: se 
 | POC-13D | Abrir, editar, guardar y recargar archivos Docker (`Dockerfile`, `Dockerfile.*`) y de ignorados (`.gitignore`, `.dockerignore`) sin invocar `Lexer` ni `Parser`. | 🟢 Verde |
 | POC-13E | Abrir, editar, guardar y recargar `.env.example` sin invocar `Lexer` ni `Parser`. | 🟢 Verde |
 | POC-13F | Bloquear **Ejecutar**, **Tokens**, **AST**, **Sugerencias del Libro** y **Corrección** para todo archivo que no sea `.cobra` ni `.co`, conservando las restricciones de rutas existentes. | 🟢 Verde |
+
+## Matriz de validación manual reproducible
+
+Una fila solo puede cambiar a **Verificada** después de ejecutar todos los pasos
+en una sesión gráfica real de ese mismo sistema operativo y de anotar las
+versiones obtenidas, no las meramente previstas. Las pruebas unitarias y un
+entorno sin pantalla no sustituyen esta validación.
+
+Procedimiento por fila:
+
+1. Crear un entorno limpio e instalar el proyecto; registrar `python --version`
+   y las versiones devueltas para `flet` y `flet-code-editor` por
+   `python -c "from importlib.metadata import version; print(version('flet')); print(version('flet-code-editor'))"`.
+2. Ejecutar `cobra gui`, crear o abrir un proyecto y un archivo `.cobra` con
+   `uno` y `dos` en líneas separadas.
+3. Comprobar Tab con el cursor (inserta cuatro espacios), seleccionar ambas
+   líneas y comprobar Tab (indenta ambas) y Shift+Tab (revierte un nivel sin
+   borrar texto). Confirmar que el editor conserva el foco tras cada acción.
+4. Abrir un archivo UTF-8 existente, modificarlo, guardarlo y verificar el
+   contenido en disco; limpiar mediante **Nuevo** y comprobar editor y ruta
+   vacíos; volver a abrirlo, modificar el archivo desde fuera y pulsar
+   **Recargar**.
+5. Abrir un `.cobra` válido, pulsar **Ejecutar** y comprobar que la salida
+   esperada aparece. Registrar cada resultado como `Pasa` o `Falla`, incluyendo
+   una observación para todo fallo.
+
+| Sistema operativo | Python | Flet | Editor (`flet-code-editor`) | Tab | Selección multilínea | Shift+Tab | Foco | Abrir | Guardar | Limpiar | Recargar | Ejecutar | Estado |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Ubuntu 24.04.4 LTS (entorno de documentación, sin sesión gráfica) | 3.12.13 | 0.28.3 instalada en el entorno; objetivo del proyecto 0.86.1 | No instalado; objetivo del proyecto 0.86.1 | No ejecutado | No ejecutado | No ejecutado | No ejecutado | No ejecutado | No ejecutado | No ejecutado | No ejecutado | No ejecutado | No verificada |
+
+No se incluyen filas de Windows ni macOS porque no existe evidencia registrada
+de ejecución manual en esas plataformas. Deben añadirse solo después de aplicar
+el procedimiento completo, con sus versiones y resultados reales.
 
 ## Limitaciones conocidas
 

--- a/docs/gui_idle_trazabilidad.md
+++ b/docs/gui_idle_trazabilidad.md
@@ -4,6 +4,8 @@ Esta matriz documenta únicamente comportamiento existente en el IDLE gráfico c
 
 | Funcionalidad visible | Archivo de implementación | Función/handler | Dependencia Lexer/Parser | Documentación relacionada | Estado |
 | --- | --- | --- | --- | --- | --- |
+| Editor de código, contenido y foco | `src/pcobra/gui/runtime.py` / `src/pcobra/gui/idle.py` | `crear_editor_codigo()` crea `CodeEditor` y devuelve `EditorCodigo`; `idle.py` usa las operaciones de contenido, limpieza y callbacks del adaptador, que además expone `solicitar_foco()` sin filtrar la API del control. | No usa Lexer/Parser para editar. La ejecución y el análisis conservan sus validaciones independientes. | `docs/gui_idle_especificacion.md`, “Contrato del editor”. | Implementado con `flet==0.86.1` y `flet-code-editor==0.86.1`; imports diferidos. |
+| Tab, selección multilínea y Shift+Tab | `flet-code-editor` / `src/pcobra/gui/runtime.py` | `CodeEditor` procesa localmente Tab y Shift+Tab; `ajustar_indentacion_editor()` especifica cuatro espacios, líneas intersectadas, desindentación y ajuste de selección. No hay handler global duplicado en `idle.py`. | No usa Lexer/Parser. | `docs/gui_idle_especificacion.md`, “Contrato del editor” y “Matriz de validación manual reproducible”. | Contrato cubierto programáticamente; validación manual de plataforma pendiente. |
 | Nuevo | `src/pcobra/gui/idle.py` / `src/pcobra/gui/runtime.py` | `nuevo_handler` → `crear_archivo_nuevo_en_editor()` → `nuevo_archivo()` | No usa Lexer/Parser; solo reinicia `GuiFileState` y el contenido del editor. | `docs/LIBRO_PROGRAMACION_COBRA.md`, sección 10.1, “Gestión de archivos / Nuevo”. | Implementado. |
 | Abrir | `src/pcobra/gui/idle.py` / `src/pcobra/gui/runtime.py` | `abrir_handler` → `cargar_archivo()` → `abrir_archivo_desde_ruta()` / `cargar_archivo_desde_arbol()` | No usa Lexer/Parser; valida ruta/sandbox y, desde el árbol, extensión Cobra antes de leer. | `docs/LIBRO_PROGRAMACION_COBRA.md`, sección 10.1, “Gestión de archivos / Abrir” y “Árbol de directorios”. | Implementado. |
 | Guardar | `src/pcobra/gui/idle.py` / `src/pcobra/gui/runtime.py` | `guardar_handler` → `guardar_archivo_activo()` → `guardar_archivo_en_estado()` | No usa Lexer/Parser; escribe el contenido normalizado del editor tras validar la ruta activa. | `docs/LIBRO_PROGRAMACION_COBRA.md`, sección 10.1, “Gestión de archivos / Guardar”. | Implementado. |
@@ -44,6 +46,21 @@ capacidades del archivo activo antes de delegar en los handlers Cobra.
 ## Especificación normativa
 
 La especificación consolidada de acciones soportadas, funciones runtime, validación previa con `Lexer`/`Parser` y restricción del selector de transpilación a `python`, `javascript` y `rust` está en [`docs/gui_idle_especificacion.md`](gui_idle_especificacion.md).
+
+## Evidencia de plataforma
+
+La lógica del adaptador y la transformación de indentación tienen cobertura
+unitaria, pero no hay una sesión gráfica manual completa registrada. El entorno
+usado para actualizar esta documentación es Ubuntu 24.04.4 LTS con Python
+3.12.13; contiene Flet 0.28.3 y no contiene `flet-code-editor`, por lo que no
+cumple las versiones fijadas ni permite validar visualmente el control. En
+consecuencia, Ubuntu queda como **no verificada** y no se declara compatibilidad
+con ella. Tampoco se declara compatibilidad con Windows o macOS sin evidencia.
+
+La matriz y el procedimiento reproducible que exigen resultados explícitos de
+Tab, selección multilínea, Shift+Tab, foco, abrir, guardar, limpiar, recargar y
+ejecutar están en
+[`docs/gui_idle_especificacion.md`](gui_idle_especificacion.md#matriz-de-validación-manual-reproducible).
 
 ## Auditoría CI de reglas derivadas del Libro
 


### PR DESCRIPTION
### Motivation

- Aclarar la elección del control visual para el editor y definir una frontera clara entre el adaptador y la lógica de coordinación del IDLE para facilitar pruebas y mantenimiento.
- Especificar el contrato de indentación y comportamiento de Tab/Shift+Tab y selección multilínea para evitar ambigüedades en la experiencia de edición.
- Añadir una matriz reproducible y procedimiento de validación manual para registrar comprobaciones por plataforma y evitar afirmar compatibilidad sin evidencia.

### Description

- Documenté que el control escogido es `CodeEditor` de `flet-code-editor` (meta: 0.86.1) y que `runtime.crear_editor_codigo()` lo encapsula en `runtime.EditorCodigo`, dejando a `idle.py` usando únicamente el adaptador (contenido, limpieza, callbacks y solicitud de foco).
- Definí el contrato de indentación como exactamente cuatro espacios por nivel y describí el comportamiento ante cursor, selección multilínea, Tab y Shift+Tab, y la decisión de no duplicar manejadores globales porque `CodeEditor` procesa esas teclas localmente (`runtime.ajustar_indentacion_editor()` sigue siendo la función pura de contrato y pruebas).
- Actualicé la sección de dependencias en la documentación para reflejar la presencia/fijado de `flet` y `flet-code-editor` como versiones objetivo, manteniendo los imports diferidos en tiempo de ejecución; se documentó la dependencia pero no se añadió código ni cambios al lexer/parser.
- Añadí una matriz de validación manual reproducible (SO, Python, Flet, editor y resultados para Tab, selección multilínea, Shift+Tab, foco, abrir, guardar, limpiar, recargar y ejecutar) y dejé explícito que no se afirma compatibilidad en plataformas sin ejecución gráfica verificada.

### Testing

- Ejecuté `python -m pytest tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py -q`, con resultado: 146 pruebas superadas.
- Ejecuté `git diff --check` para validar estilos y comprobaciones; no se detectaron errores automáticos.
- Verifiqué que sólo se modificaron los tres documentos solicitados: `docs/gui_idle.md`, `docs/gui_idle_especificacion.md` y `docs/gui_idle_trazabilidad.md` y que `Lexer` y `Parser` no fueron alterados.
- Las pruebas unitarias y la cobertura del adaptador/función de indentación quedan como evidencia programática, y la matriz manual define los pasos necesarios para completar la validación gráfica por plataforma.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f7fe0f0388327a249a4c0ebc6c318)