### PR TITLE
test: evitar carga global del shim legacy `core`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from pathlib import Path
 import sys
 
@@ -10,44 +9,17 @@ SRC_PATH = Path(__file__).resolve().parent / 'src'
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-try:  # pragma: no cover - protege entornos sin alias instalados
-    import importlib
-
-    sys.modules.setdefault('core', importlib.import_module('core'))
-    sys.modules.setdefault('cobra', importlib.import_module('cobra'))
-except ModuleNotFoundError:
-    pass
-
 import asyncio
 import inspect
 from typing import Any
 
 
-def _restore_alias(module_name: str, alias: str) -> None:
-    """Garantiza que el alias ``alias`` apunte al módulo real."""
-
-    module = import_module(module_name)
-    sys.modules[alias] = module
-    prefix = f"{module_name}."
-    alias_prefix = f"{alias}."
-    for name, mod in list(sys.modules.items()):
-        if name.startswith(prefix):
-            sys.modules[alias_prefix + name[len(prefix) :]] = mod
-
-
 def pytest_runtest_setup(item):  # noqa: ARG001
-    """Restaura los alias dinámicos antes de cada prueba."""
+    """Aísla los módulos de transpiladores cargados por cada prueba."""
 
     for prefix in ("cobra.transpilers", "pcobra.cobra.transpilers"):
         for name in [mod for mod in sys.modules if mod.startswith(prefix)]:
             sys.modules.pop(name, None)
-    _restore_alias("pcobra.core", "core")
-    _restore_alias("pcobra.cobra", "cobra")
-
-
-def pytest_collectstart(collector):  # noqa: ARG001
-    _restore_alias("pcobra.core", "core")
-    _restore_alias("pcobra.cobra", "cobra")
 
 
 def _ejecutar_corutina(funcion, **kwargs: Any) -> None:

--- a/tests/unit/test_legacy_import_shims_contract.py
+++ b/tests/unit/test_legacy_import_shims_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 import sys
 import warnings
 
@@ -31,9 +32,27 @@ def test_import_legacy_bindings_solo_via_shim_con_deprecacion() -> None:
 
 def test_import_legacy_core_solo_via_shim_con_deprecacion() -> None:
     _purge_module_prefix("core")
-    legacy = importlib.import_module("core")
-    resource_limits = importlib.import_module("core.resource_limits")
+    source_root = Path(__file__).resolve().parents[2] / "src"
+    package_root = source_root / "pcobra"
+    original_path = list(sys.path)
+    sys.path[:] = [
+        path
+        for path in sys.path
+        if not path or Path(path).resolve() != package_root
+    ]
+    sys.path.insert(0, str(source_root))
+    importlib.invalidate_caches()
 
+    try:
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", DeprecationWarning)
+            legacy = importlib.import_module("core")
+            resource_limits = importlib.import_module("core.resource_limits")
+    finally:
+        sys.path[:] = original_path
+
+    assert any(issubclass(item.category, DeprecationWarning) for item in captured)
+    assert any("`core` está deprecado" in str(item.message) for item in captured)
     assert "compatibilidad" in (legacy.__doc__ or "").lower()
     assert legacy.__name__ == "core"
     assert hasattr(resource_limits, "limitar_cpu_segundos")

--- a/tests/unit/test_pytest_global_config.py
+++ b/tests/unit/test_pytest_global_config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_configuracion_global_no_importa_shim_core() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = repo_root / "test_pytest_global_config_probe.py"
+    probe.write_text(
+        "import sys\n\n"
+        "def test_core_no_se_importa_durante_inicializacion():\n"
+        "    assert 'core' not in sys.modules\n",
+        encoding="utf-8",
+    )
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-W",
+                "error::DeprecationWarning",
+                str(probe),
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        probe.unlink(missing_ok=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- Evitar que la configuración global de Pytest importe el shim legacy `core` de forma eager durante la inicialización, ya que ese registro global fuerza compatibilidad no deseada en todos los tests.
- Mantener la compatibilidad legacy solo en pruebas que la soliciten explícitamente usando rutas canónicas `pcobra.core` en la infraestructura general y limitar alias históricos a pruebas concretas.
- Hacer cambios mínimos y localizados sin tocar Lexer, Parser, sintaxis ni reglas gramaticales.

### Description
- Eliminé la importación anticipada y el registro automático de alias legacy (`core`, `cobra`) en `conftest.py`, así como la función auxiliar `_restore_alias`, preservando únicamente el aislamiento de módulos de transpiladores en el hook global. 
- Añadí la prueba `tests/unit/test_pytest_global_config.py` que ejecuta un proceso Pytest separado con `DeprecationWarning` convertido en error y verifica que `core` no aparece en `sys.modules` durante la inicialización global.
- Modifiqué `tests/unit/test_legacy_import_shims_contract.py` para aislar `sys.path` y simular un consumidor legacy que importa explícitamente `core` desde `src`, capturando y asertando el `DeprecationWarning` esperado y su mensaje.

### Testing
- `python -m pytest tests/unit/test_pytest_global_config.py tests/unit/test_legacy_import_shims_contract.py -q` pasó con éxito (las pruebas dirigidas añadidas/ajustadas pasaron). 
- `python -m ruff check conftest.py tests/unit/test_legacy_import_shims_contract.py tests/unit/test_pytest_global_config.py` no reportó incidencias de estilo.
- `git diff --check` no mostró errores de espacio/formatos en el diff del parche.
- `python -m pytest tests/unit -q` ejecutó la suite unitaria relacionada y la ejecución se detuvo tras detectar 5 fallos que son preexistentes y no están relacionados con los cambios de alias (178 pruebas pasaron y 5 fallos permanecen en áreas de identidad de AST y caché SQLite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65e2d85e408327b192f30b38990db2)