### PR TITLE
fix(concurrency): aísla contextos por hilo

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -6,6 +6,7 @@ import os
 import hashlib
 import inspect
 import math
+import threading
 import warnings
 from pathlib import Path
 from typing import Mapping, Optional
@@ -254,6 +255,30 @@ class _ControlRetorno(Exception):
     def __init__(self, valor):
         super().__init__()
         self.valor = valor
+
+
+class _EstadoEjecucion(threading.local):
+    """Estado mutable que pertenece exclusivamente a una ejecución/hilo.
+
+    Inventario: las pilas de scopes y de bloques de memoria locales,
+    ``call_depth``, el conjunto temporal de evaluación recursiva y la
+    profundidad de aislamiento del worker. Las señales de control
+    (``_ControlRetorno``, ``_ControlRomper`` y ``_ControlContinuar``), junto
+    con ``visitados`` y demás temporales de evaluación, viajan por la pila de
+    Python y por tanto ya son locales a cada llamada.
+
+    El entorno global se conserva por referencia: los workers crean scopes
+    locales cuyo padre léxico apunta a él. Cuando una llamada necesita aislar
+    los bindings capturados se usa una copia *superficial* de ``values`` para
+    preservar las referencias léxicas a objetos compartidos.
+    """
+
+    def __init__(self) -> None:
+        self.contextos: list[Environment] | None = None
+        self.mem_contextos: list[dict[str, tuple[int, int]]] | None = None
+        self.call_depth = 0
+        self.eval_stack: set[tuple[int, int]] = set()
+        self.thread_isolation_depth = 0
 
 
 class InterpretadorCobra:
@@ -602,19 +627,23 @@ class InterpretadorCobra:
         self.analizador = AnalizadorSemantico()
         # Conjunto para evitar validar el mismo nodo varias veces
         self._validados = set()
-        # Pila de entornos para mantener variables locales en cada llamada
-        self.contextos = [Environment()]
+        # Estado estrictamente por ejecución. El entorno raíz sigue siendo la
+        # referencia léxica compartida desde la que parten los workers.
+        self._execution_state = _EstadoEjecucion()
+        self._global_environment = Environment()
+        self._global_mem_context: dict[str, tuple[int, int]] = {}
+        self.contextos = [self._global_environment]
         self.funciones_nativas = {"longitud": longitud}
         # Mapa paralelo para gestionar bloques de memoria por contexto
-        self.mem_contextos = [{}]
+        self.mem_contextos = [self._global_mem_context]
         # Gestor genético de estrategias de memoria
         self.gestor_memoria = GestorMemoriaGenetico()
         self.estrategia = self.gestor_memoria.poblacion[0]
         self.op_memoria = 0
         self._eval_stack = set()
         self._call_depth = 0
-        import threading
-
+        # Orden de bloqueo único: ninguna ruta adquiere otro lock mientras
+        # mantiene éste. Solo protege el gestor/estrategia de memoria común.
         self._thread_execution_lock = threading.RLock()
         self._thread_isolation_depth = 0
         # Funciones Cobra declaradas en el AST fuente. Se mantiene separada del
@@ -638,6 +667,54 @@ class InterpretadorCobra:
         self._imported_module_paths: set[Path] = set()
         # Debe ejecutarse siempre después de crear _validador y _usar_symbol_metadata.
         self.asegurar_estado_runtime_inicial()
+
+    @property
+    def contextos(self):
+        contextos = self._execution_state.contextos
+        if contextos is None:
+            contextos = [self._global_environment]
+            self._execution_state.contextos = contextos
+        return contextos
+
+    @contextos.setter
+    def contextos(self, value):
+        self._execution_state.contextos = value
+
+    @property
+    def mem_contextos(self):
+        contextos = self._execution_state.mem_contextos
+        if contextos is None:
+            contextos = [self._global_mem_context]
+            self._execution_state.mem_contextos = contextos
+        return contextos
+
+    @mem_contextos.setter
+    def mem_contextos(self, value):
+        self._execution_state.mem_contextos = value
+
+    @property
+    def _call_depth(self):
+        return self._execution_state.call_depth
+
+    @_call_depth.setter
+    def _call_depth(self, value):
+        self._execution_state.call_depth = value
+
+    @property
+    def _eval_stack(self):
+        return self._execution_state.eval_stack
+
+    @_eval_stack.setter
+    def _eval_stack(self, value):
+        self._execution_state.eval_stack = value
+
+    @property
+    def _thread_isolation_depth(self):
+        return self._execution_state.thread_isolation_depth
+
+    @_thread_isolation_depth.setter
+    def _thread_isolation_depth(self, value):
+        self._execution_state.thread_isolation_depth = value
 
     def asegurar_estado_runtime_inicial(self) -> None:
         """Garantiza estado mínimo de runtime para metadata de `usar`.
@@ -1112,21 +1189,23 @@ class InterpretadorCobra:
     # -- Gestión de memoria -------------------------------------------------
     def solicitar_memoria(self, tam):
         """Solicita un bloque a la estrategia actual."""
-        index = self.estrategia.asignar(tam)
-        if index == -1:
-            self.gestor_memoria.evolucionar(verbose=False)
-            self.estrategia = self.gestor_memoria.poblacion[0]
+        with self._thread_execution_lock:
             index = self.estrategia.asignar(tam)
-        self.op_memoria += 1
-        if self.op_memoria >= 1000:
-            self.gestor_memoria.evolucionar(verbose=False)
-            self.estrategia = self.gestor_memoria.poblacion[0]
-            self.op_memoria = 0
-        return index
+            if index == -1:
+                self.gestor_memoria.evolucionar(verbose=False)
+                self.estrategia = self.gestor_memoria.poblacion[0]
+                index = self.estrategia.asignar(tam)
+            self.op_memoria += 1
+            if self.op_memoria >= 1000:
+                self.gestor_memoria.evolucionar(verbose=False)
+                self.estrategia = self.gestor_memoria.poblacion[0]
+                self.op_memoria = 0
+            return index
 
     def liberar_memoria(self, index, tam):
         """Libera un bloque de memoria."""
-        self.estrategia.liberar(index, tam)
+        with self._thread_execution_lock:
+            self.estrategia.liberar(index, tam)
 
     # -- Utilidades ---------------------------------------------------------
     def _validar(self, nodo):
@@ -2914,19 +2993,21 @@ class InterpretadorCobra:
 
     def ejecutar_hilo(self, nodo):
         """Ejecuta una función en un hilo separado."""
-        import threading
-
         def destino():
-            # Las llamadas concurrentes comparten el intérprete, pero cada
-            # hilo ejecuta la función sobre una vista aislada de su entorno
-            # capturado. El bloqueo protege las pilas internas de contextos y
-            # memoria, que son estructuras compartidas y no thread-local.
-            with self._thread_execution_lock:
-                self._thread_isolation_depth += 1
-                try:
-                    self.ejecutar_llamada_funcion(nodo.llamada)
-                finally:
-                    self._thread_isolation_depth -= 1
+            # ``threading.local`` crea pilas limpias para este worker. No se
+            # serializa la ejecución completa: solo las operaciones realmente
+            # compartidas (p. ej. memoria) toman su bloqueo específico.
+            self._thread_isolation_depth += 1
+            try:
+                self.ejecutar_llamada_funcion(nodo.llamada)
+            finally:
+                self._thread_isolation_depth -= 1
+                # Una excepción no debe dejar scopes ni temporales vivos en el
+                # estado local si el Thread es retenido por instrumentación.
+                self.contextos[:] = [self._global_environment]
+                self.mem_contextos[:] = [self._global_mem_context]
+                self._eval_stack.clear()
+                self._call_depth = 0
 
         # El hilo se marca como daemon para evitar que bloquee el cierre del
         # intérprete si queda en ejecución al finalizar el programa.

--- a/tests/unit/test_interpreter_concurrency.py
+++ b/tests/unit/test_interpreter_concurrency.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.ast_nodes import (
@@ -32,3 +34,120 @@ def test_hilos_preservan_variables_globales_concurrentes():
 
     assert interp.variables['contador'] == 0
     assert len(interp.contextos) == 1
+
+
+def _registrar_nativa(interp, nombre, callback):
+    interp.funciones_nativas[nombre] = callback
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.parametrize("repeticion", range(5))
+def test_dos_workers_alcanzan_barrera_sin_serializar_ejecucion(repeticion):
+    """Falla con el bloqueo histórico: el primer worker rompe la barrera."""
+    interp = InterpretadorCobra()
+    barrera = threading.Barrier(2, timeout=1)
+    alcanzados = []
+    lock_resultados = threading.Lock()
+
+    def sincronizar(etiqueta):
+        barrera.wait()
+        with lock_resultados:
+            alcanzados.append(etiqueta)
+
+    _registrar_nativa(interp, "sincronizar", sincronizar)
+    interp.ejecutar_funcion(
+        NodoFuncion(
+            "trabajo",
+            ["etiqueta"],
+            [NodoLlamadaFuncion("sincronizar", [NodoIdentificador("etiqueta")])],
+        )
+    )
+
+    hilos = [
+        interp.ejecutar_hilo(
+            NodoHilo(NodoLlamadaFuncion("trabajo", [NodoValor(etiqueta)]))
+        )
+        for etiqueta in ("a", "b")
+    ]
+    for hilo in hilos:
+        hilo.join(timeout=2)
+
+    assert not any(hilo.is_alive() for hilo in hilos)
+    assert sorted(alcanzados) == ["a", "b"]
+    assert len(interp.contextos) == len(interp.mem_contextos) == 1
+
+
+@pytest.mark.timeout(5)
+def test_workers_aislan_locales_y_preservan_referencias_lexicas():
+    interp = InterpretadorCobra()
+    barrera = threading.Barrier(2, timeout=1)
+    compartido = []
+    observados = {}
+    lock_resultados = threading.Lock()
+
+    def observar(etiqueta, valor):
+        barrera.wait()
+        compartido.append(etiqueta)
+        with lock_resultados:
+            observados[etiqueta] = valor
+
+    interp.variables["compartido"] = compartido
+    _registrar_nativa(interp, "observar", observar)
+    interp.ejecutar_funcion(
+        NodoFuncion(
+            "local",
+            ["etiqueta"],
+            [
+                NodoAsignacion(
+                    "temporal", NodoIdentificador("etiqueta"), declaracion=True
+                ),
+                NodoLlamadaFuncion(
+                    "observar",
+                    [NodoIdentificador("etiqueta"), NodoIdentificador("temporal")],
+                ),
+            ],
+        )
+    )
+
+    hilos = [
+        interp.ejecutar_hilo(
+            NodoHilo(NodoLlamadaFuncion("local", [NodoValor(valor)]))
+        )
+        for valor in ("uno", "dos")
+    ]
+    for hilo in hilos:
+        hilo.join(timeout=2)
+
+    assert observados == {"uno": "uno", "dos": "dos"}
+    assert sorted(compartido) == ["dos", "uno"]
+    assert "temporal" not in interp.variables
+    assert len(interp.contextos) == len(interp.mem_contextos) == 1
+
+
+@pytest.mark.timeout(5)
+def test_excepcion_de_worker_no_corrompe_pilas(monkeypatch):
+    interp = InterpretadorCobra()
+    capturadas = []
+    ocurrio = threading.Event()
+
+    def capturar(args):
+        capturadas.append(args.exc_value)
+        ocurrio.set()
+
+    def fallar():
+        raise RuntimeError("fallo determinista")
+
+    monkeypatch.setattr(threading, "excepthook", capturar)
+    _registrar_nativa(interp, "fallar", fallar)
+    interp.ejecutar_funcion(
+        NodoFuncion("worker", [], [NodoLlamadaFuncion("fallar", [])])
+    )
+
+    hilo = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion("worker", [])))
+    assert ocurrio.wait(timeout=2)
+    hilo.join(timeout=2)
+
+    assert [str(exc) for exc in capturadas] == ["fallo determinista"]
+    assert len(interp.contextos) == len(interp.mem_contextos) == 1
+    assert interp._call_depth == 0
+    assert not interp._eval_stack

--- a/tests/unit/test_interpreter_hilo.py
+++ b/tests/unit/test_interpreter_hilo.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 import types
 from io import StringIO
 from unittest.mock import patch
@@ -32,3 +33,30 @@ def test_hilo_es_daemon():
         hilo = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion('marca', [])))
         assert hilo.daemon
         hilo.join()
+
+
+def test_hilo_daemon_puede_quedar_esperando_sin_bloquear_cierre():
+    interp = InterpretadorCobra()
+    liberar = threading.Event()
+    iniciado = threading.Event()
+
+    def esperar_evento():
+        iniciado.set()
+        liberar.wait()
+
+    interp.funciones_nativas["esperar_evento"] = esperar_evento
+    interp.ejecutar_funcion(
+        NodoFuncion("esperar", [], [NodoLlamadaFuncion("esperar_evento", [])])
+    )
+
+    hilo = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion("esperar", [])))
+    try:
+        assert iniciado.wait(timeout=2)
+        assert hilo.daemon
+        assert hilo.is_alive()
+    finally:
+        liberar.set()
+        hilo.join(timeout=2)
+
+    assert not hilo.is_alive()
+    assert len(interp.contextos) == len(interp.mem_contextos) == 1


### PR DESCRIPTION
### Motivation

- Aislar el estado mutable usado durante una ejecución (pilas de scopes, mapas de memoria locales, profundidad de llamada y temporales de evaluación) para permitir workers concurrentes sin serializar toda la ejecución.
- Reducir el alcance del bloqueo global a las operaciones realmente compartidas (reserva/liberación de memoria) y evitar la serialización completa de `ejecutar_hilo`.
- Mantener las referencias léxicas compartidas y no tocar Lexer/Parser ni cambiar la semántica pública más de lo necesario.

### Description

- Se introdujo la clase `_EstadoEjecucion(threading.local)` para contener `contextos`, `mem_contextos`, `call_depth`, `eval_stack` y `thread_isolation_depth` como estado local por hilo.
- `contextos` y `mem_contextos` (y los temporales asociados) ahora están expuestos por propiedades que usan el estado thread-local mientras que el entorno raíz global se conserva por referencia superficial.
- `_thread_execution_lock` se limita a proteger la asignación/evolución/liberación de memoria en `solicitar_memoria` y `liberar_memoria`, reduciendo la sección crítica global.
- `ejecutar_hilo` deja de serializar toda la ejecución; cada worker incrementa su profundidad de aislamiento y se restaura defensivamente el estado local (scopes, memoria y temporales) al terminar, incluida la limpieza ante excepciones.
- Se añadieron pruebas deterministas de concurrencia y comportamiento de hilos en `tests/unit/test_interpreter_concurrency.py` y `tests/unit/test_interpreter_hilo.py` que usan `threading.Barrier` y `threading.Event` para verificar barreras, aislamiento léxico, excepción en worker y comportamiento daemon.

### Testing

- `pytest -q tests/unit/test_interpreter_concurrency.py tests/unit/test_interpreter_hilo.py` — 10 tests passed.
- `pytest -q tests/unit/test_interpreter_scope_contract.py tests/unit/test_interpreter_memoria.py` — 27 tests passed.
- `pytest -q tests/unit/test_interpreter*.py tests/integration/test_interpreter*.py` — ejecución detenida tras 5 fallos (5 failed, 59 passed); los fallos son independientes de la concurrencia (ficheros de entorno faltantes y validación AST en tests existentes).
- `python -m py_compile src/pcobra/core/interpreter.py tests/unit/test_interpreter_concurrency.py tests/unit/test_interpreter_hilo.py` — compilación OK, y `git diff --check` no reportó problemas; búsqueda de cambios en Lexer/Parser resultó vacía.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76ee9049608327848248f8b711a9c4)