### PR TITLE
Alinear pruebas de enumeraciones con el contrato canónico

### DIFF
--- a/tests/unit/test_enum.py
+++ b/tests/unit/test_enum.py
@@ -1,30 +1,23 @@
-import core.visitor as _vis
-import sys
-
-# Compatibilidad para pruebas
-sys.modules.setdefault("pcobra.core.visitor", _vis)
-sys.modules.setdefault("pcobra.core", sys.modules.get("core"))
-
-from cobra.core import Lexer
-from cobra.core import Parser
-from core.ast_nodes import NodoEnum
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from cobra.transpilers.import_helper import get_standard_imports
+from pcobra.cobra.core import Lexer
+from pcobra.cobra.core import Parser
+from pcobra.core.ast_nodes import NodoEnum
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from pcobra.cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS_PY = get_standard_imports("python")
 IMPORTS_JS = "".join(f"{line}\n" for line in get_standard_imports("javascript"))
 
 
-def test_parser_enum():
-    codigo = "enum Color: ROJO, VERDE fin"
+def test_parser_enumeracion_color():
+    codigo = "enumeracion Color: ROJO, VERDE fin"
     ast = Parser(Lexer(codigo).analizar_token()).parsear()
     assert type(ast[0]).__name__ == "NodoEnum"
     assert ast[0].nombre == "Color"
     assert ast[0].miembros == ["ROJO", "VERDE"]
 
 
-def test_parser_enumeracion_alias():
+def test_parser_enumeracion_estado():
     codigo = "enumeracion Estado: ACTIVO, INACTIVO fin"
     parser = Parser(Lexer(codigo).analizar_token())
     ast = parser.parsear()


### PR DESCRIPTION
### Motivation
- Eliminar la contaminación modular provocada por imports legacy y shims en `tests/unit/test_enum.py` y alinear la prueba con la forma normativa `enumeracion` para evitar duplicidad de identidades AST durante la colección.

### Description
- Se migraron los imports a las rutas canónicas `pcobra.*`, se eliminaron las escrituras en `sys.modules`, y se reemplazó el caso textual `enum` por `enumeracion` renombrando sólo `tests/unit/test_enum.py` y conservando las aserciones y la lógica de transpilación sin tocar Lexer, Parser ni producción.

### Testing
- Se verificó con `python -m pytest -q tests/unit/test_enum.py` (4 passed), ejecuciones focalizadas `python -m pytest -q ... -k "test_end_to_end"` (Python passed, JavaScript skipped), y una validación acumulada `python -m pytest -q` con los casos relevantes (resultado: 90 passed, 1 skipped), mientras la colección global focalizada detectó un siguiente contaminante ajeno que no se modificó en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68762bcc3083278ee3e1830a1d4f81)