### PR TITLE
Reduce additional AST import contamination in tests

### DIFF
--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -19,17 +19,13 @@ import pytest
 sys.modules.setdefault("yaml", ModuleType("yaml"))
 sys.modules.setdefault("httpx", ModuleType("httpx"))
 
-import core.ast_nodes as core_ast_nodes
-
-sys.modules.setdefault("cobra.core.ast_nodes", core_ast_nodes)
-
 import pcobra.corelibs as core
 import pcobra.corelibs.sistema as core_sistema
 import pcobra.corelibs.tiempo as core_tiempo
-from cobra.transpilers.import_helper import get_standard_imports
-from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from core.ast_nodes import NodoLlamadaFuncion, NodoValor
+from pcobra.cobra.transpilers.import_helper import get_standard_imports
+from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.core.ast_nodes import NodoLlamadaFuncion, NodoValor
 
 IMPORTS_PY = get_standard_imports("python")
 IMPORTS_JS = "".join(f"{line}\n" for line in get_standard_imports("javascript"))

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -1,8 +1,8 @@
 import pytest
 import logging
-from core.interpreter import InterpretadorCobra, IMPORT_WHITELIST
-from core.semantic_validators.base import ValidadorBase
-from core.ast_nodes import NodoValor
+from pcobra.core.ast_nodes import NodoValor
+from pcobra.core.interpreter import IMPORT_WHITELIST, InterpretadorCobra
+from pcobra.core.semantic_validators.base import ValidadorBase
 
 class DummyError(Exception):
     pass
@@ -10,12 +10,6 @@ class DummyError(Exception):
 class DummyValidator(ValidadorBase):
     def visit_valor(self, nodo):
         raise DummyError('validado')
-
-
-@pytest.fixture(autouse=True)
-def _evitar_limites_reales_en_tests(monkeypatch):
-    monkeypatch.setattr("core.interpreter._lim_cpu", lambda *_: None)
-    monkeypatch.setattr("core.interpreter._lim_mem", lambda *_: None)
 
 
 def test_interpreter_extra_validators_list():

--- a/tests/unit/test_dead_code_integration.py
+++ b/tests/unit/test_dead_code_integration.py
@@ -1,6 +1,6 @@
-from core.interpreter import InterpretadorCobra
-from core.optimizations import remove_dead_code
-from core.ast_nodes import (
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.optimizations import remove_dead_code
+from pcobra.core.ast_nodes import (
     NodoFuncion,
     NodoRetorno,
     NodoAsignacion,
@@ -43,8 +43,8 @@ def test_condicional_constante():
     ast = [
         NodoCondicional(
             NodoValor(False),
-            [NodoAsignacion("x", NodoValor(1))],
-            [NodoAsignacion("y", NodoValor(2))],
+            [NodoAsignacion("x", NodoValor(1), declaracion=True)],
+            [NodoAsignacion("y", NodoValor(2), declaracion=True)],
         )
     ]
     interpreter = InterpretadorCobra()

--- a/tests/unit/test_decoradores_yield.py
+++ b/tests/unit/test_decoradores_yield.py
@@ -1,4 +1,4 @@
-from core.ast_nodes import (
+from pcobra.core.ast_nodes import (
     NodoFuncion,
     NodoDecorador,
     NodoYield,
@@ -6,15 +6,15 @@ from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
 )
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.import_helper import get_standard_imports
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 
 
 def test_transpilar_funcion_con_decorador():
     decorador = NodoDecorador(NodoIdentificador("decor"))
-    func = NodoFuncion("saluda", [], [NodoImprimir(NodoValor("'hola'"))], [decorador])
+    func = NodoFuncion("saluda", [], [NodoImprimir(NodoValor("hola"))], [decorador])
     codigo = TranspiladorPython().generate_code([func])
     esperado = IMPORTS + "@decor\n" + "def saluda():\n    print('hola')\n"
     assert codigo == esperado

--- a/tests/unit/test_generadores.py
+++ b/tests/unit/test_generadores.py
@@ -1,6 +1,6 @@
-from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoYield, NodoValor
-from core.ast_nodes import NodoLlamadaFuncion
-from core.interpreter import InterpretadorCobra
+from pcobra.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoYield, NodoValor
+from pcobra.core.ast_nodes import NodoLlamadaFuncion
+from pcobra.core.interpreter import InterpretadorCobra
 
 
 def test_interpretador_generador_simple():
@@ -14,7 +14,7 @@ def test_interpretador_generador_simple():
 
 def test_generador_limpia_contexto_exactamente_una_vez_en_finally():
     inter = InterpretadorCobra()
-    inter.ejecutar_asignacion(NodoAsignacion("global_previa", NodoValor(7)))
+    inter.ejecutar_asignacion(NodoAsignacion("global_previa", NodoValor(7), declaracion=True))
     contextos_iniciales = len(inter.contextos)
     mem_contextos_iniciales = len(inter.mem_contextos)
 


### PR DESCRIPTION
### Motivation

- Resolver la contaminación de identidad de clases AST que provoca fallos en `test_end_to_end` migrando únicamente los imports de tests que estaban forzando cargas legacy.
- Mantener intacta la producción bajo `src/` (Lexer, Parser, `constant_folder` y clases de AST) y aplicar cambios mínimos en los tests para alinear construcciones de nodos con el contrato runtime.
- Evitar reintroducir shims, aliases o cambios en producción; corregir solo los puntos causales de colección de pruebas.

### Description

- Sustituye imports legacy `core.*`/`cobra.*` por los módulos canónicos `pcobra.*` en cinco módulos de pruebas: `tests/unit/test_corelibs.py`, `tests/unit/test_custom_validators.py`, `tests/unit/test_dead_code_integration.py`, `tests/unit/test_decoradores_yield.py` y `tests/unit/test_generadores.py`.
- Elimina el shim que inyectaba `core.ast_nodes` en `sys.modules` y los parches de tests que replicaban identidades AST; los tests ahora importan directamente desde `pcobra.core.ast_nodes` o desde `pcobra.cobra.transpilers` según corresponda.
- Alinea construcciones de AST en pruebas: marca asignaciones globales creadas por las pruebas como declaraciones (`declaracion=True`) cuando el contrato runtime lo requiere, y ajusta `NodoValor` en un test de decoradores para representar correctamente el literal esperado.
- Remueve un fixture obsoleto que intentaba parchear límites privados inexistentes del intérprete en pruebas de validadores personalizados.

### Testing

- Ejecuté los conjuntos afectados con comandos dirigidos como `python -m pytest -q tests/unit/test_corelibs.py tests/unit/test_custom_validators.py tests/unit/test_dead_code_integration.py tests/unit/test_decoradores_yield.py tests/unit/test_generadores.py -vv --tb=long -s --maxfail=5`, obteniendo **85 passed** en esos archivos modificados.
- Instrumenté la colección de `test_end_to_end` con un plugin de diagnóstico que registró la secuencia de eventos de contaminación (`FIRST_REAL_CLASS_DUPLICATION`, `LEGACY_CONSTANT_FOLDER_CREATED`, `BEFORE_END_TO_END`) y confirmó que las correcciones aplicadas eliminaban las fuentes causales detectadas hasta este punto.
- La ejecución focalizada de end-to-end (`python -m pytest -q -k "test_end_to_end" -vv -s`) todavía falla en la colección global: `tests/integration/test_end_to_end.py::test_end_to_end` reporta `Estructura AST inválida en optimización (constant_folder) en 'NodoImprimir': NodoImprimir`, y la instrumentación apunta ahora a `tests/unit/test_enum.py` como siguiente contaminante dinámico a investigar.
- Estado actual: las cinco correcciones de tests estabilizan sus respectivos reproducciones reducidas (unitarias) pero queda pendiente la corrección del siguiente contaminante identificado dinámicamente en `tests/unit/test_enum.py`, por lo que no se avanzó a las fases de kernel/transpiler ni a las pruebas de equivalencia `run` vs `REPL` hasta resolver ese bloqueador.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a686f84533883278c65add36d7a2a50)