### PR TITLE
test: use canonical AST imports in fs access validator

### DIFF
--- a/tests/unit/test_fs_access_validator.py
+++ b/tests/unit/test_fs_access_validator.py
@@ -1,7 +1,7 @@
 import pytest
-from core.semantic_validators.fs_access import ValidadorSistemaArchivos
-from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
-from core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
+from pcobra.core.semantic_validators.fs_access import ValidadorSistemaArchivos
+from pcobra.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from pcobra.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
 
 
 def test_fs_access_funcion_prohibida():


### PR DESCRIPTION
### Motivation

- Corregir un contaminante de identidad AST mínimo que provocaba fallos en `test_end_to_end` al evitar que `tests/unit/test_fs_access_validator.py` cargue `core.ast_nodes` como namespace legacy y duplique clases como `NodoImprimir`.

### Description

- Se migraron los tres imports en `tests/unit/test_fs_access_validator.py` desde `core.*` a `pcobra.core.*` (`core.semantic_validators.fs_access` → `pcobra.core.semantic_validators.fs_access`, `core.semantic_validators.primitiva_peligrosa` → `pcobra.core.semantic_validators.primitiva_peligrosa`, `core.ast_nodes` → `pcobra.core.ast_nodes`) sin cambiar pruebas, AST ni código de producción.

### Testing

- Ejecuté `python -m pytest -q tests/unit/test_fs_access_validator.py -vv --tb=long -s` y obtuvo `2 passed`.
- Reproducciones reducidas con `pytest` que incluyen `tests/integration/test_end_to_end.py` mostraron `test_end_to_end[python]` passing y `test_end_to_end[javascript]` skip ambiental cuando el archivo corregido está presente (`1 passed, 1 skipped`), y la combinación acumulada `tests/unit/test_parser_del_global.py tests/unit/test_fs_access_validator.py tests/integration/test_end_to_end.py` dio `15 passed, 1 skipped`.
- Una colección global focalizada todavía falla por un siguiente contaminante no modificado identificado dinámicamente en `tests/unit/test_hilos.py`, por lo que esta PR resuelve únicamente el contaminante localizado en `tests/unit/test_fs_access_validator.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a687d783cf8832784b4d8cd753b47bd)