### PR TITLE
Evita contaminación de identidad AST en el validador de imports

### DIFF
--- a/tests/unit/test_import_seguro_validator.py
+++ b/tests/unit/test_import_seguro_validator.py
@@ -1,16 +1,16 @@
 import pytest
 from types import SimpleNamespace
-from core.semantic_validators.import_seguro import ValidadorImportSeguro
-from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
-from core.ast_nodes import NodoImport
-from core.interpreter import InterpretadorCobra, IMPORT_WHITELIST
+from pcobra.core.semantic_validators.import_seguro import ValidadorImportSeguro
+from pcobra.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from pcobra.core.ast_nodes import NodoImport
+from pcobra.core.interpreter import InterpretadorCobra, IMPORT_WHITELIST
 
 
 def test_import_seguro_fuera_de_ruta(tmp_path, monkeypatch):
     validator = ValidadorImportSeguro()
     nodo = NodoImport(str(tmp_path / "m.co"))
-    monkeypatch.setattr('core.interpreter.MODULES_PATH', str(tmp_path / 'mods'))
-    monkeypatch.setattr('core.interpreter.IMPORT_WHITELIST', set())
+    monkeypatch.setattr('pcobra.core.interpreter.MODULES_PATH', str(tmp_path / 'mods'))
+    monkeypatch.setattr('pcobra.core.interpreter.IMPORT_WHITELIST', set())
     with pytest.raises(PrimitivaPeligrosaError):
         nodo.aceptar(validator)
 


### PR DESCRIPTION
### Motivation
- Localizar y eliminar una fuente dinámica de duplicación de identidades de clases AST detectada durante la colección de tests, sin modificar Lexer/Parser ni `constant_folder`.
- Evitar que un archivo de prueba cargue el mismo código de `ast_nodes` bajo dos nombres modulares distintos, lo que provoca fallos por `isinstance`/contratos estructurales.
- Añadir instrumentación de solo lectura para identificar con precisión el último archivo sano y el primer archivo con duplicación antes de actuar.

### Description
- Añade un plugin de diagnóstico de solo lectura en `/tmp/pcobra_find_next_ast_contaminant.py` que registra eventos de colección en `/tmp/pcobra-next-contaminant.jsonl` y `/tmp/pcobra-collection-timeline.jsonl` y calcula comparaciones `legacy.X is canonical.X` para las clases AST clave.
- Corrige `tests/unit/test_import_seguro_validator.py` sustituyendo imports legacy `core.*` por los canónicos `pcobra.core.*` y actualizando las rutas usadas en `monkeypatch` para apuntar al módulo canónico `pcobra.core.interpreter`.
- No se tocan Lexer, Parser, `constant_folder`, ni código bajo `src/` más allá de los imports en la prueba, y no se introducen escrituras en `sys.modules` ni modificaciones de `sys.path`.

### Testing
- Ejecutado `python -m pytest -q tests/unit/test_hilos.py tests/unit/test_parser_del_global.py tests/unit/test_fs_access_validator.py -vv --tb=long -s` y obtuvo `22 passed`.
- Ejecutado `python -m pytest -q tests/unit/test_import_seguro_validator.py -vv --tb=long -s` tras la corrección y obtuvo `3 passed`.
- Ejecutado `python -m pytest -q tests/integration/test_end_to_end.py -k "test_end_to_end" -vv --tb=long -s` en control aislado y obtuvo `1 passed, 1 skipped`; la colección global focalizada aún muestra `2 failed, 3 skipped, 4712 deselected` indicando otro contaminante posterior no modificado en este cambio.
- Verificada la compilación del plugin con `python -m py_compile /tmp/pcobra_find_next_ast_contaminant.py` y realizada la comprobación de operaciones prohibidas por `grep`, ambas exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a688f0aab588327a77eab28c1a27cd0)