### PR TITLE
Evita contaminación de identidad AST en pruebas de inlining

### DIFF
--- a/tests/unit/test_inlining_transpilers.py
+++ b/tests/unit/test_inlining_transpilers.py
@@ -1,8 +1,14 @@
 import pytest
-from core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoAsignacion, NodoLlamadaFuncion
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from cobra.transpilers.import_helper import get_standard_imports
+from pcobra.core.ast_nodes import (
+    NodoFuncion,
+    NodoRetorno,
+    NodoValor,
+    NodoAsignacion,
+    NodoLlamadaFuncion,
+)
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from pcobra.cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 


### PR DESCRIPTION
### Motivation

- La prueba `tests/unit/test_inlining_transpilers.py` importaba módulos legacy (`core.*` y `cobra.*`) que ejecutaban `src/pcobra/core/ast_nodes.py` bajo dos nombres modulares distintos, produciendo duplicación de identidad de clases AST y fallos en las comprobaciones de `isinstance` durante optimizaciones.

### Description

- Sustituye exclusivamente los cuatro imports legacy en `tests/unit/test_inlining_transpilers.py` por sus rutas canónicas bajo `pcobra` (nodos AST y transpiladores), sin cambiar ninguna otra lógica del archivo ni añadir aliases o shims.
- Se creó un probe observacional fuera del repositorio en `/tmp/pcobra_identity_probe.py` para inspeccionar `sys.modules`, IDs de módulos y la identidad de las clases antes/after de la colección; el probe no altera el entorno.
- No se modificó `src/`, `Lexer`, `Parser`, `constant_folder` ni producción; la intención y las aserciones de las pruebas permanecen intactas.

### Testing

- Prueba focalizada previa (sin cambios) mostró el fallo replicado: `python -m pytest -q tests/unit/test_inlining_transpilers.py -vv --tb=long -s` => `2 failed` (RuntimeError en `constant_folder`).
- Tras el cambio, `python -m pytest -q tests/unit/test_inlining_transpilers.py -vv --tb=long -s` => `2 passed`.
- Orden combinado con end-to-end: ejecutar `tests/unit/test_inlining_transpilers.py` antes/ después de `tests/integration/test_end_to_end.py` produjo resultados consistentes (`1 passed, 1 skipped, 2 deselected` según la selección de backend JS preexistente) y ya no depende del orden de colección.
- Validación acumulada cercana (`tests/unit/test_import_seguro_validator.py`, `tests/unit/test_imports_alias_clase.py`, `tests/unit/test_inlining_transpilers.py`, `tests/integration/test_end_to_end.py`) resultó en `8 passed, 1 skipped`.
- Colección focalizada y global instrumentadas con el probe mostraron que `tests/unit/test_inlining_transpilers.py` dejó de provocar la transición `healthy -> duplicated` y que `pcobra.core.ast_nodes` permanece como la única identidad canónica durante su colección.
- Se detectó un contaminante independiente posterior en la colección global: `tests/unit/test_interactive_block_depth.py` pasa de sano a duplicado al coleccionarlo; este contaminante fue identificado pero no se corrigió en esta tarea.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69acb16b9c83278e1cd96fdddef34c)