### PR TITLE
Stabilize REPL error recovery monkeypatches

### DIFF
--- a/tests/cli/test_repl_error_recovery_contract.py
+++ b/tests/cli/test_repl_error_recovery_contract.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.cli.commands import interactive_cmd as interactive_cmd_module
+
+InteractiveCommand = interactive_cmd_module.InteractiveCommand
 
 
 @pytest.mark.integration
@@ -59,7 +61,8 @@ def test_repl_error_sintactico_por_cierre_extra_reporta_y_acepta_nuevas_entradas
         return next(entradas)
 
     monkeypatch.setattr(
-        "pcobra.cobra.cli.commands.interactive_cmd.mostrar_error",
+        interactive_cmd_module,
+        "mostrar_error",
         lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
     )
 
@@ -93,7 +96,8 @@ def test_repl_error_runtime_no_cierra_sesion_y_permite_recuperacion(monkeypatch)
         return next(entradas)
 
     monkeypatch.setattr(
-        "pcobra.cobra.cli.commands.interactive_cmd.mostrar_error",
+        interactive_cmd_module,
+        "mostrar_error",
         lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
     )
 
@@ -135,7 +139,8 @@ def test_repl_usar_errores_esperados_solo_mensaje_breve_sin_traceback(
     logs_debug: list[str] = []
 
     monkeypatch.setattr(
-        "pcobra.cobra.cli.commands.interactive_cmd.mostrar_error",
+        interactive_cmd_module,
+        "mostrar_error",
         lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
     )
     monkeypatch.setattr(
@@ -176,7 +181,8 @@ def test_repl_usar_error_debug_incluye_traceback(monkeypatch):
     logs_debug: list[str] = []
 
     monkeypatch.setattr(
-        "pcobra.cobra.cli.commands.interactive_cmd.mostrar_error",
+        interactive_cmd_module,
+        "mostrar_error",
         lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Tests were patching `mostrar_error` via a textual import path which could resolve to a different module object when `interactive_cmd` is loaded under multiple identities, causing the real `mostrar_error` to be invoked by `InteractiveCommand` and making assertions fail.

### Description
- Replace `from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand` with `from pcobra.cobra.cli.commands import interactive_cmd as interactive_cmd_module` and `InteractiveCommand = interactive_cmd_module.InteractiveCommand` so the test retains the canonical module object during collection.
- Replace textual `monkeypatch.setattr("pcobra.cobra.cli.commands.interactive_cmd.mostrar_error", ...)` calls with `monkeypatch.setattr(interactive_cmd_module, "mostrar_error", ...)` in the four affected locations inside `tests/cli/test_repl_error_recovery_contract.py` so patches apply to the same module object used by `InteractiveCommand`.
- No production code, assertions, messages, conftest, Lexer, Parser or other tests were modified.

### Testing
- Ran `python -m pytest -q tests/cli/test_repl_error_recovery_contract.py -vv --tb=short --maxfail=1` and observed `8 passed`.
- Ran the focused selectors and suites: the targeted REPL selection (`-k` for the three recovery tests) passed (6 passed, 3 skipped, 4708 deselected) and the sensitive single-test selection passed (`1 passed`), the focused REPL/related suite passed (`117 passed`), and the import/alias-related suite passed (`64 passed`, 2 warnings).
- A full `pytest` run exited with code `1` due to five unrelated, pre-existing failures in other integration tests; those failures are outside the single modified test file and were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6643397c548327a2e0f22fd622af0c)