### PR TITLE
security(io): centraliza sandbox de rutas

### DIFF
--- a/src/pcobra/corelibs/_sandbox_paths.py
+++ b/src/pcobra/corelibs/_sandbox_paths.py
@@ -1,0 +1,75 @@
+"""Resolución interna de rutas confinadas para las corelibs de E/S.
+
+Si ``COBRA_IO_BASE_DIR`` no está configurada, el sandbox usa un directorio
+temporal exclusivo del proceso, creado con permisos privados por
+``tempfile.mkdtemp``. Este módulo es deliberadamente interno y no forma parte
+de las superficies públicas de :mod:`pcobra.corelibs`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Final
+
+_VARIABLE_RAIZ: Final = "COBRA_IO_BASE_DIR"
+_raiz_privada: Path | None = None
+
+
+def _obtener_raiz() -> Path:
+    """Devuelve la raíz configurada o crea una privada para este proceso."""
+
+    configurada = os.environ.get(_VARIABLE_RAIZ)
+    if configurada:
+        raiz = Path(configurada).expanduser().resolve(strict=True)
+        if not raiz.is_dir():
+            raise NotADirectoryError(f"La raíz del sandbox no es un directorio: {raiz}")
+        return raiz
+
+    global _raiz_privada
+    if _raiz_privada is None:
+        _raiz_privada = Path(tempfile.mkdtemp(prefix="pcobra-io-"))
+    return _raiz_privada.resolve(strict=True)
+
+
+def _normalizar_ruta_usuario(ruta: str | os.PathLike[str]) -> Path:
+    texto = os.fspath(ruta)
+    if not isinstance(texto, str):
+        raise TypeError("La ruta debe ser texto")
+    if not texto or "\x00" in texto:
+        raise ValueError("La ruta no es válida")
+
+    # Se comprueban ambas sintaxis antes de adaptar separadores al anfitrión.
+    if PurePosixPath(texto).is_absolute() or PureWindowsPath(texto).is_absolute():
+        raise ValueError("Las rutas absolutas no están permitidas")
+    normalizada = Path(texto.replace("\\", "/"))
+    if ".." in normalizada.parts:
+        raise ValueError("La ruta no puede contener '..'")
+    return normalizada
+
+
+def _comprobar_confinamiento(ruta: Path, raiz: Path) -> Path:
+    try:
+        ruta.relative_to(raiz)
+    except ValueError as exc:
+        raise ValueError("La ruta queda fuera del directorio permitido") from exc
+    return ruta
+
+
+def resolver_ruta_existente(ruta: str | os.PathLike[str]) -> Path:
+    """Resuelve una ruta relativa existente y confinada dentro del sandbox."""
+
+    raiz = _obtener_raiz()
+    objetivo = (raiz / _normalizar_ruta_usuario(ruta)).resolve(strict=True)
+    return _comprobar_confinamiento(objetivo, raiz)
+
+
+def resolver_destino_nuevo(ruta: str | os.PathLike[str]) -> Path:
+    """Resuelve un destino nuevo tras validar el padre real y su confinamiento."""
+
+    raiz = _obtener_raiz()
+    destino = raiz / _normalizar_ruta_usuario(ruta)
+    padre_real = destino.parent.resolve(strict=True)
+    _comprobar_confinamiento(padre_real, raiz)
+    return padre_real / destino.name

--- a/tests/unit/test_sandbox_paths.py
+++ b/tests/unit/test_sandbox_paths.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from pcobra.corelibs import _sandbox_paths
+
+
+def test_resuelve_ruta_existente_desde_raiz_configurada(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "datos.txt"
+    archivo.write_text("ok", encoding="utf-8")
+
+    assert _sandbox_paths.resolver_ruta_existente("datos.txt") == archivo
+
+
+def test_raiz_por_defecto_es_privada(monkeypatch):
+    monkeypatch.delenv("COBRA_IO_BASE_DIR", raising=False)
+    monkeypatch.setattr(_sandbox_paths, "_raiz_privada", None)
+
+    destino = _sandbox_paths.resolver_destino_nuevo("datos.txt")
+
+    assert destino.parent != Path.cwd().resolve()
+    assert destino.parent.stat().st_mode & 0o077 == 0
+
+
+@pytest.mark.parametrize(
+    "ruta",
+    ["/etc/passwd", r"C:\Windows\system.ini", r"\\servidor\recurso\dato"],
+)
+def test_rechaza_rutas_absolutas_de_ambas_plataformas(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+    with pytest.raises(ValueError, match="absolutas"):
+        _sandbox_paths.resolver_ruta_existente(ruta)
+
+
+@pytest.mark.parametrize("ruta", ["../dato", "carpeta/../../dato", r"carpeta\..\..\dato"])
+def test_rechaza_componentes_de_traversal(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+    with pytest.raises(ValueError, match=r"\.\."):
+        _sandbox_paths.resolver_destino_nuevo(ruta)
+
+
+def test_rechaza_symlink_existente_que_sale_de_la_raiz(monkeypatch, tmp_path):
+    raiz = tmp_path / "raiz"
+    exterior = tmp_path / "exterior"
+    raiz.mkdir()
+    exterior.mkdir()
+    secreto = exterior / "secreto.txt"
+    secreto.write_text("no", encoding="utf-8")
+    (raiz / "enlace").symlink_to(exterior, target_is_directory=True)
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(raiz))
+
+    with pytest.raises(ValueError, match="fuera"):
+        _sandbox_paths.resolver_ruta_existente("enlace/secreto.txt")
+
+
+@pytest.mark.parametrize("ruta", ["carpeta/dato.txt", r"carpeta\dato.txt"])
+def test_normaliza_separadores_posix_y_windows(monkeypatch, tmp_path, ruta):
+    carpeta = tmp_path / "carpeta"
+    carpeta.mkdir()
+    archivo = carpeta / "dato.txt"
+    archivo.write_text("ok", encoding="utf-8")
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+    assert _sandbox_paths.resolver_ruta_existente(ruta) == archivo
+
+
+def test_destino_inexistente_valida_symlinks_del_padre(monkeypatch, tmp_path):
+    raiz = tmp_path / "raiz"
+    exterior = tmp_path / "exterior"
+    raiz.mkdir()
+    exterior.mkdir()
+    (raiz / "enlace").symlink_to(exterior, target_is_directory=True)
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(raiz))
+
+    with pytest.raises(ValueError, match="fuera"):
+        _sandbox_paths.resolver_destino_nuevo("enlace/nuevo.txt")
+
+
+def test_modos_distinguen_existencia_del_objetivo(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+    with pytest.raises(FileNotFoundError):
+        _sandbox_paths.resolver_ruta_existente("nuevo.txt")
+    assert _sandbox_paths.resolver_destino_nuevo("nuevo.txt") == tmp_path / "nuevo.txt"
+
+
+def test_modulo_no_se_exporta_desde_corelibs():
+    assert "_sandbox_paths" not in __import__("pcobra.corelibs", fromlist=["__all__"]).__all__


### PR DESCRIPTION
### Motivation

- Centralizar la lógica de resolución y confinamiento de rutas usada por las corelibs de E/S para reducir duplicación y cerrar vectores de escape.
- Forzar una política segura: rechazar rutas absolutas de ambas plataformas, bloquear componentes `..` y tratar symlinks antes de comprobar confinamiento.
- Proveer modos distintos para resolución de rutas que ya existen y para destinos nuevos de forma que la validación del padre real sea explícita.

### Description

- Se añade un módulo interno `src/pcobra/corelibs/_sandbox_paths.py` con funciones auxiliares privadas: `_obtener_raiz`, `_normalizar_ruta_usuario`, `_comprobar_confinamiento`, `resolver_ruta_existente` y `resolver_destino_nuevo`.
- La raíz se resuelve desde la variable `COBRA_IO_BASE_DIR`; si falta, se crea una raíz privada por proceso usando `tempfile.mkdtemp` y se usa como fallback seguro.
- Antes de combinar la ruta con la raíz se rechazan rutas absolutas POSIX y Windows, se normalizan separadores (`\` → `/`) y se prohíben componentes `..`, y se resuelven symlinks de componentes existentes antes de verificar confinamiento con `Path.relative_to`.
- Se añade `tests/unit/test_sandbox_paths.py` con pruebas focales que cubren: raíz configurada, raíz por defecto privada, rutas absolutas POSIX/Windows, `..`/traversal, symlink saliente, normalización de separadores y distinción entre destinos existentes y nuevos; el módulo permanece interno y no se exporta en la superficie pública.

### Testing

- Se ejecutaron las pruebas focales con `pytest -q tests/unit/test_sandbox_paths.py` y todas pasaron (`14 passed`).
- Se comprobó la sintaxis/estática con `ruff check src/pcobra/corelibs/_sandbox_paths.py tests/unit/test_sandbox_paths.py` y `python -m py_compile src/pcobra/corelibs/_sandbox_paths.py tests/unit/test_sandbox_paths.py`, ambos sin errores.
- Se ejecutó `git diff --check` para detectar problemas en el diff y se revisó que no hubo modificaciones en los ficheros de Lexer/Parser solicitados.
- El cambio es interno y aislado a la nueva utilidad y sus pruebas, sin migraciones adicionales de `archivo`, `red` o `compresion` en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76f50607708327905d3e7a44314198)