### PR TITLE
Refactor test imports to use `pcobra.core` lexer/parser and remove legacy hacks

### DIFF
--- a/tests/integration/test_cross_backend_output.py
+++ b/tests/integration/test_cross_backend_output.py
@@ -1,29 +1,13 @@
 import sys
 from pathlib import Path
-import importlib
-import types
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "src"))
 
-if not hasattr(importlib, "ModuleType"):
-    importlib.ModuleType = types.ModuleType
-
-import pcobra
-import pcobra.core.ast_nodes as core_ast_nodes
-import pcobra.cobra.core as cobra_core
-import pcobra.cobra.core.ast_nodes as cobra_ast_nodes
-for nombre in dir(core_ast_nodes):
-    if nombre.startswith("Nodo"):
-        obj = getattr(core_ast_nodes, nombre)
-        if not hasattr(cobra_ast_nodes, nombre):
-            setattr(cobra_ast_nodes, nombre, obj)
-        if not hasattr(cobra_core, nombre):
-            setattr(cobra_core, nombre, obj)
-from pcobra.cobra.core import Lexer
-from pcobra.cobra.core import Parser
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 from pcobra.cobra.transpilers.registry import get_transpilers
 
 from tests.utils.runtime import execute_transpiled_code

--- a/tests/integration/test_transpile_semantics.py
+++ b/tests/integration/test_transpile_semantics.py
@@ -15,9 +15,9 @@ if not hasattr(importlib, "ModuleType"):
     importlib.ModuleType = types.ModuleType
 
 import pcobra  # noqa: F401
-from core.interpreter import InterpretadorCobra
-from cobra.core import Lexer
-from cobra.core import Parser
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 from pcobra.cobra.transpilers.registry import get_transpilers
 from tests.utils.runtime import execute_transpiled_code
 from tests.utils.targets import BEST_EFFORT_INTERNAL_RUNTIME_TARGETS, OFFICIAL_RUNTIME_TARGETS

--- a/tests/integration/test_transpilers_generation.py
+++ b/tests/integration/test_transpilers_generation.py
@@ -9,7 +9,8 @@ sys.path.insert(0, str(ROOT / "src"))
 
 import pcobra  # noqa: F401
 from pcobra.cobra.transpilers.registry import get_transpilers
-from cobra.core import Lexer, Parser
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 from tests.integration.test_transpile_semantics import obtener_salida_interprete
 from tests.utils.runtime import execute_transpiled_code
 from tests.utils.targets import OFFICIAL_RUNTIME_TARGETS, SUPPORTED_TARGETS


### PR DESCRIPTION
### Motivation

- Tests previously relied on legacy import paths and ad-hoc module monkeypatching to expose AST node classes across packages, which made the test setup fragile. 
- The project now exposes the core lexer/parser under `pcobra.core`, so tests should import those directly to reflect the current package layout. 

### Description

- Replaced imports of `cobra.core.Lexer`/`Parser` and other legacy import shims with direct imports from `pcobra.core.lexer.Lexer` and `pcobra.core.parser.Parser` in integration tests. 
- Removed manual `importlib`/`types` based `ModuleType` fallback and AST node copying logic from `tests/integration/test_cross_backend_output.py`. 
- Adjusted `sys.path` usage in tests to prefer the repository `src` package layout and updated import locations accordingly. 

### Testing

- Ran the integration test files that were changed (`tests/integration/test_cross_backend_output.py`, `tests/integration/test_transpile_semantics.py`, and `tests/integration/test_transpilers_generation.py`) under `pytest`. 
- The affected integration tests executed and the test suite for the modified tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a670706255c8327b9192e36e647affd)