### PR TITLE
test: use canonical imports in Python runtime coverage

### DIFF
--- a/tests/integration/test_runtime_python.py
+++ b/tests/integration/test_runtime_python.py
@@ -1,21 +1,13 @@
 import shutil
 
 import pytest
-import cobra.core as cobra_core
-import core.ast_nodes as core_ast_nodes
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 
 from tests.utils.runtime import run_code
 
-# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
-node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
-core_ast_nodes.__all__ = node_names
-for name in node_names:
-    setattr(cobra_core, name, getattr(core_ast_nodes, name))
-
-from cobra.core import Lexer, Parser
-
 try:
-    from cobra.transpilers.transpiler.to_python import TranspiladorPython
+    from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
 except Exception:  # pragma: no cover - si falla la importación se omite la prueba
     TranspiladorPython = None
 


### PR DESCRIPTION
### Motivation

- Evitar la contaminación de identidades modulares introducida por imports y shims legacy en `tests/integration/test_runtime_python.py`, que provocaba fallos dependientes del orden en `test_cross_backend_output.py`.

### Description

- Sustituye los imports legacy por rutas canónicas importando `Lexer` y `Parser` desde `pcobra.core` y el transpilador Python desde `pcobra.cobra.transpilers.transpiler.to_python`.
- Elimina el shim que exponía y copiaba las clases `Nodo*` desde `core.ast_nodes` a `cobra.core` y la manipulación de `__all__` que provocaba identidades de clase divergentes.
- Mantiene intacta la lógica de las pruebas, la parametrización y las aserciones; el cambio se limita únicamente a `tests/integration/test_runtime_python.py`.

### Testing

- Ejecutado `python -m pytest -q tests/integration/test_runtime_python.py -vv --tb=long -s --maxfail=3` y todas las pruebas del archivo pasaron (3 passed, advertencias por compatibilidad de `ast.Str`).
- Ejecutada la secuencia problemática con `test_runtime_python_ejecucion[codigo_imprimir]` seguida de `test_cross_backend_output[transpiler_case0]` y la ejecución inversa, y ambas órdenes pasaron (2 passed en cada orden dirigido).
- Ejecutada la combinación reducida `tests/integration/test_runtime_python.py` + `tests/integration/test_cross_backend_output.py` y ambas pruebas pasaron (5 passed en la ejecución conjunta relevante).
- Ejecutada una validación más amplia con varias suites relacionadas y se obtuvieron `28 passed, 5 skipped, 2 failed`; los dos fallos son independientes y se producen al recopilar pruebas adicionales no modificadas en este cambio (no se alteró ningún otro archivo de producción ni lexer/parser).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a670f9ebc5883278a60abc7b6ade4ab)