### PR TITLE
Evita contaminación AST en pruebas de rutas de importación

### DIFF
--- a/tests/unit/test_import_path_security.py
+++ b/tests/unit/test_import_path_security.py
@@ -3,14 +3,14 @@ import builtins
 
 import pytest
 
-from core.ast_nodes import NodoImport
-from core.interpreter import InterpretadorCobra, _ruta_import_permitida
-from core.semantic_validators.import_seguro import ValidadorImportSeguro
-from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from pcobra.core.ast_nodes import NodoImport
+from pcobra.core.interpreter import InterpretadorCobra, _ruta_import_permitida
+from pcobra.core.semantic_validators.import_seguro import ValidadorImportSeguro
+from pcobra.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
 
 
 def _configurar_imports(monkeypatch, modules_dir, whitelist=None):
-    import core.interpreter as interpreter_mod
+    import pcobra.core.interpreter as interpreter_mod
 
     lista = set() if whitelist is None else set(whitelist)
     monkeypatch.setattr(interpreter_mod, "MODULES_PATH", str(modules_dir))


### PR DESCRIPTION
### Motivation
- La colección de pruebas creaba una segunda familia de clases AST al importar módulos con el namespace legacy `core.*`, provocando fallos por identidades de clase distintas (p.ej. `isinstance` false negatives) durante optimizaciones y compilación end-to-end.
- La intención es evitar la ejecución duplicada del módulo de nodos AST y asegurar que los `monkeypatch` en pruebas actúen sobre el mismo módulo canonical usado por el intérprete, sin tocar código de producción ni el lexer/parser.

### Description
- Se migraron los imports en `tests/unit/test_import_path_security.py` de `core.*` a `pcobra.core.*` para usar el namespace canónico de runtime. 
- Se ajustó la importación local en `_configurar_imports` a `import pcobra.core.interpreter as interpreter_mod` para que los `monkeypatch.setattr` modifiquen el mismo módulo que usa `InterpretadorCobra` en runtime.
- No se realizaron cambios en `src/`, `constant_folder`, `lexer` ni `parser`, ni se modificaron aserciones, skips o el comportamiento funcional de las pruebas.

### Testing
- Ejecuté `python -m pytest -q tests/unit/test_import_path_security.py -vv --tb=long -s` y obtuvo `5 passed`.
- Ejecuté reproducciones dirigidas con end-to-end: `python -m pytest -q tests/unit/test_import_path_security.py tests/integration/test_end_to_end.py -k "test_end_to_end" -vv --tb=long -s --maxfail=2` y cada orden devolvió `1 passed, 1 skipped`.
- Suite dirigida acumulada con `tests/unit/test_parser_del_global.py tests/unit/test_fs_access_validator.py tests/unit/test_hilos.py tests/unit/test_import_path_security.py tests/integration/test_end_to_end.py` retornó `28 passed, 1 skipped`.
- La colección global aún muestra contaminación adicional fuera del alcance de este cambio en ejecuciones focalizadas (`2 failed` en otra colección global), por lo que se recomienda auditar `tests/unit/test_import_path_security.py` y el siguiente contaminante de forma aislada si se continúa con estabilización completa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68847153708327a8d823a0af297bed)