### PR TITLE
Corrige contaminación de identidad AST en tests/unit/test_hilos.py

### DIFF
--- a/tests/unit/test_hilos.py
+++ b/tests/unit/test_hilos.py
@@ -3,12 +3,12 @@ from unittest.mock import patch
 import asyncio
 import subprocess
 
-from cobra.core import Token, TipoToken
-from cobra.core import Parser
-from core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoImprimir, NodoIdentificador, NodoAsignacion, NodoFuncion
-from core.interpreter import InterpretadorCobra
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from pcobra.cobra.core import Token, TipoToken
+from pcobra.cobra.core import Parser
+from pcobra.core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoImprimir, NodoIdentificador, NodoAsignacion, NodoFuncion
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 
 
 def test_parser_hilo():
@@ -70,8 +70,12 @@ def test_interpreter_varios_hilos():
 
 def test_hilos_preservan_variables_globales():
     interp = InterpretadorCobra()
-    interp.ejecutar_asignacion(NodoAsignacion('contador', NodoValor(0)))
-    funcion = NodoFuncion('trabajo', [], [NodoAsignacion('contador', NodoValor(5))])
+    interp.ejecutar_asignacion(NodoAsignacion('contador', NodoValor(0), declaracion=True))
+    funcion = NodoFuncion(
+        'trabajo',
+        [],
+        [NodoAsignacion('contador', NodoValor(5), declaracion=True)],
+    )
     interp.ejecutar_funcion(funcion)
     h1 = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion('trabajo', [])))
     h2 = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion('trabajo', [])))


### PR DESCRIPTION
### Motivation
- La colección de Pytest generaba duplicación de clases AST al importar namespaces legacy (`core.*`, `cobra.*`) desde `tests/unit/test_hilos.py`, provocando que `constant_folder` tratara nodos de familias distintas y fallara durante optimizaciones.
- Se requiere una corrección mínima localizada que elimine la creación del namespace legacy durante la colección y preserve las aserciones funcionales existentes.

### Description
- Migra los imports en `tests/unit/test_hilos.py` desde los namespaces legacy a los módulos canónicos: `core.* -> pcobra.core.*` y `cobra.* -> pcobra.cobra.*`.
- Ajusta las asignaciones construidas en las pruebas para marcar explícitamente declaraciones conforme al contrato canónico de `NodoAsignacion` usando `declaracion=True`, evitando efectos secundarios de scope en hilos.
- Cambios limitados únicamente a `tests/unit/test_hilos.py` sin tocar Lexer, Parser, `constant_folder`, nodos de producción ni código en `src/`.

### Testing
- Ejecutado `python -m pytest -q tests/unit/test_hilos.py -vv --tb=long -s` → `8 passed`.
- Ejecutado reproducción reducida con end-to-end: `python -m pytest -q tests/unit/test_hilos.py tests/integration/test_end_to_end.py -k "test_end_to_end" -vv --tb=long -s --maxfail=2` → `1 passed, 1 skipped` (python passed, javascript skip ambiental).
- Ejecutada suite acumulada dirigida: `python -m pytest -q tests/unit/test_parser_del_global.py tests/unit/test_fs_access_validator.py tests/unit/test_hilos.py tests/integration/test_end_to_end.py -vv --tb=long -s --maxfail=3` → `23 passed, 1 skipped`.
- Nota: al ejecutar la colección global focalizada apareció un siguiente contaminante en `tests/unit/test_import_path_security.py` (fuera del alcance de esta corrección) y no fue modificado aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6881d91a808327b52783709abc3a0e)