### PR TITLE
Use canonical imports in ReverseFromJS integration test

### DIFF
--- a/src/pcobra/core/__init__.py
+++ b/src/pcobra/core/__init__.py
@@ -20,7 +20,6 @@ from .performance import optimizar, perfilar
 from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 sys.modules["core"] = sys.modules[__name__]
-sys.modules["core.ast_nodes"] = sys.modules[f"{__name__}.ast_nodes"]
 
 __all__ = [
     "NodoAST",

--- a/tests/integration/reverse/test_from_js.py
+++ b/tests/integration/reverse/test_from_js.py
@@ -2,8 +2,8 @@ import pytest
 
 pytest.importorskip("tree_sitter")
 
-from cobra.transpilers.reverse.from_js import ReverseFromJS
-from core.ast_nodes import (
+from pcobra.cobra.transpilers.reverse.from_js import ReverseFromJS
+from pcobra.cobra.core.ast_nodes import (
     NodoFuncion,
     NodoClase,
     NodoBucleMientras,


### PR DESCRIPTION
### Motivation
- Arreglar una prueba que dependía de un alias legacy añadido en runtime para `core.ast_nodes` sin reintroducir compatibilidad legacy en producción. 
- Aplicar la política de la rama que prohíbe restaurar aliases históricos salvo contrato explícito, migrando la prueba a las rutas canónicas usadas por el transpiler inverso.

### Description
- Elimina la inserción del alias puntual `core.ast_nodes` en `src/pcobra/core/__init__.py` (se quitó la línea que exponía `core.ast_nodes` en `sys.modules`).
- Actualiza `tests/integration/reverse/test_from_js.py` para importar `ReverseFromJS` desde `pcobra.cobra.transpilers.reverse.from_js` y las clases AST desde `pcobra.cobra.core.ast_nodes`, preservando todas las aserciones `isinstance` y el comportamiento de la prueba.
- No se modificó el transpiler inverso, no se añadieron nuevos aliases, y no se tocaron el Lexer ni el Parser.

### Testing
- Ejecutado `python -m pytest -q tests/integration/reverse/test_from_js.py::test_reverse_from_js_constructs -vv --tb=long` — resultado: `1 passed`.
- Ejecutado `python -m pytest -q tests/integration/reverse -vv --tb=short --maxfail=3` — resultado: `1 passed, 1 skipped`.
- Ejecutado `python -m pytest -q tests/test_legacy_import_aliases.py tests/unit/test_legacy_import_shims_contract.py -vv --tb=short --maxfail=3` — resultado: `5 passed` con una advertencia de deprecación esperada al activar el shim legacy.
- Ejecutado `python -m pytest -q --maxfail=5` para obtener el siguiente grupo de fallos preexistentes — resultado: la suite general cayó en un grupo no relacionado (5 fail, 396 passed, 6 skipped); esos fallos no fueron abordados por este cambio porque están fuera del alcance del parche aplicado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a664cf547748327a0c270ef2378de77)