### PR TITLE
Canonicaliza imports en test_interactive_block_depth para evitar contaminación AST

### DIFF
--- a/tests/unit/test_interactive_block_depth.py
+++ b/tests/unit/test_interactive_block_depth.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cobra.cli.commands.interactive_cmd import InteractiveCommand
-from cobra.core import ParserError
-from core.interpreter import InterpretadorCobra
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.core import ParserError
+from pcobra.core.interpreter import InterpretadorCobra
 
 
 def _args() -> SimpleNamespace:
@@ -39,7 +39,7 @@ def test_multilinea_con_bloque_completo_se_ejecuta_una_vez() -> None:
         except StopIteration as exc:
             raise EOFError from exc
 
-    with patch("cobra.cli.commands.interactive_cmd.validar_dependencias"), patch.object(
+    with patch("pcobra.cobra.cli.commands.interactive_cmd.validar_dependencias"), patch.object(
         cmd,
         "ejecutar_codigo",
     ) as mock_ejecutar:
@@ -65,7 +65,7 @@ def test_lineas_en_blanco_se_ignoran_sin_romper_el_bloque() -> None:
         except StopIteration as exc:
             raise EOFError from exc
 
-    with patch("cobra.cli.commands.interactive_cmd.validar_dependencias"), patch.object(
+    with patch("pcobra.cobra.cli.commands.interactive_cmd.validar_dependencias"), patch.object(
         cmd,
         "ejecutar_codigo",
     ) as mock_ejecutar:


### PR DESCRIPTION
### Motivation

- La prueba `tests/unit/test_interactive_block_depth.py` importaba un módulo legacy (`core.interpreter`) que cargaba `src/pcobra/core/ast_nodes.py` bajo un nombre distinto, duplicando identidades de clases AST y provocando fallos por mezcla de `pcobra.core.ast_nodes` y `core.ast_nodes` durante la colección.
- Se buscó la corrección mínima para evitar la contaminación de identidad modular / AST sin tocar código de producción, lexer, parser ni optimizaciones.

### Description

- Se reemplazaron los tres imports internos legacy en `tests/unit/test_interactive_block_depth.py` por sus rutas canónicas: `pcobra.cobra.cli.commands.interactive_cmd`, `pcobra.cobra.core` y `pcobra.core.interpreter`.
- Se migraron los objetivos textuales de `patch(...)` que apuntaban a `cobra.cli.commands.interactive_cmd.validar_dependencias` hacia el módulo canónico realmente consultado por `InteractiveCommand` (`pcobra.cobra.cli.commands.interactive_cmd.validar_dependencias`).
- No se modificó ninguna otra lógica de las pruebas: se conservaron los nueve tests, nombres, aserciones, entradas, `_args`, parches sobre objetos y el comportamiento del REPL.

### Testing

- Se verificó la base previa con `python -m pytest -q tests/unit/test_inlining_transpilers.py` y obtuvo `2 passed` antes de cambios.
- Reproducción previa al cambio de `tests/unit/test_interactive_block_depth.py` mostró `6 passed, 3 failed` por contaminación AST (evidencia antes del arreglo).
- Tras el cambio, `python -m pytest -q tests/unit/test_interactive_block_depth.py -vv -s` devolvió `9 passed` (archivo aislado).
- Ejecutadas comprobaciones de integración y orden: `pytest` combinando `tests/unit/test_interactive_block_depth.py` y `tests/integration/test_end_to_end.py` en ambos órdenes resultó en `1 passed, 1 skipped, 9 deselected` y sin fallos de identidad AST; la suite cercana combinada produjo `17 passed, 1 skipped`.
- Se añadió un probe observacional temporal (fuera del repo) y una colección instrumentada que confirmó que el archivo corregido ya no introduce `core.ast_nodes` ni duplicaciones; la siguiente contaminación independiente localizada quedó en `tests/unit/test_interactive_cmd_repl_pipeline_coupling.py` (no fue modificada aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b2ff55248327a402a40d064a88f2)