### PR TITLE
Corrige literales de cadena, asignaciones iniciales y evita contaminación modular del intérprete

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1,5 +1,6 @@
 """Implementación del intérprete del lenguaje Cobra."""
 
+import ast
 import logging
 import os
 import hashlib
@@ -272,6 +273,19 @@ class InterpretadorCobra:
         """Imprime trazas internas solo cuando el modo debug está activo."""
         if self.in_execution() and self._debug_trazas_habilitadas():
             print(mensaje)
+
+    @staticmethod
+    def _valor_literal(valor):
+        """Convierte representaciones textuales válidas de cadenas a runtime."""
+        if not isinstance(valor, str) or len(valor) < 2:
+            return valor
+        if valor[0] not in {"'", '"'} or valor[-1] != valor[0]:
+            return valor
+        try:
+            normalizado = ast.literal_eval(valor)
+        except (SyntaxError, ValueError):
+            return valor
+        return normalizado if isinstance(normalizado, str) else valor
 
     @staticmethod
     def _registrar_auditoria_validador(
@@ -600,6 +614,10 @@ class InterpretadorCobra:
         self._eval_stack = set()
         self._call_depth = 0
         self._with_return_depth = 0
+        import threading
+
+        self._thread_execution_lock = threading.RLock()
+        self._thread_isolation_depth = 0
         # Funciones Cobra declaradas en el AST fuente. Se mantiene separada del
         # entorno de variables para que los optimizadores puedan eliminar nodos
         # ``NodoFuncion`` sin impedir que sus nombres sigan siendo resolubles
@@ -1410,7 +1428,12 @@ class InterpretadorCobra:
                 if isinstance(actual, NodoIdentificador):
                     if actual.nombre == nombre:
                         # Permite patrones válidos como ``x = x + 1`` usando el
-                        # valor previamente materializado en el entorno actual.
+                        # valor previamente materializado en el entorno actual;
+                        # sin un binding previo, ``x = x`` sí es un ciclo.
+                        if not self.contextos[-1].contains(nombre):
+                            raise RuntimeError(
+                                f"Ciclo de variables detectado en '{nombre}'"
+                            )
                         continue
                     self._resolver_identificador(actual.nombre, visitados)
                     continue
@@ -1793,11 +1816,8 @@ class InterpretadorCobra:
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
-                    if self._call_depth == 0:
-                        raise NameError(f"Variable no declarada: {nombre}")
-                    # Una asignación simple dentro de una función introduce un
-                    # nombre local cuando no existe en su cadena léxica. Este
-                    # contexto permanece activo durante todo el cuerpo.
+                    # La primera asignación introduce el nombre en el entorno
+                    # activo; las lecturas siguen exigiendo que ya exista.
                     indice_contexto = len(self.mem_contextos) - 1
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
@@ -1845,14 +1865,14 @@ class InterpretadorCobra:
                 )
 
             if isinstance(expresion, NodoValor):
-                return expresion.valor  # Obtiene el valor directo si es un NodoValor
+                return self._valor_literal(expresion.valor)
             elif isinstance(expresion, Token) and expresion.tipo in {
                 TipoToken.ENTERO,
                 TipoToken.FLOTANTE,
                 TipoToken.CADENA,
                 TipoToken.BOOLEANO,
             }:
-                return expresion.valor  # Si es un token de tipo literal, devuelve su valor
+                return self._valor_literal(expresion.valor)
             elif isinstance(expresion, NodoAsignacion):
                 # Resuelve asignaciones anidadas y devuelve su valor
                 return self.ejecutar_asignacion(expresion, visitados)
@@ -2247,6 +2267,11 @@ class InterpretadorCobra:
         entorno_capturado = funcion.get(
             "scope_lexico", funcion.get("entorno", self.contextos[-1])
         )
+        if self._thread_isolation_depth:
+            entorno_capturado = Environment(
+                values=dict(entorno_capturado.values),
+                parent=entorno_capturado.parent,
+            )
         self.contextos.append(Environment(parent=entorno_capturado))
         self.mem_contextos.append({})
         try:
@@ -2349,6 +2374,11 @@ class InterpretadorCobra:
                 entorno_capturado = funcion.get(
                     "scope_lexico", funcion.get("entorno", self.contextos[-1])
                 )
+                if self._thread_isolation_depth:
+                    entorno_capturado = Environment(
+                        values=dict(entorno_capturado.values),
+                        parent=entorno_capturado.parent,
+                    )
                 self.contextos.append(Environment(parent=entorno_capturado))
                 self.mem_contextos.append({})
                 for nombre_param, valor in zip(parametros, argumentos_resueltos):
@@ -2784,7 +2814,16 @@ class InterpretadorCobra:
         import threading
 
         def destino():
-            self.ejecutar_llamada_funcion(nodo.llamada)
+            # Las llamadas concurrentes comparten el intérprete, pero cada
+            # hilo ejecuta la función sobre una vista aislada de su entorno
+            # capturado. El bloqueo protege las pilas internas de contextos y
+            # memoria, que son estructuras compartidas y no thread-local.
+            with self._thread_execution_lock:
+                self._thread_isolation_depth += 1
+                try:
+                    self.ejecutar_llamada_funcion(nodo.llamada)
+                finally:
+                    self._thread_isolation_depth -= 1
 
         # El hilo se marca como daemon para evitar que bloquee el cierre del
         # intérprete si queda en ejecución al finalizar el programa.

--- a/tests/unit/test_interpreter_cycles.py
+++ b/tests/unit/test_interpreter_cycles.py
@@ -1,7 +1,7 @@
 import pytest
 
-from core.interpreter import InterpretadorCobra
-from core.ast_nodes import (
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.ast_nodes import (
     NodoAsignacion,
     NodoBloque,
     NodoCondicional,
@@ -9,7 +9,7 @@ from core.ast_nodes import (
     NodoOperacionBinaria,
     NodoValor,
 )
-from cobra.core import TipoToken, Token
+from pcobra.core.lexer import TipoToken, Token
 
 
 def test_referencia_circular_variable():


### PR DESCRIPTION
### Motivation

- Resolver dos fallos funcionales del intérprete: representación de literales de cadena (tests/unit/test_interpreter_atributo.py) y NameError en asignación previa a concurrencia (tests/unit/test_interpreter_concurrency.py).
- Evitar la contaminación modular detectada durante la colección de tests en tests/unit/test_interpreter_cycles.py mediante imports canónicos.
- Mantener contratos de semántica del lenguaje (no tocar Lexer/Parser/constant_folder) y asegurar correcciones mínimas y localizadas.

### Description

- Añade `_valor_literal` en `InterpretadorCobra` para normalizar representaciones textuales válidas de literales de cadena usando `ast.literal_eval` y aplica la normalización tanto a `NodoValor` como a tokens literales en `evaluar_expresion` para producir valores runtime sin comillas extra.
- Permite que la primera asignación introduzca un nombre en el entorno activo (antes fallaba con `NameError`), preservando el comportamiento de lecturas inexistentes y el contrato de declaraciones explícitas/inferencia en `ejecutar_asignacion`.
- Aísla la ejecución concurrente del entorno capturado: añade un `RLock` y un modo de aislamiento (`_thread_isolation_depth`) y crea vistas copiadas del `Environment` capturado para llamadas iniciadas desde hilos, protegiendo las pilas compartidas de contextos y memoria y manteniendo la semántica concurrente prevista.
- Refina la detección de autorreferencia en `_asegurar_no_autorreferencia_asignacion` para rechazar `x = x` cuando no existe un binding previo, conservando `x = x + 1` válido cuando `x` ya está definido.
- Canonicaliza imports en `tests/unit/test_interpreter_cycles.py` para usar `pcobra.core.*` y evita la carga dual de módulos legacy que producía duplicados de clases AST.

### Testing

- Ejecuté la prueba focal de atributos: `python -m pytest -q tests/unit/test_interpreter_atributo.py -vv` — 1 passed.
- Ejecuté pruebas relacionadas con literales/impresión/atributos: selección de `tests/unit/test_interpreter.py`, `tests/unit/test_metodo_atributo.py`, `tests/unit/test_lark_parser_tokens.py` — 38 passed (27 deselect).
- Ejecuté la prueba concurrente y repeticiones: `python -m pytest -q tests/unit/test_interpreter_concurrency.py -vv` y cinco ejecuciones secuenciales — todas pasaron (1 passed each run).
- Ejecuté colección y ejecución de ciclos tras canonicalizar imports: `python -m pytest -q tests/unit/test_interpreter_cycles.py --collect-only` (12 collected) y `python -m pytest -q tests/unit/test_interpreter_cycles.py -vv` — 12 passed.
- Validación acumulada y end-to-end parcial: conjunto ejecutado incluía `tests/unit/*` relevantes y `tests/integration/test_end_to_end.py`, resultando en `74 passed, 1 skipped` para la selección realizada; la colección global produjo `4714 tests collected` (exit 0) y el siguiente contaminante detectado quedó localizado en `tests/unit/test_interpreter_herencia.py` y no fue modificado.
- `git diff --check` y las comprobaciones solicitadas sobre Lexer/Parser/constant_folder mostraron sin cambios en esos ficheros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69d0be5c1883279102149e99916dd7)