### PR TITLE
fix(interpreter): rechaza retorno fuera de función

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -613,7 +613,6 @@ class InterpretadorCobra:
         self.op_memoria = 0
         self._eval_stack = set()
         self._call_depth = 0
-        self._with_return_depth = 0
         import threading
 
         self._thread_execution_lock = threading.RLock()
@@ -1806,18 +1805,10 @@ class InterpretadorCobra:
             self.evaluar_expresion(nodo.contexto)
             self.contextos.append(Environment(parent=self.contextos[-1]))
             self.mem_contextos.append({})
-            capturar_retorno = self._call_depth == 0
-            self._with_return_depth += 1
             try:
-                try:
-                    for instr in nodo.cuerpo:
-                        self.ejecutar_nodo(instr)
-                except _ControlRetorno as retorno:
-                    if not capturar_retorno:
-                        raise
-                    return retorno.valor
+                for instr in nodo.cuerpo:
+                    self.ejecutar_nodo(instr)
             finally:
-                self._with_return_depth -= 1
                 memoria_local = self.mem_contextos.pop()
                 for idx, tam in memoria_local.values():
                     self.liberar_memoria(idx, tam)
@@ -1829,7 +1820,7 @@ class InterpretadorCobra:
         elif isinstance(nodo, NodoHilo):
             return self.ejecutar_hilo(nodo)
         elif isinstance(nodo, NodoRetorno):
-            if self._call_depth == 0 and self._with_return_depth == 0:
+            if self._call_depth == 0:
                 raise RuntimeError("retorno fuera de función")
             raise _ControlRetorno(self.evaluar_expresion(nodo.expresion))
         elif isinstance(nodo, NodoRomper):

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -294,45 +294,99 @@ def test_del_objetivo_no_identificador_lanza_typeerror():
         inter.ejecutar_nodo(NodoDel(NodoValor(1)))
 
 
-def test_with_limpia_contexto_y_memoria_en_retorno_temprano():
+def test_retorno_fuera_de_funcion_es_rechazado():
+    inter = InterpretadorCobra()
+
+    with pytest.raises(RuntimeError, match=r"^retorno fuera de función$"):
+        inter.ejecutar_nodo(NodoRetorno(NodoValor(7)))
+
+
+def test_with_no_transforma_retorno_fuera_de_funcion_en_valor():
+    inter = InterpretadorCobra()
+    contextos_iniciales = len(inter.contextos)
+    mem_contextos_iniciales = len(inter.mem_contextos)
+
+    with pytest.raises(RuntimeError, match=r"^retorno fuera de función$"):
+        inter.ejecutar_nodo(
+            NodoWith(
+                NodoValor("ctx"),
+                None,
+                [NodoRetorno(NodoValor(7))],
+            )
+        )
+
+    assert len(inter.contextos) == contextos_iniciales
+    assert len(inter.mem_contextos) == mem_contextos_iniciales
+
+
+def test_with_limpia_contexto_y_memoria_en_retorno_temprano_de_funcion():
     inter = InterpretadorCobra()
     inter.ejecutar_nodo(NodoAsignacion("x", NodoValor(0), declaracion=True))
     contextos_iniciales = len(inter.contextos)
     mem_contextos_iniciales = len(inter.mem_contextos)
+    liberaciones = []
+    liberar_memoria = inter.liberar_memoria
 
-    resultado = inter.ejecutar_nodo(
-        NodoWith(
-            NodoValor("ctx"),
-            None,
+    def registrar_liberacion(indice, tamano):
+        liberaciones.append((indice, tamano))
+        liberar_memoria(indice, tamano)
+
+    inter.liberar_memoria = registrar_liberacion
+
+    inter.ejecutar_nodo(
+        NodoFuncion(
+            "actualizar",
+            [],
             [
-                NodoAsignacion("x", NodoValor(7)),
-                NodoRetorno(NodoIdentificador("x")),
+                NodoWith(
+                    NodoValor("ctx"),
+                    None,
+                    [
+                        NodoAsignacion("temporal", NodoValor(1), declaracion=True),
+                        NodoAsignacion("x", NodoValor(7)),
+                        NodoRetorno(NodoIdentificador("x")),
+                    ],
+                )
             ],
         )
     )
+    resultado = inter.ejecutar_nodo(NodoLlamadaFuncion("actualizar", []))
 
     assert resultado == 7
     assert inter.obtener_variable("x") == 7
     assert len(inter.contextos) == contextos_iniciales
     assert len(inter.mem_contextos) == mem_contextos_iniciales
+    assert liberaciones
 
 
 def test_with_limpia_contexto_y_memoria_si_hay_excepcion():
     inter = InterpretadorCobra()
     contextos_iniciales = len(inter.contextos)
     mem_contextos_iniciales = len(inter.mem_contextos)
+    liberaciones = []
+    liberar_memoria = inter.liberar_memoria
+
+    def registrar_liberacion(indice, tamano):
+        liberaciones.append((indice, tamano))
+        liberar_memoria(indice, tamano)
+
+    inter.liberar_memoria = registrar_liberacion
 
     with pytest.raises(NameError, match=r"^Variable no declarada: no_definida$"):
         inter.ejecutar_nodo(
             NodoWith(
                 NodoValor("ctx"),
                 None,
-                [NodoImprimir(NodoIdentificador("no_definida"))],
+                [
+                    NodoAsignacion("temporal", NodoValor(1), declaracion=True),
+                    NodoImprimir(NodoIdentificador("no_definida")),
+                ],
             )
         )
 
     assert len(inter.contextos) == contextos_iniciales
     assert len(inter.mem_contextos) == mem_contextos_iniciales
+    assert liberaciones
 
 
 def test_with_declara_local_y_no_contamina_scope_vecino():


### PR DESCRIPTION
### Motivation

- Corregir una regresión donde un `retorno` ejecutado fuera de una función podía ser silenciosamente transformado en un valor por el manejador de `with` en lugar de ser rechazado. 
- Garantizar que la comprobación de validez de `NodoRetorno` dependa únicamente de la profundidad de llamadas (`_call_depth`) y no pueda esquivarse vía handlers de contexto.
- Asegurar la liberación de contexto y memoria en todos los caminos (retorno válido, retorno inválido y excepción).

### Description

- Elimino el contador `_with_return_depth` y su lógica asociada para evitar que el manejador de `with` capture/transforme la señal interna `_ControlRetorno` en un valor normal. 
- Modifico el manejo de `NodoWith` para dejar que las señales de control (incluido `_ControlRetorno`) se propaguen fuera del `with`, manteniendo la limpieza de memoria y contextos en el bloque `finally`.
- Cambio la validación de `NodoRetorno` para que compruebe únicamente `self._call_depth == 0` y lance `RuntimeError("retorno fuera de función")` cuando no haya una llamada de función activa.
- Añado y adapto pruebas de regresión en `tests/unit/test_interpreter.py` que verifican: rechazo de `retorno` fuera de función, que `with` no convierte un `retorno` inválido en un valor, limpieza de contexto/memoria en retornos tempranos dentro de funciones y en excepciones dentro de `with`.

### Testing

- Ejecuté las pruebas focales y vecinas: `pytest -q tests/unit/test_interpreter.py -k 'retorno_fuera or with_limpia_contexto_y_memoria'` y `pytest -q tests/unit/test_interpreter.py -k 'with or funcion'`, ambas finalizaron exitosas. 
- Ejecuté integración de retornos y contratos de scope: `pytest -q tests/unit/test_retornos.py::test_interpreter_funcion_con_retorno tests/unit/test_interpreter_scope_contract.py`, las pruebas relevantes pasaron.
- Verifiqué compilación estática de los archivos modificados con `python -m py_compile src/pcobra/core/interpreter.py tests/unit/test_interpreter.py` y ejecuté `git diff --check`; ambas comprobaciones fueron exitosas y no se modificaron `lexer` ni `parser`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76ead0e9d48327bce960343c8a1c39)