### PR TITLE
test: use canonical imports for string equality

### DIFF
--- a/tests/integration/test_interpreter_string_equality.py
+++ b/tests/integration/test_interpreter_string_equality.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 
 import pytest
 
-from cobra.core import Lexer, Parser
-from core.interpreter import InterpretadorCobra
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 
 
 def _parsear_y_ejecutar(codigo: str) -> str:


### PR DESCRIPTION
### Motivation
- Evitar la contaminación de identidad AST provocada por imports legacy durante la recolección de tests que hacía fallar optimizaciones posteriores en `pcobra.core.optimizations.constant_folder`, realizando un cambio mínimo y localizado en la prueba afectada.

### Description
- En `tests/integration/test_interpreter_string_equality.py` se reemplazaron los imports legacy `from cobra.core import Lexer, Parser` y `from core.interpreter import InterpretadorCobra` por las rutas canónicas `from pcobra.core.interpreter import InterpretadorCobra`, `from pcobra.core.lexer import Lexer` y `from pcobra.core.parser import Parser` sin tocar código de producción, Lexer, Parser ni aserciones de la prueba.

### Testing
- Se ejecutaron pruebas automatizadas relevantes: antes del cambio la ejecución aislada `python -m pytest -q tests/integration/test_interpreter_string_equality.py` fallaba con `2 failed` por incompatibilidad de identidad AST; tras el cambio la misma ejecución pasa (`2 passed`), las combinaciones con `tests/integration/test_end_to_end.py::test_end_to_end[python|javascript]` pasan en ambos órdenes (`3 passed, 1 skipped`), la validación cercana con la batería indicada resultó en `31 passed, 6 skipped, 5 warnings`, y la ejecución global con `python -m pytest -q --maxfail=3` alcanzó 3 fallos no relacionados (los dos `end_to_end` afectados por otra contaminación y `test_execute_en_contenedor`), con salida final `3 failed, 343 passed, 6 skipped`; además se verificó `git diff --check` y que solo `tests/integration/test_interpreter_string_equality.py` fue modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67188d03488327b4b00d61f0389c74)