### PR TITLE
fix(strings): evita doble decodificación de literales

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1958,7 +1958,7 @@ class InterpretadorCobra:
                 )
 
             if isinstance(expresion, NodoValor):
-                return self._valor_literal(expresion.valor)
+                return expresion.valor
             elif isinstance(expresion, Token) and expresion.tipo in {
                 TipoToken.ENTERO,
                 TipoToken.FLOTANTE,

--- a/tests/unit/test_interpreter_string_literals.py
+++ b/tests/unit/test_interpreter_string_literals.py
@@ -1,0 +1,61 @@
+"""Regresiones de la frontera entre literales léxicos y texto runtime."""
+
+import pytest
+
+from pcobra.core.ast_nodes import (
+    NodoAsignacion,
+    NodoIdentificador,
+    NodoImprimir,
+    NodoLlamadaFuncion,
+    NodoValor,
+)
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.lexer import TipoToken, Token
+
+
+TEXTOS_RUNTIME = (
+    'texto con "comillas"',
+    "texto con 'comillas'",
+    "barra C:\\directorio\\archivo",
+    "primera línea\nsegunda línea",
+    "España 🐍",
+    "'parece un literal Python'",
+    '"también parece un literal Python"',
+    "['no', 'evaluar']",
+)
+
+
+def _formas_de_imprimir(texto):
+    return (
+        [NodoImprimir(NodoValor(texto))],
+        [NodoLlamadaFuncion("imprimir", [NodoValor(texto)])],
+        [
+            NodoAsignacion("mensaje", NodoValor(texto), declaracion=True),
+            NodoImprimir(NodoIdentificador("mensaje")),
+        ],
+    )
+
+
+@pytest.mark.parametrize("texto", TEXTOS_RUNTIME)
+def test_imprimir_preserva_texto_runtime_en_sus_tres_formas(texto, capsys):
+    for ast in _formas_de_imprimir(texto):
+        InterpretadorCobra().ejecutar_ast(ast)
+        assert capsys.readouterr().out == f"{texto}\n"
+
+
+def test_token_crudo_se_decodifica_pero_nodo_valor_runtime_no():
+    interprete = InterpretadorCobra()
+    token_crudo = Token(TipoToken.CADENA, r'"línea\ncon \"comillas\""')
+    texto_runtime = '"literal Python conservado"'
+
+    assert interprete.evaluar_expresion(token_crudo) == 'línea\ncon "comillas"'
+    assert interprete.evaluar_expresion(NodoValor(texto_runtime)) == texto_runtime
+
+
+def test_regresion_nodo_valor_no_pierde_sus_comillas_exteriores():
+    texto_runtime = "'contenido entre comillas'"
+
+    assert (
+        InterpretadorCobra().evaluar_expresion(NodoValor(texto_runtime))
+        == texto_runtime
+    )


### PR DESCRIPTION
### Motivation

- Evitar la doble decodificación de literales de cadena que provoca pérdida de las comillas exteriores al reevaluar valores ya materializados en runtime.
- Mantener la frontera de decodificación en la entrada léxica y no tocar Lexer/Parser ni la sintaxis del lenguaje.

### Description

- Al evaluar expresiones, `NodoValor` ahora devuelve su `valor` tal cual en lugar de pasar por `_valor_literal` en `InterpretadorCobra`.
- La función `_valor_literal` queda aplicada únicamente a tokens léxicos (`Token`) que aún necesitan decodificación.
- Se añade la nueva prueba `tests/unit/test_interpreter_string_literals.py` que cubre las tres formas de `imprimir`, escapes, barras invertidas, saltos de línea, Unicode y cadenas con apariencia de literal Python, y pruebas AST que distinguen `Token` crudo de `NodoValor` runtime.
- No se modificaron archivos de Lexer ni Parser y no se cambió la sintaxis del lenguaje.

### Testing

- Ejecutado `pytest -q tests/unit/test_interpreter_string_literals.py` — 10 tests aprobados.
- Ejecutado `pytest -q tests/integration/test_interpreter_string_equality.py` y pruebas focales relacionadas con impresión/valores — superadas (tests relevantes pasaron).
- Ejecutado `python -m py_compile src/pcobra/core/interpreter.py tests/unit/test_interpreter_string_literals.py`, `python scripts/ci/gate_no_parser_lexer_changes.py` y `git diff --check` — todas verificaciones automáticas pasaron.
- Al ejecutar suites más amplias aparecieron fallos preexistentes no relacionados con la corrección (fixtures de import ausentes y algunas aserciones de estabilidad de nodos); la regresión focal y las pruebas añadidas pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76ec83d06083278e56f067e0e24947)