### PR TITLE
Use canonical imports in JavaScript runtime integration test

### DIFF
--- a/tests/integration/test_runtime_js.py
+++ b/tests/integration/test_runtime_js.py
@@ -1,21 +1,13 @@
 import shutil
 
 import pytest
-import cobra.core as cobra_core
-import core.ast_nodes as core_ast_nodes
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 
 from tests.utils.runtime import run_code
 
-# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
-node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
-core_ast_nodes.__all__ = node_names
-for name in node_names:
-    setattr(cobra_core, name, getattr(core_ast_nodes, name))
-
-from cobra.core import Lexer, Parser
-
 try:
-    from cobra.transpilers.transpiler.to_js import (
+    from pcobra.cobra.transpilers.transpiler.to_js import (
         TranspiladorJavaScript as TranspiladorJS,
     )
 except Exception:  # pragma: no cover - si falla la importación se omite la prueba


### PR DESCRIPTION
### Motivation
- El test de runtime JavaScript introducía contaminación modular durante la importación al exponer y copiar clases AST desde rutas legacy, lo que provocaba fallos dependientes del orden en pruebas posteriores.
- Se busca eliminar la contaminación manteniendo comportamiento, parametrización y aserciones del test sin tocar Lexer, Parser ni código de producción.

### Description
- Modifica únicamente `tests/integration/test_runtime_js.py` para usar importaciones canónicas: `from pcobra.core.lexer import Lexer` y `from pcobra.core.parser import Parser` en lugar de las rutas legacy.
- Cambia la importación del transpilador a la ruta canónica `from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript as TranspiladorJS`.
- Elimina la lógica de colección que mutaba `__all__` y copiaba clases `Nodo*` sobre el paquete `cobra.core`, evitando así la creación/mezcla de identidades modulares duplicadas.
- No se cambió ninguna aserción, parametrización, skip ambiental ni archivos de producción, y no se tocaron Lexer ni Parser.

### Testing
- Ejecutado el diagnóstico de importación con `PYTHONPATH="/workspace/pCobra/src${PYTHONPATH:+:$PYTHONPATH}" python /tmp/diagnose_runtime_js_imports.py`, que confirma que tras el cambio las clases AST son provistas solo por `pcobra.core.ast_nodes` y no se importan módulos legacy duplicados.
- Pruebas dirigidas y orden problemático: `python -m pytest -q tests/integration/test_runtime_js.py 'tests/integration/test_cross_backend_output.py::test_cross_backend_output[transpiler_case0]'` y la inversa pasaron (`2 passed, 2 skipped`).
- Validación del archivo modificado: `python -m pytest -q tests/integration/test_runtime_js.py -vv` pasó (`1 passed, 2 skipped`).
- Validación cercana de integración: ejecución combinada de suites relacionadas devolvió `29 passed, 6 skipped, 5 warnings` para el conjunto relevante; la auditoría global mostró 3 fallos preexistentes no relacionados con este cambio (fuera del alcance de esta corrección focused).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67140b7da88327b8ab186edc3ea44f)