### PR TITLE
Update import paths in end-to-end integration test to match refactor

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -17,10 +17,10 @@ if not hasattr(importlib, "ModuleType"):
     importlib.ModuleType = types.ModuleType
 
 import pcobra  # noqa: F401
-from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
-from cobra.core import Lexer
-from cobra.core import Parser
-from core.interpreter import InterpretadorCobra
+from pcobra.cli.commands.compile_cmd import CompileCommand
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
+from pcobra.core.interpreter import InterpretadorCobra
 import cobra.transpilers.module_map as module_map
 
 from tests.utils.runtime import execute_transpiled_code


### PR DESCRIPTION
### Motivation
- Align the integration test with a recent package refactor that moved core modules under `pcobra.core` and adjusted CLI module paths so the test can import the correct symbols.

### Description
- Updated `tests/integration/test_end_to_end.py` imports to use `from pcobra.cli.commands.compile_cmd import CompileCommand`, `from pcobra.core.lexer import Lexer`, `from pcobra.core.parser import Parser`, and `from pcobra.core.interpreter import InterpretadorCobra` to reflect the new module layout.

### Testing
- Ran `pytest -q tests/integration/test_end_to_end.py` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66fd81fedc8327afd625c5352e9cc7)