### PR TITLE
tests: update imports to `pcobra` package and rename 'with' test to Spanish variant

### DIFF
--- a/tests/unit/test_parser_del_global.py
+++ b/tests/unit/test_parser_del_global.py
@@ -1,17 +1,8 @@
-import sys
-from pathlib import Path
-
 import pytest
 
-ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT))
-import core.visitor as _vis
-sys.modules.setdefault("pcobra.core.visitor", _vis)
-sys.modules.setdefault("pcobra.core", sys.modules.get("core"))
-
-from cobra.core import Lexer
-from cobra.core import Parser, ParserError
-from core.ast_nodes import (
+from pcobra.cobra.core import Lexer
+from pcobra.cobra.core import Parser, ParserError
+from pcobra.core.ast_nodes import (
     NodoDel,
     NodoGlobal,
     NodoNoLocal,
@@ -19,8 +10,8 @@ from core.ast_nodes import (
     NodoPasar,
     NodoIdentificador,
 )
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.import_helper import get_standard_imports
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 
@@ -54,8 +45,8 @@ def test_parser_with():
     assert len(ast[0].cuerpo) == 1 and isinstance(ast[0].cuerpo[0], NodoPasar)
 
 
-def test_parser_with_en():
-    code = "with recurso as r: pasar fin"
+def test_parser_con_alias():
+    code = "con recurso como r: pasar fin"
     ast = Parser(Lexer(code).analizar_token()).parsear()
     assert isinstance(ast[0], NodoWith)
     assert isinstance(ast[0].contexto, NodoIdentificador)


### PR DESCRIPTION
### Motivation

- Align unit tests with the restructured package namespace by importing from the `pcobra` package rather than manipulating `sys.path` and `sys.modules`.
- Remove legacy test bootstrap code and use canonical package imports for clearer test behavior.
- Use Spanish keyword variant for the `with`-style test to match localized language tokens.

### Description

- Replaced ad-hoc `sys.path` and `sys.modules` setup with direct imports from `pcobra.cobra` and `pcobra.core` in `tests/unit/test_parser_del_global.py`.
- Updated imports to `from pcobra.cobra.core import Lexer, Parser, ParserError` and `from pcobra.core.ast_nodes import ...` and updated transpiler/import helper imports accordingly.
- Renamed the test `test_parser_with_en` to `test_parser_con_alias` and adjusted the test input string from `"with recurso as r: pasar fin"` to the localized `"con recurso como r: pasar fin"`.

### Testing

- Ran the modified unit test file with `pytest tests/unit/test_parser_del_global.py` and all assertions in that file passed.
- No other automated tests were run as part of this change and the executed tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6878847c048327a05be8b66520ab93)