### PR TITLE
test: use canonical imports in AST contract

### DIFF
--- a/tests/unit/test_ast_contract.py
+++ b/tests/unit/test_ast_contract.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import pytest
 
-from cobra.core import Lexer, Parser
-from core.ast_nodes import (
+from pcobra.core.ast_nodes import (
     NodoBloque,
     NodoBucleMientras,
     NodoCondicional,
     NodoPara,
     NodoValor,
 )
-from core.interpreter import InterpretadorCobra
-from core.utils import ErrorEstructuraAST, validar_ast_estructural
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
+from pcobra.core.utils import ErrorEstructuraAST, validar_ast_estructural
 
 
 def test_ast_falla_si_hay_lista_donde_se_espera_nodo_bloque() -> None:


### PR DESCRIPTION
### Motivation

- Evitar la contaminación de identidades de clases AST que se producía durante la colección al importar módulos legacy desde `core.*` / `cobra.core` y que provocaba fallos posteriores en `constant_folder`.
- Mantener el cambio mínimo y localizado en la prueba que genera la contaminación para no tocar producción, Lexer ni Parser.

### Description

- Se migraron los imports de `tests/unit/test_ast_contract.py` desde rutas legacy a los módulos canónicos: `pcobra.core.ast_nodes`, `pcobra.core.interpreter`, `pcobra.core.lexer`, `pcobra.core.parser` y `pcobra.core.utils`.
- No se modificaron aserciones, mensajes de error, parametrizaciones ni semántica de las pruebas; el cambio es únicamente la sustitución de imports a rutas canónicas.
- No se añadieron shims, manipulación de `sys.modules`, recargas ni cambios en producción.

### Testing

- Ejecutado `python -m pytest -q tests/unit/test_ast_contract.py -vv --tb=long -s --maxfail=3` y la suite del contrato AST pasó `8 passed`.
- Ejecutado combinado con end-to-end Python `python -m pytest -q tests/unit/test_ast_contract.py 'tests/integration/test_end_to_end.py::test_end_to_end[python]'` y la combinación pasó (`9 passed`).
- Ejecutado validación cercana con `python -m pytest -q` sobre el conjunto indicado en la fase 8 y obtuvo `39 passed, 8 skipped, 5 warnings`.
- Ejecución global de la suite mostró fallos previos/independientes fuera del alcance (3 fallos sobre 352 tests totales), documentados como contaminantes posteriores no resueltos por este cambio; los fallos relevantes a la contaminación resuelta aquí ya no aparecen en `test_ast_contract.py` ni durante las combinaciones dirigidas realizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a685d6934e083278dcc825161b5809d)