### PR TITLE
Evita contaminación de identidades AST en la prueba runtime Rust

### DIFF
--- a/tests/integration/test_runtime_rust.py
+++ b/tests/integration/test_runtime_rust.py
@@ -1,27 +1,16 @@
 import shutil
 
 import pytest
-import cobra.core as cobra_core
-import core.ast_nodes as core_ast_nodes
+
+from pcobra.core.lexer import Lexer
+from pcobra.core.parser import Parser
+from pcobra.cobra.transpilers.transpiler.to_rust import TranspiladorRust
 
 from tests.utils.runtime import run_code
 
-# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
-node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
-core_ast_nodes.__all__ = node_names
-for name in node_names:
-    setattr(cobra_core, name, getattr(core_ast_nodes, name))
-
-from cobra.core import Lexer, Parser  # noqa: E402
-
-try:
-    from cobra.transpilers.transpiler.to_rust import TranspiladorRust  # noqa: E402
-except Exception:  # pragma: no cover - si la importación falla se omite la prueba
-    TranspiladorRust = None
-
 
 @pytest.mark.skipif(
-    TranspiladorRust is None or shutil.which("rustc") is None,
+    shutil.which("rustc") is None,
     reason="requiere rustc",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Evitar que una prueba de integración cree shims que carguen el mismo código físico bajo nombres modulares distintos y produzcan clases AST con identidades diferentes durante la colección de Pytest.

### Description

- Modifica `tests/integration/test_runtime_rust.py` para usar las superficies canónicas `pcobra.*` (`from pcobra.core.lexer import Lexer`, `from pcobra.core.parser import Parser`, `from pcobra.cobra.transpilers.transpiler.to_rust import TranspiladorRust`).
- Elimina el shim que importaba `cobra.core` y `core.ast_nodes`, modificaba `core_ast_nodes.__all__` y copiaba clases `Nodo*` con `setattr`, evitando así la creación de identidades AST duplicadas.
- Simplifica la condición de `skip` para depender únicamente de la disponibilidad ambiental real (`rustc`) en lugar de un intento de import dinámico que ocultaba la contaminación.

### Testing

- Se creó una instrumentación temporal en `/tmp/pcobra_find_next_ast_contaminant.py` y fue verificada con `python -m py_compile` para asegurarse de que no accede a `collector.obj`; el plugin registró eventos JSONL en `/tmp/pcobra-next-contaminant.jsonl` y reportó `FIRST_REAL_CLASS_DUPLICATION` durante la colección de `tests/integration/test_runtime_rust.py` antes de la corrección.
- Ejecuciones automatizadas después de la corrección:
  - `python -m pytest -q tests/integration/test_runtime_rust.py -vv --tb=long` → `3 passed`.
  - Reproducciones combinadas (ambos órdenes) que incluyen `tests/integration/test_end_to_end.py` y `tests/integration/test_runtime_rust.py` → `1 passed, 1 skipped, 3 deselected` en ambos órdenes.
  - Suite de validación cercana de 8 archivos (incluye runtimes y `test_end_to_end`) → `20 passed, 5 skipped`.
- Resultado: la instrumentación mostró la duplicación real previa y las ejecuciones posteriores confirman que la eliminación del shim elimina la contaminación y restaura el comportamiento esperado sin tocar `Lexer`, `Parser` ni `constant_folder`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6864c079ac832794be1af606019662)