### PR TITLE
test: migrar imports de CLI y ast_cache a módulos canónicos

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -7,15 +7,15 @@ from unittest.mock import patch
 import pytest
 
 import pcobra  # ensure package is initialized
-import cobra.cli.cli as cli_module
-from cobra.cli.cli import main
-from cobra.cli.commands import cache_cmd, modules_cmd
+import pcobra.cli.cli as cli_module
+from pcobra.cli.cli import main
+from pcobra.cobra.cli.commands import cache_cmd, modules_cmd
 from pcobra.cobra.core import Lexer, Parser
 
 
 def _reload_ast_cache(monkeypatch):
     monkeypatch.delenv("COBRA_AST_CACHE", raising=False)
-    import core.ast_cache as ast_cache_module
+    import pcobra.core.ast_cache as ast_cache_module
 
     ast_cache_module = importlib.reload(ast_cache_module)
     ast_cache_module.limpiar_cache()


### PR DESCRIPTION
### Motivation
- La suite de tests fallaba porque `tests/integration/test_cli.py` importaba el wrapper legacy `cobra.cli.cli` y el alias `core.ast_cache`, lo que causaba errores de setup al no exponer `setup_gettext` y desalineaba los módulos usados por la prueba y la producción.

### Description
- Se actualizan los imports en `tests/integration/test_cli.py` para usar las rutas canónicas: `pcobra.cli.cli`, `pcobra.cobra.cli.commands` y `pcobra.core.ast_cache` en lugar de los wrappers legacy.
- Se recarga la implementación canónica de la caché AST desde `pcobra.core.ast_cache` para que el test y la preparación de datos compartan la misma capa de producción.
- No se modificó código de producción, Lexer ni Parser; el cambio es únicamente en el test y es mínimo para alinear superficies.

### Testing
- Ejecuté `python -m pytest -q tests/integration/test_cli.py::test_cache_command_clears_database -vv --tb=long -s` y el test pasó (`1 passed`).
- Ejecuté `python -m pytest -q tests/integration/test_cli.py -vv --tb=short --maxfail=3` y el fichero de integración completo pasó (`5 passed`).
- Ejecuté los tests cercanos con `python -m pytest -q tests/unit/test_cli_cache_cmd.py tests/core/test_database.py tests/unit/test_cli_db_key_gating.py tests/unit/test_cli_sqlite_db_key.py -vv --tb=short --maxfail=3` y obtuve errores de recopilación en `tests/unit/test_cli_db_key_gating.py` y `tests/unit/test_cli_sqlite_db_key.py` debido a imports legacy fuera del alcance de este cambio; esos errores permanecen sin modificar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6652e97e6483278c05ef0f7237ed73)