### PR TITLE
Use canonical runtime imports in string equality integration tests

### DIFF
--- a/tests/integration/test_interpreter_string_equality.py
+++ b/tests/integration/test_interpreter_string_equality.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
-from cobra.core import Lexer, Parser
-from core.interpreter import InterpretadorCobra
+from pcobra.cobra.core import Lexer, Parser
+from pcobra.cobra.core.runtime import InterpretadorCobra
 
 
 def _parsear_y_ejecutar(codigo: str) -> str:


### PR DESCRIPTION
### Motivation

- Corrige fallos en dos pruebas de igualdad de cadenas causados por imports mixtos que generaban identidades de módulo distintas entre los nodos AST y el intérprete, provocando que `isinstance` rechazara los nodos creados por otra ruta de importación.

### Description

- Se actualizó `tests/integration/test_interpreter_string_equality.py` para reemplazar los imports legacy por las superficies canónicas: se cambió `from cobra.core import Lexer, Parser` y `from core.interpreter import InterpretadorCobra` por `from pcobra.cobra.core import Lexer, Parser` y `from pcobra.cobra.core.runtime import InterpretadorCobra` respectivamente, sin tocar producción ni Lexer/Parser.

### Testing

- Ejecutadas las pruebas focales `python -m pytest -q tests/integration/test_interpreter_string_equality.py::test_igualdad_cadenas_hola_hola_es_verdadero` y `python -m pytest -q tests/integration/test_interpreter_string_equality.py::test_igualdad_cadenas_hola_adios_es_falso`, ambas pasaron; el archivo completo `python -m pytest -q tests/integration/test_interpreter_string_equality.py` devolvió `2 passed`; ejecución combinada con `tests/integration/test_interpreter_loop_mutation_persistence.py`, `tests/integration/test_interactive_persistence.py` y `tests/integration/test_run_repl_equivalence.py` mostró las pruebas relacionadas pasando (46 passed in that run); la ejecución completa de la suite arrojó 5 fallos no relacionados con este cambio (`test_end_to_end[python]`, `test_end_to_end[javascript]`, `test_execute_en_contenedor`, `test_kernel_transpiler_mode`, `test_misma_secuencia_semantica_equivale_entre_run_y_repl`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66f99cf0cc83279d95bda8753285f4)