### PR TITLE
Canonicaliza imports del intérprete para evitar duplicación AST

### DIFF
--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -2,10 +2,10 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from core.interpreter import InterpretadorCobra
-from core.environment import Environment
-from cobra.core import Token, TipoToken
-from core.ast_nodes import (
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.environment import Environment
+from pcobra.core.lexer import Token, TipoToken
+from pcobra.core.ast_nodes import (
     NodoAsignacion,
     NodoDel,
     NodoFuncion,
@@ -611,7 +611,7 @@ def test_mode_se_restaura_en_import_si_falla_validacion(monkeypatch):
     inter = InterpretadorCobra()
     modo_inicial = inter.mode
 
-    monkeypatch.setattr("core.interpreter.cargar_ast_modulo", lambda *a, **k: [NodoValor(1)])
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", lambda *a, **k: [NodoValor(1)])
 
     def _falla_validacion(_nodo):
         raise RuntimeError("validacion import")
@@ -630,7 +630,7 @@ def test_mode_se_restaura_en_import_si_falla_ejecucion(monkeypatch):
     inter = InterpretadorCobra()
     modo_inicial = inter.mode
 
-    monkeypatch.setattr("core.interpreter.cargar_ast_modulo", lambda *a, **k: [NodoValor(3)])
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", lambda *a, **k: [NodoValor(3)])
     monkeypatch.setattr(inter, "_validar", lambda _nodo: None)
 
     def _falla_ejecucion(_nodo):


### PR DESCRIPTION
### Motivation

- Durante la colección de `tests/unit/test_interpreter.py` se detectó que el mismo fichero físico `src/pcobra/core/ast_nodes.py` se cargaba bajo dos identities (`pcobra.core.ast_nodes` y `core.ast_nodes`), provocando contaminación de identidad AST y fallos de `isinstance`/comparación de clases.

### Description

- Se canonicalizaron los imports en `tests/unit/test_interpreter.py` para usar los módulos canónicos `pcobra.core.*` en lugar de los legacy `core.*` y `cobra.core` (se cambiaron `InterpretadorCobra`, `Environment`, `Token`, `TipoToken` y la importación de nodos AST a `pcobra.core.*`).
- Se actualizaron los objetivos textuales de `monkeypatch.setattr(...)` que apuntaban a `core.interpreter.cargar_ast_modulo` para que apunten a `pcobra.core.interpreter.cargar_ast_modulo`, asegurando que los parches actúen sobre el módulo canónico.
- Sólo se modificó `tests/unit/test_interpreter.py`; no se tocó código de producción, `Lexer`, `Parser` ni `constant_folder`.

### Testing

- Se ejecutó `python -m pytest -q tests/unit/test_interpreter.py --collect-only -p pcobra_test_interpreter_probe -s` y la colección fue `36` pruebas con estado `BEFORE`/`AFTER` mostrando `canonical_present=True legacy_present=False parent_aligned=True` (la contaminación quedó resuelta durante la colección focalizada).
- Se ejecutó `python -m pytest -q tests/unit/test_interpreter.py -vv --tb=long -s` y la suite mostró que la duplicación de módulos ya no aparece, aunque quedaron 5 fallos funcionales preexistentes no causados por mezcla de identidades (tests: `test_asignacion_y_operacion_aritmetica`, `test_with_limpia_contexto_y_memoria_en_retorno_temprano`, `test_mode_se_restaura_en_import_si_falla_validacion`, `test_longitud_recibe_lista_literal_como_argumento`, `test_lista_literal_evalua_elementos_recursivos`) que permanecen sin vinculación a la contaminación modular.
- Se ejecutaron comparaciones end-to-end y colecciones mayores: `tests/integration/test_end_to_end.py` vs `tests/unit/test_interpreter.py` (ambos órdenes) y una colección global instrumentada; la colección global localizó el siguiente contaminante independiente en `tests/unit/test_interpreter_atributo.py` (detectado pero no modificado en este PR).
- Verificaciones de integridad: `git diff --check` mostró cero problemas y no se modificaron archivos protegidos (`src/pcobra/core/lexer.py`, `src/pcobra/core/parser.py`, `src/pcobra/core/optimizations/constant_folder.py` y demás producción).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69c1a1f7508327951aed2a722acf12)