### PR TITLE
test: isolate Go runtime collection from legacy AST modules

### DIFF
--- a/tests/integration/test_runtime_go.py
+++ b/tests/integration/test_runtime_go.py
@@ -1,21 +1,13 @@
 import shutil
 
 import pytest
-import cobra.core as cobra_core
-import core.ast_nodes as core_ast_nodes
 
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
 from tests.utils.runtime import run_code
 
-# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
-node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
-core_ast_nodes.__all__ = node_names
-for name in node_names:
-    setattr(cobra_core, name, getattr(core_ast_nodes, name))
-
-from cobra.core import Lexer, Parser  # noqa: E402
-
 try:
-    from cobra.transpilers.transpiler.to_go import TranspiladorGo  # noqa: E402
+    from pcobra.cobra.transpilers.transpiler.to_go import TranspiladorGo
 except ImportError:
     TranspiladorGo = None
 


### PR DESCRIPTION
### Motivation
- Eliminar la contaminación de identidad AST provocada por un shim de colección en `tests/integration/test_runtime_go.py` que importaba y mutaba módulos legacy (`cobra.core` / `core.ast_nodes`) y que provocaba fallos posteriores en la optimización `constant_folder` durante ejecución de la suite.

### Description
- Se eliminó el shim que importaba `cobra.core` y `core.ast_nodes`, se quitó la construcción de `__all__` y el bucle `setattr` que copiaba las clases `Nodo*`, y se reemplazaron los imports por `from pcobra.core.lexer import Lexer`, `from pcobra.core.parser import Parser` y un `try/except` que intenta `from pcobra.cobra.transpilers.transpiler.to_go import TranspiladorGo` conservando el comportamiento experimental cuando el módulo no está presente.

### Testing
- Pruebas automáticas ejecutadas: `python -m pytest -q tests/integration/test_runtime_go.py` (2 skipped, exit 0), `python -m pytest -q tests/integration/test_runtime_go.py tests/integration/test_end_to_end.py::test_end_to_end[python]` (1 passed, 2 skipped, exit 0), reproducción con ambos backends (python passed, javascript skipped), validación cercana con el conjunto de integraciones relevantes (31 passed, 8 skipped), y corrida global hasta 3 fallos donde se observaron 3 fallos adicionales ajenos al cambio (3 failed, 343 passed, 6 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67604467dc8327b2d253bd51986030)