### PR TITLE
fix(interpreter): restaura asignaciones iniciales válidas

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1679,10 +1679,15 @@ class InterpretadorCobra:
         self._auditar_en_ejecucion(nodo)
         
         if isinstance(nodo, NodoAsignacion):
+            es_asignacion_de_variable = isinstance(nodo.variable, str)
+            entorno_admite_nuevos_bindings = isinstance(
+                self.contextos[-1], Environment
+            )
             return self.ejecutar_asignacion(
                 nodo,
-                permitir_asignacion_inicial=isinstance(
-                    getattr(nodo, "expresion", None), NodoInstancia
+                permitir_asignacion_inicial=(
+                    es_asignacion_de_variable
+                    and entorno_admite_nuevos_bindings
                 ),
             )
         elif isinstance(nodo, NodoCondicional):

--- a/tests/unit/test_interpreter_initial_assignment_contract.py
+++ b/tests/unit/test_interpreter_initial_assignment_contract.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+
+from pcobra.core.ast_nodes import (
+    NodoAsignacion,
+    NodoAtributo,
+    NodoClase,
+    NodoFuncion,
+    NodoIdentificador,
+    NodoInstancia,
+    NodoLista,
+    NodoLlamadaFuncion,
+    NodoOperacionBinaria,
+    NodoRetorno,
+    NodoValor,
+)
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.lexer import TipoToken, Token
+
+
+def test_primera_asignacion_superior_de_numero() -> None:
+    inter = InterpretadorCobra()
+
+    assert inter.ejecutar_nodo(NodoAsignacion("numero", NodoValor(7))) == 7
+    assert inter.obtener_variable("numero") == 7
+
+
+def test_primera_asignacion_superior_de_cadena() -> None:
+    inter = InterpretadorCobra()
+
+    assert inter.ejecutar_nodo(NodoAsignacion("texto", NodoValor("cobra"))) == "cobra"
+    assert inter.obtener_variable("texto") == "cobra"
+
+
+def test_primera_asignacion_superior_de_lista() -> None:
+    inter = InterpretadorCobra()
+
+    lista = NodoLista([NodoValor(1), NodoValor(2)])
+
+    assert inter.ejecutar_nodo(NodoAsignacion("valores", lista)) == [1, 2]
+    assert inter.obtener_variable("valores") == [1, 2]
+
+
+def test_primera_asignacion_superior_de_operacion_aritmetica() -> None:
+    inter = InterpretadorCobra()
+    suma = NodoOperacionBinaria(
+        NodoValor(2),
+        Token(TipoToken.SUMA, "+"),
+        NodoValor(3),
+    )
+
+    assert inter.ejecutar_nodo(NodoAsignacion("total", suma)) == 5
+    assert inter.obtener_variable("total") == 5
+
+
+def test_primera_asignacion_superior_de_instancia() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoClase("Vacia", []))
+
+    instancia = inter.ejecutar_nodo(
+        NodoAsignacion("objeto", NodoInstancia("Vacia"))
+    )
+
+    assert inter.obtener_variable("objeto") is instancia
+    assert instancia["__clase__"]["nombre"] == "Vacia"
+
+
+def test_declaracion_explicita_define_binding() -> None:
+    inter = InterpretadorCobra()
+
+    inter.ejecutar_nodo(
+        NodoAsignacion("declarada", NodoValor(11), declaracion=True)
+    )
+
+    assert inter.obtener_variable("declarada") == 11
+
+
+def test_inferencia_define_binding() -> None:
+    inter = InterpretadorCobra()
+
+    inter.ejecutar_nodo(NodoAsignacion("inferida", NodoValor(13), inferencia=True))
+
+    assert inter.obtener_variable("inferida") == 13
+
+
+def test_primera_asignacion_local_de_funcion_define_binding_local() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(
+        NodoFuncion(
+            "crear_local",
+            [],
+            [
+                NodoAsignacion("local", NodoValor(17)),
+                NodoRetorno(NodoIdentificador("local")),
+            ],
+        )
+    )
+
+    assert inter.ejecutar_nodo(NodoLlamadaFuncion("crear_local", [])) == 17
+    with pytest.raises(NameError, match=r"^Variable no declarada: local$"):
+        inter.obtener_variable("local")
+
+
+def test_mutacion_posterior_actualiza_binding_existente() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("contador", NodoValor(1)))
+
+    inter.ejecutar_nodo(NodoAsignacion("contador", NodoValor(2)))
+
+    assert inter.obtener_variable("contador") == 2
+
+
+def test_asignacion_de_atributo_actualiza_instancia_existente() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoClase("Caja", []))
+    inter.ejecutar_nodo(NodoAsignacion("caja", NodoInstancia("Caja")))
+
+    inter.ejecutar_nodo(
+        NodoAsignacion(
+            NodoAtributo(NodoIdentificador("caja"), "valor"),
+            NodoValor(19),
+        )
+    )
+
+    caja = inter.obtener_variable("caja")
+    assert caja["__atributos__"]["valor"] == 19
+
+
+def test_nodo_atributo_exige_binding_previo() -> None:
+    inter = InterpretadorCobra()
+    asignacion = NodoAsignacion(
+        NodoAtributo(NodoIdentificador("ausente"), "valor"),
+        NodoValor(23),
+    )
+
+    with pytest.raises(NameError, match=r"^Variable no declarada: ausente$"):
+        inter.ejecutar_nodo(asignacion)

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -403,9 +403,10 @@ def test_contrato_anticoopia_entorno_cierre_observa_mutaciones_posteriores() -> 
     assert inter.obtener_variable("resultado") == 2
 
 
-def test_asignar_sin_declarar_falla_con_name_error() -> None:
-    with pytest.raises(NameError, match=r"^Variable no declarada: x$"):
-        _ejecutar([NodoAsignacion("x", NodoValor(10))])
+def test_primera_asignacion_simple_define_binding_superior() -> None:
+    inter = _ejecutar([NodoAsignacion("x", NodoValor(10))])
+
+    assert inter.obtener_variable("x") == 10
 
 
 def test_declaracion_y_reasignacion_mantienen_contexto_y_memoria_sin_desfase() -> None:


### PR DESCRIPTION
### Motivation

- Corregir la autorización de la primera asignación: el intérprete estaba permitiendo la creación de bindings iniciales solo cuando el valor era `NodoInstancia`, lo que impedía asignaciones válidas de números, cadenas, listas u operaciones aritméticas en el REPL/proveedor de top-level.
- Preservar la semántica estricta existente para asignaciones a atributos, que deben exigir un objeto ya enlazado y seguir lanzando `NameError` si falta el binding previo.

### Description

- Cambia la rama en `InterpretadorCobra.ejecutar_nodo` para decidir `permitir_asignacion_inicial` por la intención del destino, concretamente si `nodo.variable` es una `str` (variable nominal) y el contexto activo es un `Environment`, en lugar de basarse en que la expresión sea `NodoInstancia` (archivo modificado: `src/pcobra/core/interpreter.py`).
- Mantiene la comprobación estricta para asignaciones cuyo destino es `NodoAtributo`, de modo que seguirán fallando si el objeto no existe (se preserva el contrato que obliga a un binding previo para atributos).
- Añade una regresión focal con pruebas que usan únicamente imports `pcobra.*` para cubrir primeras asignaciones top-level de número, cadena, lista, operación aritmética e instancia, además de declaración explícita, inferencia, primer local de función, mutación posterior y el caso de `NodoAtributo` que debe lanzar `NameError` (nuevo fichero `tests/unit/test_interpreter_initial_assignment_contract.py`).
- Actualiza una prueba vecina que esperaba un `NameError` en la primera asignación simple para validar el nuevo contrato (archivo modificado: `tests/unit/test_interpreter_scope_contract.py`).

### Testing

- Se ejecutó la regresión focal `pytest -q tests/unit/test_interpreter_initial_assignment_contract.py` y pasó completamente (`11 passed`).
- Se ejecutaron las suites relevantes y unitarias del intérprete y alcance con resultados verdes: la suite de alcance y focal combinada pasó (`30 passed`), la suite principal del intérprete pasó (`36 passed`) y las pruebas de objetos/herencia pasaron (`5 passed`).
- Se verificó que `src/pcobra/core/interpreter.py` compila con `python -m py_compile` y que `git diff --check` no reporta problemas, además de confirmar que `src/pcobra/core/lexer.py`, los parsers y `src/pcobra/core/constant_folder.py` permanecen sin cambios.
- Nota de integración: se creó el cambio en el repositorio local (commit con el mensaje solicitado), pero la herramienta `make_pr` no está disponible en este entorno y no hay remoto/CLI configurado para abrir automáticamente el PR desde aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76e692b308832788410b600d05d294)