### PR TITLE
Evita contaminación AST en pruebas concurrentes del intérprete

### DIFF
--- a/tests/unit/test_interpreter_concurrency.py
+++ b/tests/unit/test_interpreter_concurrency.py
@@ -1,6 +1,6 @@
 import pytest
-from core.interpreter import InterpretadorCobra
-from core.ast_nodes import (
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.ast_nodes import (
     NodoAsignacion,
     NodoValor,
     NodoFuncion,


### PR DESCRIPTION
### Motivation
- Durante la colección la prueba `tests/unit/test_interpreter_concurrency.py` importaba rutas legacy (`core.interpreter` / `core.ast_nodes`) que creaban una segunda identidad modular y clases AST duplicadas, desalineando el paquete padre y contaminando la colección.

### Description
- Se reemplazaron las dos importaciones legacy por las rutas canónicas en el propio test: `from core.interpreter` → `from pcobra.core.interpreter` y `from core.ast_nodes` → `from pcobra.core.ast_nodes`, sin tocar producción ni la lógica concurrente.

### Testing
- Ejecuté la colección focal (`pytest --collect-only`) y la ejecución del test modificado; la colección ya no produce módulos legacy (`legacy_present=False`, `parent_aligned=True`) según el probe temporal, y la prueba sigue fallando por el mismo fallo funcional preexistente `NameError: Variable no declarada: contador` (fallo no relacionado con la contaminación); además validé la colección global con el probe y la integridad de `src/` y realicé el commit focal correspondiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69cca069848327b04c4b181ec5bd78)