### PR TITLE
Corrige contratos de ejecución en el intérprete: asignaciones, with, imports y builtins

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -88,6 +88,7 @@ from .usar_symbol_policy import (
     validate_usar_symbol_metadata,
 )
 from .environment import Environment
+from pcobra.corelibs.datos import longitud
 from pcobra.cobra.usar_loader import descubrir_raiz_proyecto
 
 MODULES_PATH = _DEFAULT_MODULES_PATH
@@ -589,6 +590,7 @@ class InterpretadorCobra:
         self._validados = set()
         # Pila de entornos para mantener variables locales en cada llamada
         self.contextos = [Environment()]
+        self.funciones_nativas = {"longitud": longitud}
         # Mapa paralelo para gestionar bloques de memoria por contexto
         self.mem_contextos = [{}]
         # Gestor genético de estrategias de memoria
@@ -597,6 +599,7 @@ class InterpretadorCobra:
         self.op_memoria = 0
         self._eval_stack = set()
         self._call_depth = 0
+        self._with_return_depth = 0
         # Funciones Cobra declaradas en el AST fuente. Se mantiene separada del
         # entorno de variables para que los optimizadores puedan eliminar nodos
         # ``NodoFuncion`` sin impedir que sus nombres sigan siendo resolubles
@@ -1720,10 +1723,18 @@ class InterpretadorCobra:
             self.evaluar_expresion(nodo.contexto)
             self.contextos.append(Environment(parent=self.contextos[-1]))
             self.mem_contextos.append({})
+            capturar_retorno = self._call_depth == 0
+            self._with_return_depth += 1
             try:
-                for instr in nodo.cuerpo:
-                    self.ejecutar_nodo(instr)
+                try:
+                    for instr in nodo.cuerpo:
+                        self.ejecutar_nodo(instr)
+                except _ControlRetorno as retorno:
+                    if not capturar_retorno:
+                        raise
+                    return retorno.valor
             finally:
+                self._with_return_depth -= 1
                 memoria_local = self.mem_contextos.pop()
                 for idx, tam in memoria_local.values():
                     self.liberar_memoria(idx, tam)
@@ -1735,7 +1746,7 @@ class InterpretadorCobra:
         elif isinstance(nodo, NodoHilo):
             return self.ejecutar_hilo(nodo)
         elif isinstance(nodo, NodoRetorno):
-            if self._call_depth == 0:
+            if self._call_depth == 0 and self._with_return_depth == 0:
                 raise RuntimeError("retorno fuera de función")
             raise _ControlRetorno(self.evaluar_expresion(nodo.expresion))
         elif isinstance(nodo, NodoRomper):
@@ -1751,8 +1762,8 @@ class InterpretadorCobra:
 
     def ejecutar_asignacion(self, nodo, visitados=None):
         """Evalúa una asignación de variable o atributo."""
-        # Contrato: una declaración (`var`/`variable`) solo muta contexto y nunca
-        # devuelve señal de control para cortar un bloque.
+        # El valor de una asignación es un resultado ordinario. El control de
+        # flujo se propaga exclusivamente mediante las señales _Control*.
         visitados = set() if visitados is None else visitados
         nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
         valor_nodo = getattr(nodo, "expresion", getattr(nodo, "valor", None))
@@ -1778,9 +1789,7 @@ class InterpretadorCobra:
                 indice = self.solicitar_memoria(1)
                 self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                 self.contextos[-1].define(nombre, valor)
-                # Contrato explícito: toda declaración muta estado local y
-                # devuelve ``None`` (nunca señal de control).
-                return None
+                return valor
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
@@ -1800,9 +1809,7 @@ class InterpretadorCobra:
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                     self.contextos[-1].set(nombre, valor)
-        # Igual que una declaración, una reasignación solo muta estado y nunca
-        # debe propagarse como señal de control dentro de bloques/bucles.
-        return None
+        return valor
 
     def evaluar_expresion(self, expresion, visitados=None):
         """Resuelve el valor de una expresión de forma recursiva.
@@ -2291,7 +2298,12 @@ class InterpretadorCobra:
                 if emitir_salida_llamada:
                     print(valor)
         else:
-            funcion = self.obtener_variable(nodo.nombre)
+            try:
+                funcion = self.obtener_variable(nodo.nombre)
+            except NameError:
+                if nodo.nombre not in self.funciones_nativas:
+                    raise
+                funcion = self.funciones_nativas[nodo.nombre]
 
             if callable(funcion):
                 argumentos_resueltos = []
@@ -2526,7 +2538,13 @@ class InterpretadorCobra:
         self._current_module_stack.append(ruta_canonica)
         try:
             for subnodo in ast:
-                self.ejecutar_nodo(subnodo)
+                modo_previo = self._set_mode("analysis")
+                try:
+                    self._validar(subnodo)
+                    self._set_mode("execution")
+                    self.ejecutar_nodo(subnodo)
+                finally:
+                    self._set_mode(modo_previo)
         finally:
             self._current_module_stack.pop()
             self._import_execution_stack.pop()


### PR DESCRIPTION
### Motivation

- Resolver cinco fallos reproducibles en `tests/unit/test_interpreter.py` relacionados con el valor devuelto por asignaciones, retornos tempranos en `with`, restauración de `mode` en imports y disponibilidad de la función nativa `longitud`.
- Mantener cambios mínimos y localizados en producción para preservar contratos semánticos existentes y no tocar Lexer/Parser ni otras áreas prohibidas.

### Description

- Asignaciones: `ejecutar_asignacion` ahora devuelve el valor materializado de la expresión asignada en lugar de `None`, manteniendo la separación entre valores ordinarios y señales de control internas (`_Control*`). (modificación en `src/pcobra/core/interpreter.py`)
- With/retorno: `NodoWith` establece una frontera que captura `_ControlRetorno` en el caso top-level solicitado, garantiza limpieza de `mem_contextos` y `contextos` en `finally`, y relanza la señal cuando el `with` está dentro de una llamada para que el retorno siga aplicando a la función contenedora.
- Imports/validación: `ejecutar_import` ahora valida cada subnodo en modo `analysis` antes de ejecutarlo en `execution`, usando un `try/finally` para restaurar siempre el `mode`, de modo que errores de validación se propaguen y el `mode` anterior se restaure.
- Builtins separadas: se registra `longitud` desde `pcobra.corelibs.datos` en un mapa `funciones_nativas` separado y `ejecutar_llamada_funcion` consulta primero el entorno léxico y sólo ante `NameError` recurre a `funciones_nativas`, evitando colisiones con `usar`/bindings de usuario.
- Alcance del cambio: único archivo modificado `src/pcobra/core/interpreter.py`; no se cambió Lexer, Parser, gramática ni `constant_folder`.

### Testing

- Ejecuté las pruebas focales y suites relacionadas de forma automatizada con `pytest` y probe de colección; comandos clave ejecutados y resultados:
  - `python -m pytest -q tests/unit/test_interpreter.py` — 36 passed.
  - Pruebas focales de los cinco fallos: `test_asignacion_y_operacion_aritmetica`, `test_with_limpia_contexto_y_memoria_en_retorno_temprano`, `test_mode_se_restaura_en_import_si_falla_validacion`, `test_longitud_recibe_lista_literal_como_argumento`, `test_lista_literal_evalua_elementos_recursivos` — todas pasaron en ejecuciones individuales.
  - Llamadas agrupadas solicitadas y órdenes end-to-end: ambos órdenes con `test_end_to_end` resultaron en `1 passed, 1 skipped` (condición esperada en la prueba) y el conjunto acumulado pedido terminó `60 passed, 1 skipped`.
  - Regresiones e integridad: pruebas de imports y `usar` relacionadas (por ejemplo, `tests/unit/test_project_root_usar_resolution.py`, `tests/unit/test_import_path_security.py`) ejecutadas; regresiones comprobadas pasaron (ej.: 12 passed en el bloque investigado).
  - Colección global observacional con probe: `4714 tests collected`; la contaminación modular independiente sigue siendo `tests/unit/test_interpreter_atributo.py` según la recolección (no se modificó dicho archivo en este PR).
  - Comprobación estática: `python -m py_compile src/pcobra/core/interpreter.py` y `git diff --check` sin errores; archivos restringidos no fueron modificados.

Cambios verificados por pruebas automatizadas y colecciones focales; no se introdujeron cambios en tests ni en módulos prohibidos por las reglas del repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69c55ef61c83279518856aaf3dec35)