### PR TITLE
Evita contaminación AST en pruebas de hilos del intérprete

### DIFF
--- a/tests/unit/test_interpreter_hilo.py
+++ b/tests/unit/test_interpreter_hilo.py
@@ -20,8 +20,8 @@ if "tree_sitter_languages" not in sys.modules:
     tsl_mod.get_parser = lambda lang: None
     sys.modules["tree_sitter_languages"] = tsl_mod
 
-from core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoFuncion
-from core.interpreter import InterpretadorCobra
+from pcobra.core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoFuncion
+from pcobra.core.interpreter import InterpretadorCobra
 
 
 def test_hilo_es_daemon():


### PR DESCRIPTION
### Motivation
- Durante la colección de `tests/unit/test_interpreter_hilo.py` se detectó contaminación modular: la sentencia `from core.ast_nodes import ...` cargaba un segundo módulo `core.ast_nodes` (mismo archivo físico) y generaba clases AST incompatibles con las ya importadas desde `pcobra.core.ast_nodes`.

### Description
- Se canonicalizaron los imports en `tests/unit/test_interpreter_hilo.py`, sustituyendo `from core.ast_nodes` y `from core.interpreter` por `from pcobra.core.ast_nodes` y `from pcobra.core.interpreter` respectivamente, sin tocar producción ni modificar la semántica de la prueba.
- No se cambiaron Lexer, Parser, gramática, tokens ni `constant_folder`, ni se alteró el contrato funcional de la prueba (nodos, creación de hilo, `daemon`, `join()` y aserciones permanecen idénticos).
- Se creó un commit local con el mensaje `Evita contaminación AST en pruebas de hilos del intérprete` para registrar el cambio (sin push manual).

### Testing
- Se ejecutó colección y ejecución focal con `python -m pytest -q tests/unit/test_interpreter_hilo.py --collect-only` y `python -m pytest -q tests/unit/test_interpreter_hilo.py`, resultando en `1 collected` y `1 passed` respectivamente.
- Se verificó estabilidad ejecutando la prueba focal cinco veces en procesos separados, todas las ejecuciones pasaron (`5/5 passed`), y el probe temporal (`/tmp/pcobra_test_interpreter_hilo_probe.py`) confirmó `BEFORE/AFTER/FILE_AFTER: canonical_present=True legacy_present=False parent_aligned=True`.
- Se ejecutó regresión de los seis archivos del intérprete relacionados con la frontera: `tests/unit/test_interpreter.py`, `test_interpreter_atributo.py`, `test_interpreter_concurrency.py`, `test_interpreter_cycles.py`, `test_interpreter_herencia.py` y `test_interpreter_hilo.py`, obteniendo `52 passed` en ese conjunto; la ejecución acumulada solicitada produjo `76 passed, 1 skipped` y la colección global registró `4714 tests collected` (suite funcional global completa no fue ejecutada aquí).
- `git diff --check` y las comprobaciones de integridad sobre los ficheros protegidos no mostraron cambios; el único archivo modificado en el repo fue `tests/unit/test_interpreter_hilo.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69d8e25d5883278f903fcd2b0ca1ed)