### PR TITLE
Canonicaliza imports de interfaz para evitar duplicación AST

### DIFF
--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -1,9 +1,9 @@
-from cobra.core import Lexer
-from cobra.core import Parser
-from core.ast_nodes import NodoInterface, NodoClase
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from pcobra.cobra.core import Lexer
+from pcobra.cobra.core import Parser
+from pcobra.core.ast_nodes import NodoInterface, NodoClase
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from pcobra.cobra.transpilers.transpiler.to_rust import TranspiladorRust
 
 CODIGO = """
 interface Printable:


### PR DESCRIPTION
### Motivation
- Durante la colección Pytest `tests/unit/test_interface.py` cargaba `src/pcobra/core/ast_nodes.py` también como `core.ast_nodes`, lo que creaba dos módulos distintos con clases AST incompatibles y provocaba un fallo de `isinstance` en la recolección; la corrección busca evitar esa contaminación de identidad usando las rutas canónicas.

### Description
- Se actualizan los imports en `tests/unit/test_interface.py` para usar las rutas canónicas `pcobra.*` (Lexer, Parser, clases AST y transpiladores) y así evitar la importación accidental como `core.ast_nodes` en tiempo de colección.
- No se cambia código de producción, ni Lexer/Parser/constant_folder, ni se modifican nombres de pruebas, aserciones o parametrizaciones.
- El cambio es mínimo y limitado al archivo `tests/unit/test_interface.py`.

### Testing
- Antes del arreglo la ejecución aislada de `tests/unit/test_interface.py` devolvía 1 passed / 1 failed debido a la desalineación de identidad AST; la sonda observacional mostró `legacy_present=True` y `parent_aligned=False` después de la colección del archivo.
- Tras el cambio, `tests/unit/test_interface.py` pasó aislado con `2 passed`, y la sonda indicó `canonical_present=True`, `legacy_present=False`, `parent_aligned=True` tanto antes como después de la colección focalizada.
- Se ejecutaron comparaciones con `tests/integration/test_end_to_end.py` en ambos órdenes y obtuvieron `1 passed, 1 skipped` (skip JavaScript preexistente) sin errores de identidad AST.
- Validación acumulada sobre el conjunto afectado terminó con `24 passed, 1 skipped` y la colección global instrumentada completó (4714 tests recopilados) localizando el siguiente contaminante independiente en `tests/unit/test_interpreter.py`, que no se corrigió en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69be7f667c8327bb8e535009dd0814)