### PR TITLE
Evita contaminación AST en pruebas de herencia del intérprete

### DIFF
--- a/tests/unit/test_interpreter_herencia.py
+++ b/tests/unit/test_interpreter_herencia.py
@@ -1,5 +1,5 @@
-from core.interpreter import InterpretadorCobra
-from core.ast_nodes import (
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.ast_nodes import (
     NodoClase,
     NodoMetodo,
     NodoRetorno,


### PR DESCRIPTION
### Motivation
- Evitar la creación de una segunda identidad modular/AST durante la colección de `tests/unit/test_interpreter_herencia.py` causada por imports legacy `core.*` que cargaban el mismo archivo físico bajo dos nombres distintos.

### Description
- Canonicaliza los imports en `tests/unit/test_interpreter_herencia.py` cambiando `from core.interpreter import InterpretadorCobra` a `from pcobra.core.interpreter import InterpretadorCobra` y `from core.ast_nodes import (...)` a `from pcobra.core.ast_nodes import (...)` sin tocar producción.
- No se modificó la semántica de las pruebas, nombres, jerarquías, aserciones ni se añadieron shims, manipulación de `sys.modules` ni cambios en Lexer/Parser/optimizations/`constant_folder`.

### Testing
- `python -m pytest -q tests/unit/test_interpreter_herencia.py --collect-only` — `1` item recolectado; `python -m pytest -q tests/unit/test_interpreter_herencia.py` — `1 passed` (exit 0).
- Probe Pytest (`/tmp/pcobra_test_interpreter_herencia_probe.py`) antes/después mostró `BEFORE: canonical_present=True legacy_present=False parent_aligned=True` y `AFTER/FILE_AFTER: canonical_present=True legacy_present=False parent_aligned=True`, confirmando que no se cargan módulos legacy duplicados tras el cambio.
- Conjunto de cinco pruebas del intérprete ejecutado: `tests/unit/test_interpreter.py`, `test_interpreter_atributo.py`, `test_interpreter_concurrency.py`, `test_interpreter_cycles.py`, `test_interpreter_herencia.py` — `51 passed`, exit 0.
- Validación acumulada solicitada (incluye integration `test_end_to_end`): `75 passed, 1 skipped`, exit 0; prueba concurrente repetida 5 veces pasó en todas.
- `git diff --check` y verificación de archivos protegidos (`src/pcobra/core/lexer.py`, `src/pcobra/core/parser.py`, `src/pcobra/cobra/core/lexer.py`, `src/pcobra/cobra/core/parser.py`, `src/pcobra/core/optimizations/constant_folder.py`) sin cambios ni errores.

Commit realizado: `Evita contaminación AST en pruebas de herencia del intérprete` (modifica únicamente `tests/unit/test_interpreter_herencia.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69d47853e48327a0fc3c5c24146bb2)