### PR TITLE
security(usar): aplica capacidades a procesos

### DIFF
--- a/src/pcobra/cobra/usar_capabilities.py
+++ b/src/pcobra/cobra/usar_capabilities.py
@@ -1,0 +1,41 @@
+"""Contratos internos e inmutables de capacidades para ``usar``."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from types import MappingProxyType
+
+
+class CapacidadUsar(StrEnum):
+    PROCESS_SPAWN = "process.spawn"
+    PROCESS_SHELL = "process.shell"
+
+
+_SIMBOLO_CANONICO = MappingProxyType(
+    {
+        ("proceso", "ejecutar"): ("proceso", "ejecutar"),
+        ("proceso", "capturar"): ("proceso", "ejecutar"),
+        ("proceso", "ejecutar_async"): ("proceso", "ejecutar_async"),
+        ("proceso", "ejecutar_stream"): ("proceso", "ejecutar_stream"),
+    }
+)
+
+_CAPACIDADES = MappingProxyType(
+    {
+        ("proceso", "ejecutar"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
+        ("proceso", "ejecutar_async"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
+        ("proceso", "ejecutar_stream"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
+    }
+)
+
+
+def simbolo_canonico(modulo: str, nombre: str) -> tuple[str, str]:
+    """Resuelve aliases sin consultar atributos del objeto exportado."""
+
+    return _SIMBOLO_CANONICO.get((modulo, nombre), (modulo, nombre))
+
+
+def capacidades_de(modulo: str, nombre: str) -> frozenset[CapacidadUsar]:
+    """Devuelve el contrato mantenido por código para el símbolo canónico."""
+
+    return _CAPACIDADES.get(simbolo_canonico(modulo, nombre), frozenset())

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import subprocess
 import sys
 import tomllib as tomli
+from functools import wraps
 from typing import Any
 
 from pcobra.cobra.imports import resolver as imports_resolver
 from pcobra.cobra.imports.resolver import ImportResolutionError
+from pcobra.cobra.usar_capabilities import CapacidadUsar, capacidades_de
 from pcobra.cobra.usar_policy import (
     CANONICAL_MODULE_SURFACE_CONTRACTS,
     REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
@@ -113,6 +115,33 @@ def _construir_exports_usar(
     exports = UsarExports({"simbolos": simbolos, "metadata": metadata})
     exports.update(dict(simbolos))
     return exports
+
+
+def _aplicar_capacidades(
+    modulo: str,
+    simbolos: list[tuple[str, Any]],
+    *,
+    safe_mode: bool,
+) -> list[tuple[str, Any]]:
+    """Construye wrappers desde contratos internos, nunca desde atributos Cobra."""
+
+    resultado: list[tuple[str, Any]] = []
+    for nombre, simbolo in simbolos:
+        capacidades = capacidades_de(modulo, nombre)
+        if not callable(simbolo) or CapacidadUsar.PROCESS_SPAWN not in capacidades:
+            resultado.append((nombre, simbolo))
+            continue
+
+        @wraps(simbolo)
+        def protegido(*args, __simbolo=simbolo, **kwargs):
+            if safe_mode:
+                if kwargs.get("shell") is True:
+                    raise PermissionError("capacidad process.shell denegada en modo seguro")
+                raise PermissionError("capacidad process.spawn denegada en modo seguro")
+            return __simbolo(*args, **kwargs)
+
+        resultado.append((nombre, protegido))
+    return resultado
 
 
 def normalizar_nombre_usar(nombre: str) -> str:
@@ -813,6 +842,7 @@ def usar_modulo(
     loading_stack: list[Path] | None = None,
     permitir_modulos_proyecto: bool | None = None,
     contexto_proyecto_verificado: bool | None = None,
+    safe_mode: bool = True,
 ) -> dict[str, Any]:
     """API única para resolver ``usar`` en runtime y transpilación Python.
 
@@ -856,6 +886,9 @@ def usar_modulo(
             )
         if not simbolos_saneados:
             raise ImportError(f"No se encontraron símbolos exportables para usar '{nombre_validado_oficial}'.")
+        simbolos_saneados = _aplicar_capacidades(
+            nombre_validado_oficial, simbolos_saneados, safe_mode=safe_mode
+        )
         return _construir_exports_usar(simbolos_saneados, metadata_por_simbolo)
     except ModuloFueraCatalogoPublicoError as permiso_exc:
         # Caso 3: un nombre externo/no canónico no puede convertirse

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -262,6 +262,8 @@ CANONICAL_MODULE_SURFACE_CONTRACTS: dict[str, CanonicalModuleSurfaceContract] = 
         required_functions=(
             "ejecutar",
             "capturar",
+            "ejecutar_async",
+            "ejecutar_stream",
             "codigo_salida",
             "salida",
             "errores",

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -107,6 +107,7 @@ def _usar_modulo_con_estado_aislado(
     module_cache: dict[Path, dict[str, object]],
     loading_stack: list[Path],
     contexto_proyecto_verificado: bool,
+    safe_mode: bool,
 ) -> Mapping[str, object]:
     """Llama a ``usar_modulo`` pasando estado aislado si la función lo soporta."""
 
@@ -124,6 +125,8 @@ def _usar_modulo_con_estado_aislado(
         "contexto_proyecto_verificado" in parametros
     ):
         kwargs["contexto_proyecto_verificado"] = contexto_proyecto_verificado
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parametros.values()) or "safe_mode" in parametros:
+        kwargs["safe_mode"] = safe_mode
     return usar_modulo(nombre, **kwargs)
 USAR_DIRECT_BACKEND_IMPORT_ERROR = (
     "usar_error[backend_import_directo]: import directo de backend no permitido en usar"
@@ -2854,6 +2857,7 @@ class InterpretadorCobra:
                 module_cache=self._usar_module_cache,
                 loading_stack=self._usar_loading_stack,
                 contexto_proyecto_verificado=self._contexto_proyecto_verificado,
+                safe_mode=self.safe_mode,
             )
             self._inyectar_exports_modulo_proyecto(exports)
         except Exception as exc:

--- a/src/pcobra/corelibs/proceso.py
+++ b/src/pcobra/corelibs/proceso.py
@@ -8,6 +8,7 @@ la entrada no es confiable.
 
 from __future__ import annotations
 
+import asyncio
 import shlex
 import subprocess
 from collections.abc import Sequence
@@ -18,6 +19,8 @@ ResultadoProceso = dict[str, int | str]
 __all__ = [
     "ejecutar",
     "capturar",
+    "ejecutar_async",
+    "ejecutar_stream",
     "codigo_salida",
     "salida",
     "errores",
@@ -77,6 +80,7 @@ def ejecutar(
     *,
     argumentos: Sequence[object] | None = None,
     shell: bool = False,
+    autorizar_shell: bool = False,
     cwd: str | None = None,
     entorno: dict[str, str] | None = None,
     timeout: int | float | None = None,
@@ -98,6 +102,10 @@ def ejecutar(
     ``127`` y ``124`` respectivamente.
     """
 
+    if not isinstance(shell, bool) or not isinstance(autorizar_shell, bool):
+        raise TypeError("shell y autorizar_shell deben ser booleanos")
+    if shell and not autorizar_shell:
+        raise PermissionError("shell=True requiere autorizar_shell=True explícito")
     comando_preparado = _preparar_comando(comando, argumentos=argumentos, shell=shell)
     try:
         completado = subprocess.run(
@@ -130,6 +138,7 @@ def capturar(
     *,
     argumentos: Sequence[object] | None = None,
     shell: bool = False,
+    autorizar_shell: bool = False,
     cwd: str | None = None,
     entorno: dict[str, str] | None = None,
     timeout: int | float | None = None,
@@ -140,10 +149,31 @@ def capturar(
         comando,
         argumentos=argumentos,
         shell=shell,
+        autorizar_shell=autorizar_shell,
         cwd=cwd,
         entorno=entorno,
         timeout=timeout,
     )
+
+
+async def ejecutar_async(
+    comando: str | Sequence[object],
+    **opciones: Any,
+) -> ResultadoProceso:
+    """Ejecuta sin bloquear el bucle de eventos, con el mismo contrato seguro."""
+
+    return await asyncio.to_thread(ejecutar, comando, **opciones)
+
+
+async def ejecutar_stream(
+    comando: str | Sequence[object],
+    **opciones: Any,
+):
+    """Produce por líneas la salida capturada de un proceso terminado."""
+
+    resultado = await ejecutar_async(comando, **opciones)
+    for linea in str(resultado["salida"]).splitlines(keepends=True):
+        yield linea
 
 
 def codigo_salida(resultado: dict[str, Any]) -> int:

--- a/tests/data/usar_exports_snapshot.json
+++ b/tests/data/usar_exports_snapshot.json
@@ -215,6 +215,8 @@
     "proceso": [
       "ejecutar",
       "capturar",
+      "ejecutar_async",
+      "ejecutar_stream",
       "codigo_salida",
       "salida",
       "errores"

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -1103,8 +1103,14 @@ def test_repl_contract_pipeline_completo_por_modulo_canonico(monkeypatch, tmp_pa
             interp.contextos[-1].values[symbol]("cobra")
         elif modulo == "cripto" and symbol == "comparar_seguro":
             interp.contextos[-1].values[symbol]("cobra", "cobra")
-        elif modulo == "proceso" and symbol in {"ejecutar", "capturar"}:
-            interp.contextos[-1].values[symbol](["python", "--version"])
+        elif modulo == "proceso" and symbol in {
+            "ejecutar",
+            "capturar",
+            "ejecutar_async",
+            "ejecutar_stream",
+        }:
+            with pytest.raises(PermissionError, match="process.spawn"):
+                interp.contextos[-1].values[symbol](["python", "--version"])
         elif modulo == "proceso" and symbol == "codigo_salida":
             interp.contextos[-1].values[symbol]({"codigo": 0})
         elif modulo == "proceso" and symbol == "salida":

--- a/tests/unit/test_usar_proceso_capabilities.py
+++ b/tests/unit/test_usar_proceso_capabilities.py
@@ -1,0 +1,121 @@
+"""Regresiones de capacidades para la superficie pública ``proceso``."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from pcobra.cobra.usar_capabilities import CapacidadUsar, capacidades_de, simbolo_canonico
+from pcobra.cobra.usar_loader import usar_modulo
+from pcobra.corelibs import proceso
+
+
+EXPORTS_QUE_CREAN_PROCESOS = (
+    "ejecutar",
+    "capturar",
+    "ejecutar_async",
+    "ejecutar_stream",
+)
+
+
+def test_modo_seguro_conserva_exports_puros_de_proceso():
+    exports = usar_modulo("proceso", safe_mode=True)
+    resultado = {"codigo": 7, "salida": "out", "error": "err"}
+
+    assert exports["codigo_salida"](resultado) == 7
+    assert exports["salida"](resultado) == "out"
+    assert exports["errores"](resultado) == "err"
+
+
+@pytest.mark.parametrize("nombre", EXPORTS_QUE_CREAN_PROCESOS)
+def test_modo_seguro_deniega_todos_los_exports_que_crean_procesos(nombre):
+    simbolo = usar_modulo("proceso", safe_mode=True)[nombre]
+
+    with pytest.raises(PermissionError, match="process.spawn"):
+        simbolo("programa-inexistente")
+
+
+def test_capturar_no_alcanza_subprocess_si_ejecutar_publico_esta_bloqueado(monkeypatch):
+    llamadas = []
+    monkeypatch.setattr(proceso.subprocess, "run", lambda *a, **k: llamadas.append((a, k)))
+    exports = usar_modulo("proceso", safe_mode=True)
+
+    with pytest.raises(PermissionError, match="process.spawn"):
+        exports["ejecutar"]("programa")
+    with pytest.raises(PermissionError, match="process.spawn"):
+        exports["capturar"]("programa")
+
+    assert llamadas == []
+
+
+def test_reproduce_bypass_de_bloquear_solo_el_export_ejecutar(monkeypatch):
+    """Documenta por qué bloquear un nombre, en vez de su capacidad, era insuficiente."""
+
+    llamadas = []
+    monkeypatch.setattr(
+        proceso.subprocess,
+        "run",
+        lambda *a, **k: llamadas.append((a, k))
+        or type("Completado", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+    superficie_ingenua = {
+        "ejecutar": lambda *a, **k: (_ for _ in ()).throw(PermissionError()),
+        "capturar": proceso.capturar,
+    }
+
+    with pytest.raises(PermissionError):
+        superficie_ingenua["ejecutar"]("programa")
+    superficie_ingenua["capturar"]("programa")
+
+    assert len(llamadas) == 1
+
+
+def test_alias_capturar_hereda_capacidades_del_simbolo_canonico():
+    assert simbolo_canonico("proceso", "capturar") == ("proceso", "ejecutar")
+    assert capacidades_de("proceso", "capturar") == frozenset(
+        {CapacidadUsar.PROCESS_SPAWN}
+    )
+
+
+def test_contrato_no_depende_de_atributos_mutables_del_callable():
+    proceso.capturar.capacidades = frozenset()  # type: ignore[attr-defined]
+    try:
+        assert capacidades_de("proceso", "capturar") == frozenset(
+            {CapacidadUsar.PROCESS_SPAWN}
+        )
+    finally:
+        del proceso.capturar.capacidades  # type: ignore[attr-defined]
+
+
+def test_modo_seguro_deniega_shell_siempre():
+    ejecutar = usar_modulo("proceso", safe_mode=True)["ejecutar"]
+    with pytest.raises(PermissionError, match="process.shell"):
+        ejecutar("echo no", shell=True, autorizar_shell=True)
+
+
+def test_modo_no_seguro_exige_autorizacion_shell(monkeypatch):
+    monkeypatch.setattr(
+        proceso.subprocess,
+        "run",
+        lambda *args, **kwargs: type(
+            "Completado", (), {"returncode": 0, "stdout": "ok", "stderr": ""}
+        )(),
+    )
+    ejecutar = usar_modulo("proceso", safe_mode=False)["ejecutar"]
+
+    with pytest.raises(PermissionError, match="autorizar_shell=True"):
+        ejecutar("echo no", shell=True)
+    assert ejecutar("echo si", shell=True, autorizar_shell=True)["salida"] == "ok"
+
+
+@pytest.mark.parametrize("campo", ("shell", "autorizar_shell"))
+def test_modo_no_seguro_exige_booleanos_validos(campo):
+    opciones = {campo: 1}
+    with pytest.raises(TypeError, match="deben ser booleanos"):
+        proceso.ejecutar("programa", **opciones)
+
+
+def test_exports_async_conservan_su_forma_publica():
+    assert inspect.iscoroutinefunction(proceso.ejecutar_async)
+    assert inspect.isasyncgenfunction(proceso.ejecutar_stream)


### PR DESCRIPTION
### Motivation

- Asegurar que la API pública de `usar` aplique contratos de capacidad inmutables para operaciones que crean procesos y evitar bypasses que dependían de nombres o atributos mutables.  
- Denegar creación de procesos (`process.spawn`) por defecto en modo seguro y denegar siempre ejecución por shell (`process.shell`).  
- Mantener la compatibilidad en modo no seguro pero exigir autorización explícita para `shell=True` sin introducir comportamientos implícitos.

### Description

- Añade el módulo canónico `pcobra.cobra.usar_capabilities` que define `CapacidadUsar` y contratos inmutables mapeando símbolos canónicos a capacidades mantenidas por código.  
- Actualiza `pcobra.cobra.usar_loader` para aplicar capacidades al construir la superficie pública y envolver (wrap) callables según el contrato, negando `process.spawn`/`process.shell` en `safe_mode`.  
- Extiende `src/pcobra/corelibs/proceso.py` con `ejecutar_async` y `ejecutar_stream`, y exige `autorizar_shell=True` (booleano) para `shell=True`; valida tipos booleanos y convierte timeouts/comandos en resultados no excepcionales.  
- Propaga `safe_mode` desde `InterpretadorCobra` a `usar_modulo` para que el cargador construya la superficie pública correcta en contexto; actualiza contratos públicos y snapshots relacionados y añade pruebas de regresión específicas.

### Testing

- Ejecuté `pytest -q tests/unit/test_usar_proceso_capabilities.py` y la suite de pruebas específicas integradas; las pruebas focales completaron correctamente (nuevo test file y comprobaciones de alias/capacidades ejecutadas).  
- Ejecuté la batería combinada `pytest -q tests/unit/test_usar_proceso_capabilities.py tests/core/test_superficie_publica_canonica.py tests/core/test_usar_policy_nuevas_corelibs.py tests/unit/test_usar_policy_contract.py tests/test_usar_public_exports_snapshot.py 'tests/integration/test_repl_usar_entrypoints_contract.py::test_repl_contract_pipeline_completo_por_modulo_canonico[proceso]'` y obtuve todas las pruebas verdes (`134 passed`).  
- Comprobé la compilación estática de los módulos modificados con `python -m py_compile src/pcobra/cobra/usar_capabilities.py src/pcobra/cobra/usar_loader.py src/pcobra/core/interpreter.py src/pcobra/corelibs/proceso.py` y no se reportaron errores.  
- Ejecuté `git diff --check` y verifiqué que no se modificaron Lexer ni Parser en el diff final.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76f1017a1083278ca361978f749a53)