### PR TITLE
Fix legacy AST module identity for core.ast_nodes

### DIFF
--- a/src/pcobra/core/__init__.py
+++ b/src/pcobra/core/__init__.py
@@ -20,6 +20,7 @@ from .performance import optimizar, perfilar
 from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 sys.modules["core"] = sys.modules[__name__]
+sys.modules["core.ast_nodes"] = sys.modules[f"{__name__}.ast_nodes"]
 
 __all__ = [
     "NodoAST",


### PR DESCRIPTION
### Motivation
- Corregir un fallo donde los nodos AST generados por `ReverseFromJS` no eran reconocidos por `isinstance` porque `core.ast_nodes` no estaba registrado como alias del módulo ya cargado `pcobra.core.ast_nodes`.

### Description
- Añadida una línea en `src/pcobra/core/__init__.py` que registra `core.ast_nodes` en `sys.modules` como alias de `pcobra.core.ast_nodes` para preservar la identidad de las clases AST.

### Testing
- Se ejecutaron las pruebas dirigidas: `pytest tests/integration/reverse/test_from_js.py::test_reverse_from_js_constructs` (antes del cambio fallaba por identidad de clase; después del cambio pasó), `pytest tests/integration/reverse/test_from_js.py` (pasó), y `pytest tests/integration/reverse` (resultado: 1 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6646c6b42c832784d6b6738b9247a7)