### PR TITLE
fix(interpreter): implementa bindings nolocal

### DIFF
--- a/src/pcobra/core/environment.py
+++ b/src/pcobra/core/environment.py
@@ -12,6 +12,10 @@ class Environment:
 
     values: dict[str, Any] = field(default_factory=dict)
     parent: Environment | None = None
+    is_function_scope: bool = False
+    local_names: set[str] = field(default_factory=set)
+    nonlocal_bindings: dict[str, Environment] = field(default_factory=dict)
+    global_names: set[str] = field(default_factory=set)
 
     def get(self, name: str) -> Any:
         """Obtiene ``name`` desde el entorno actual o alguno de sus ancestros."""

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -730,6 +730,52 @@ class InterpretadorCobra:
                 return indice
         return None
 
+    def _entorno_funcion_activo(self) -> Environment | None:
+        """Devuelve el entorno de la llamada activa, si existe."""
+        for entorno in reversed(self.contextos):
+            if entorno.is_function_scope:
+                return entorno
+        return None
+
+    def _entorno_global(self) -> Environment:
+        entorno = self.contextos[-1]
+        while entorno.parent is not None:
+            entorno = entorno.parent
+        return entorno
+
+    def _indice_contexto_entorno(self, entorno: Environment) -> int | None:
+        for indice, candidato in enumerate(self.contextos):
+            if candidato is entorno:
+                return indice
+        return None
+
+    def _declarar_nolocal(self, nombre: str) -> None:
+        entorno_funcion = self._entorno_funcion_activo()
+        if entorno_funcion is None:
+            raise SyntaxError("nolocal fuera de función")
+        if nombre in entorno_funcion.local_names:
+            raise SyntaxError(f"Nombre '{nombre}' declarado local y nolocal")
+        if nombre in entorno_funcion.global_names:
+            raise SyntaxError(f"Nombre '{nombre}' declarado global y nolocal")
+
+        exterior = entorno_funcion.parent
+        while exterior is not None and exterior.parent is not None:
+            if exterior.is_function_scope and nombre in exterior.values:
+                entorno_funcion.nonlocal_bindings[nombre] = exterior
+                return
+            exterior = exterior.parent
+        raise SyntaxError(f"No existe binding nolocal para '{nombre}'")
+
+    def _declarar_global(self, nombre: str) -> None:
+        entorno_funcion = self._entorno_funcion_activo()
+        if entorno_funcion is None:
+            return
+        if nombre in entorno_funcion.local_names:
+            raise SyntaxError(f"Nombre '{nombre}' declarado local y global")
+        if nombre in entorno_funcion.nonlocal_bindings:
+            raise SyntaxError(f"Nombre '{nombre}' declarado nolocal y global")
+        entorno_funcion.global_names.add(nombre)
+
     def _liberar_memoria_variable_en_contexto(self, nombre: str, indice_contexto: int) -> None:
         """Libera el bloque de memoria asociado a ``nombre`` en un contexto concreto."""
         if indice_contexto < 0 or indice_contexto >= len(self.mem_contextos):
@@ -1751,9 +1797,11 @@ class InterpretadorCobra:
             if indice_contexto is not None:
                 self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
         elif isinstance(nodo, NodoGlobal):
-            pass  # sin efecto en este intérprete simplificado
+            for nombre in nodo.nombres:
+                self._declarar_global(nombre)
         elif isinstance(nodo, NodoNoLocal):
-            pass
+            for nombre in nodo.nombres:
+                self._declarar_nolocal(nombre)
         elif isinstance(nodo, NodoWith):
             self.evaluar_expresion(nodo.contexto)
             self.contextos.append(Environment(parent=self.contextos[-1]))
@@ -1823,8 +1871,20 @@ class InterpretadorCobra:
             self._verificar_valor_contexto(valor)
             atributos[nombre.nombre] = valor
         else:
+            entorno_funcion = self._entorno_funcion_activo()
+            destino_declarado = None
+            if entorno_funcion is not None:
+                destino_declarado = entorno_funcion.nonlocal_bindings.get(nombre)
+                if nombre in entorno_funcion.global_names:
+                    destino_declarado = self._entorno_global()
             if getattr(nodo, "inferencia", False) or getattr(nodo, "declaracion", False):
                 # Declaración local (explícita o por inferencia)
+                if entorno_funcion is not None:
+                    if nombre in entorno_funcion.nonlocal_bindings:
+                        raise SyntaxError(f"Nombre '{nombre}' declarado nolocal y local")
+                    if nombre in entorno_funcion.global_names:
+                        raise SyntaxError(f"Nombre '{nombre}' declarado global y local")
+                    entorno_funcion.local_names.add(nombre)
                 indice_contexto = len(self.mem_contextos) - 1
                 self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
                 indice = self.solicitar_memoria(1)
@@ -1832,7 +1892,18 @@ class InterpretadorCobra:
                 self.contextos[-1].define(nombre, valor)
                 return valor
             else:
-                indice_contexto = self._indice_entorno_variable(nombre)
+                indice_contexto = (
+                    self._indice_contexto_entorno(destino_declarado)
+                    if destino_declarado is not None
+                    else self._indice_entorno_variable(nombre)
+                )
+                if destino_declarado is not None:
+                    destino_declarado.values[nombre] = valor
+                    if indice_contexto is not None:
+                        self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                        indice = self.solicitar_memoria(1)
+                        self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                    return valor
                 if indice_contexto is None:
                     if self._call_depth == 0 and not permitir_asignacion_inicial:
                         raise NameError(f"Variable no declarada: {nombre}")
@@ -1842,6 +1913,8 @@ class InterpretadorCobra:
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                     self.contextos[-1].define(nombre, valor)
+                    if entorno_funcion is not None:
+                        entorno_funcion.local_names.add(nombre)
                 elif 0 < indice_contexto < len(self.contextos) - 1:
                     # Sin una declaración ``nolocal``, una escritura desde una
                     # función anidada sombrea el local de la función exterior.
@@ -1849,6 +1922,8 @@ class InterpretadorCobra:
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                     self.contextos[-1].define(nombre, valor)
+                    if entorno_funcion is not None:
+                        entorno_funcion.local_names.add(nombre)
                 else:
                     # Mutación sobre una variable existente: ``set`` solo
                     # actualiza en el scope donde ya está declarada.
@@ -2299,13 +2374,16 @@ class InterpretadorCobra:
                 values=dict(entorno_capturado.values),
                 parent=entorno_capturado.parent,
             )
-        self.contextos.append(Environment(parent=entorno_capturado))
+        self.contextos.append(
+            Environment(parent=entorno_capturado, is_function_scope=True)
+        )
         self.mem_contextos.append({})
         try:
             for nombre_param, valor in zip(parametros, argumentos):
                 indice = self.solicitar_memoria(1)
                 self.mem_contextos[-1][nombre_param] = (indice, 1)
                 self.contextos[-1].define(nombre_param, valor)
+                self.contextos[-1].local_names.add(nombre_param)
 
             self._call_depth += 1
             try:
@@ -2406,12 +2484,15 @@ class InterpretadorCobra:
                         values=dict(entorno_capturado.values),
                         parent=entorno_capturado.parent,
                     )
-                self.contextos.append(Environment(parent=entorno_capturado))
+                self.contextos.append(
+                    Environment(parent=entorno_capturado, is_function_scope=True)
+                )
                 self.mem_contextos.append({})
                 for nombre_param, valor in zip(parametros, argumentos_resueltos):
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[-1][nombre_param] = (indice, 1)
                     self.contextos[-1].define(nombre_param, valor)
+                    self.contextos[-1].local_names.add(nombre_param)
 
             def limpiar_contexto():
                 # Se restaura el scope anterior al finalizar la llamada.
@@ -2515,13 +2596,17 @@ class InterpretadorCobra:
             raise ValueError(f"Método '{nodo.nombre_metodo}' no encontrado")
 
         entorno_capturado = metodo.get("entorno", self.contextos[-1])
-        self.contextos.append(Environment(parent=entorno_capturado))
+        self.contextos.append(
+            Environment(parent=entorno_capturado, is_function_scope=True)
+        )
         self.mem_contextos.append({})
         self.contextos[-1].define("self", objeto)
+        self.contextos[-1].local_names.add("self")
         for nombre_param, arg in zip(metodo.get("parametros", [])[1:], nodo.argumentos):
             valor = self.evaluar_expresion(arg)
             self._verificar_valor_contexto(valor)
             self.contextos[-1].define(nombre_param, valor)
+            self.contextos[-1].local_names.add(nombre_param)
 
         try:
             self._call_depth += 1

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -12,9 +12,11 @@ from pcobra.core.ast_nodes import (
     NodoCondicional,
     NodoContinuar,
     NodoFuncion,
+    NodoGlobal,
     NodoIdentificador,
     NodoLlamadaFuncion,
     NodoOperacionBinaria,
+    NodoNoLocal,
     NodoRomper,
     NodoRetorno,
     NodoValor,
@@ -29,6 +31,169 @@ def _ejecutar(nodos: list) -> InterpretadorCobra:
     for nodo in nodos:
         inter.ejecutar_nodo(nodo)
     return inter
+
+
+def _incremento(nombre: str) -> NodoAsignacion:
+    return NodoAsignacion(
+        nombre,
+        NodoOperacionBinaria(
+            NodoIdentificador(nombre),
+            Token(TipoToken.SUMA, "+"),
+            NodoValor(1),
+        ),
+    )
+
+
+def test_nolocal_lee_y_escribe_binding_de_funcion_exterior() -> None:
+    inter = _ejecutar(
+        [
+            NodoFuncion(
+                "exterior",
+                [],
+                [
+                    NodoAsignacion("x", NodoValor(1), declaracion=True),
+                    NodoFuncion(
+                        "interior",
+                        [],
+                        [
+                            NodoNoLocal(["x"]),
+                            _incremento("x"),
+                            NodoRetorno(NodoIdentificador("x")),
+                        ],
+                    ),
+                    NodoRetorno(NodoLlamadaFuncion("interior", [])),
+                ],
+            ),
+            NodoAsignacion(
+                "resultado", NodoLlamadaFuncion("exterior", []), declaracion=True
+            ),
+        ]
+    )
+
+    assert inter.obtener_variable("resultado") == 2
+
+
+def test_nolocal_busca_el_binding_mas_cercano_en_dos_niveles() -> None:
+    inter = _ejecutar(
+        [
+            NodoFuncion(
+                "exterior",
+                [],
+                [
+                    NodoAsignacion("x", NodoValor(1), declaracion=True),
+                    NodoFuncion(
+                        "medio",
+                        [],
+                        [
+                            NodoAsignacion("x", NodoValor(10), declaracion=True),
+                            NodoFuncion(
+                                "interior",
+                                [],
+                                [NodoNoLocal(["x"]), _incremento("x")],
+                            ),
+                            NodoLlamadaFuncion("interior", []),
+                            NodoRetorno(NodoIdentificador("x")),
+                        ],
+                    ),
+                    NodoRetorno(NodoLlamadaFuncion("medio", [])),
+                ],
+            ),
+            NodoAsignacion(
+                "resultado", NodoLlamadaFuncion("exterior", []), declaracion=True
+            ),
+        ]
+    )
+
+    assert inter.obtener_variable("resultado") == 11
+
+
+def test_asignacion_anidada_sin_nolocal_sombrea_binding_exterior() -> None:
+    inter = _ejecutar(
+        [
+            NodoFuncion(
+                "exterior",
+                [],
+                [
+                    NodoAsignacion("x", NodoValor(1), declaracion=True),
+                    NodoFuncion("interior", [], [NodoAsignacion("x", NodoValor(9))]),
+                    NodoLlamadaFuncion("interior", []),
+                    NodoRetorno(NodoIdentificador("x")),
+                ],
+            ),
+            NodoAsignacion(
+                "resultado", NodoLlamadaFuncion("exterior", []), declaracion=True
+            ),
+        ]
+    )
+
+    assert inter.obtener_variable("resultado") == 1
+
+
+def test_nolocal_sin_binding_exterior_falla_inmediatamente_y_limpia_llamada() -> None:
+    inter = _ejecutar(
+        [NodoFuncion("invalida", [], [NodoNoLocal(["ausente"])])]
+    )
+
+    with pytest.raises(SyntaxError, match="No existe binding nolocal para 'ausente'"):
+        inter.ejecutar_nodo(NodoLlamadaFuncion("invalida", []))
+
+    assert len(inter.contextos) == 1
+    assert len(inter.mem_contextos) == 1
+
+
+def test_registros_nolocal_son_independientes_entre_llamadas_sucesivas() -> None:
+    inter = _ejecutar(
+        [
+            NodoFuncion(
+                "contador",
+                [],
+                [
+                    NodoAsignacion("x", NodoValor(0), declaracion=True),
+                    NodoFuncion(
+                        "subir",
+                        [],
+                        [NodoNoLocal(["x"]), _incremento("x")],
+                    ),
+                    NodoLlamadaFuncion("subir", []),
+                    NodoRetorno(NodoIdentificador("x")),
+                ],
+            ),
+            NodoAsignacion(
+                "primera", NodoLlamadaFuncion("contador", []), declaracion=True
+            ),
+            NodoAsignacion(
+                "segunda", NodoLlamadaFuncion("contador", []), declaracion=True
+            ),
+        ]
+    )
+
+    assert inter.obtener_variable("primera") == 1
+    assert inter.obtener_variable("segunda") == 1
+
+
+def test_nolocal_rechaza_contradicciones_local_y_global() -> None:
+    inter = _ejecutar(
+        [
+            NodoFuncion(
+                "local_conflict",
+                [],
+                [
+                    NodoAsignacion("x", NodoValor(1), declaracion=True),
+                    NodoNoLocal(["x"]),
+                ],
+            ),
+            NodoFuncion(
+                "global_conflict",
+                [],
+                [NodoGlobal(["x"]), NodoNoLocal(["x"])],
+            ),
+        ]
+    )
+
+    with pytest.raises(SyntaxError, match="declarado local y nolocal"):
+        inter.ejecutar_nodo(NodoLlamadaFuncion("local_conflict", []))
+    with pytest.raises(SyntaxError, match="declarado global y nolocal"):
+        inter.ejecutar_nodo(NodoLlamadaFuncion("global_conflict", []))
 
 
 def test_reasignacion_en_mientras_persiste_fuera_del_loop() -> None:


### PR DESCRIPTION
### Motivation

- Resolver la semántica faltante de `nolocal`/`global` en el intérprete para que funciones anidadas puedan referenciar y mutar bindings en la función exterior más próxima cuando corresponda. 
- Mantener cambios mínimos y localizados en runtime (sin tocar Lexer/Parser/AST) y preservar creación/destrucción de entornos por llamada.

### Description

- Añadí metadatos por entorno en `Environment` (`is_function_scope`, `local_names`, `nonlocal_bindings`, `global_names`) para registrar declaraciones por llamada. 
- Implementé resolución y validación de `nolocal` y `global` en `InterpretadorCobra`, buscando el binding en la función exterior más próxima y excluyendo el scope global cuando el contrato lo requiere. 
- Modifiqué la lógica de asignación para que las escrituras marcadas por `nolocal` o `global` actualicen el entorno exterior registrado en lugar de crear un local; y detecten contradicciones `local`/`nolocal`/`global` con `SyntaxError` explícito. 
- Añadí registros por llamada al crear entornos de función y marqué parámetros/locales en dichos registros, reutilizando las rutas `finally` existentes para garantizar limpieza incluso ante excepciones. 

### Testing

- Ejecuté `pytest -q tests/unit/test_interpreter_scope_contract.py` y todas las pruebas focales pasaron (25 passed). 
- Ejecuté suites relacionadas `pytest -q tests/unit/test_interpreter.py tests/unit/test_environment.py tests/unit/test_interpreter_loop_scope_regression.py` y pasaron (45 passed). 
- Comprobé `python -m py_compile` sobre los ficheros modificados y `git diff --check`, ambos sin errores, y verifiqué que `src/pcobra/core/lexer.py` y `src/pcobra/core/parser.py` no fueron alterados. 
- Los cambios están contenidos en un único commit con el mensaje `fix(interpreter): implementa bindings nolocal` y las pruebas automatizadas mencionadas informaron éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76e86fc9c88327b6190781933e0f3b)