### PR TITLE
security(network): hace descargas atómicas y confinadas

### DIFF
--- a/src/pcobra/corelibs/_sandbox_paths.py
+++ b/src/pcobra/corelibs/_sandbox_paths.py
@@ -66,10 +66,22 @@ def resolver_ruta_existente(ruta: str | os.PathLike[str]) -> Path:
 
 
 def resolver_destino_nuevo(ruta: str | os.PathLike[str]) -> Path:
-    """Resuelve un destino nuevo tras validar el padre real y su confinamiento."""
+    """Resuelve un destino nuevo validando primero su confinamiento.
+
+    Los directorios intermedios pueden no existir todavía. Se resuelve el
+    ancestro existente más próximo para detectar enlaces simbólicos salientes
+    sin crear nada antes de completar la validación.
+    """
 
     raiz = _obtener_raiz()
     destino = raiz / _normalizar_ruta_usuario(ruta)
-    padre_real = destino.parent.resolve(strict=True)
-    _comprobar_confinamiento(padre_real, raiz)
-    return padre_real / destino.name
+    ancestro = destino.parent
+    partes_pendientes: list[str] = []
+    while not ancestro.exists():
+        partes_pendientes.append(ancestro.name)
+        ancestro = ancestro.parent
+    ancestro_real = ancestro.resolve(strict=True)
+    _comprobar_confinamiento(ancestro_real, raiz)
+    padre_validado = ancestro_real.joinpath(*reversed(partes_pendientes))
+    _comprobar_confinamiento(padre_validado, raiz)
+    return padre_validado / destino.name

--- a/src/pcobra/corelibs/red.py
+++ b/src/pcobra/corelibs/red.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import tempfile
 from typing import Any, TYPE_CHECKING
 import urllib.parse
 
 import requests
+
+from pcobra.corelibs._sandbox_paths import resolver_destino_nuevo
 
 try:  # pragma: no cover - depende de extras opcionales
     import httpx  # type: ignore[import-not-found]
@@ -172,15 +175,16 @@ async def _leer_respuesta_async(resp: "_httpx.Response") -> str:
     return datos.decode(resp.encoding or "utf-8", errors="replace")
 
 
-async def _descargar_a_archivo(resp: "_httpx.Response", destino: Path) -> Path:
+async def _descargar_a_archivo(resp: "_httpx.Response", archivo: Any) -> None:
     total = 0
-    with destino.open("wb") as archivo:
-        async for chunk in resp.aiter_bytes(chunk_size=8192):
-            total += len(chunk)
-            if total > _MAX_RESP_SIZE:
-                raise ValueError("Respuesta demasiado grande")
-            archivo.write(chunk)
-    return destino
+    async for chunk in resp.aiter_bytes(chunk_size=8192):
+        nuevo_total = total + len(chunk)
+        if nuevo_total > _MAX_RESP_SIZE:
+            raise ValueError("Respuesta demasiado grande")
+        archivo.write(chunk)
+        total = nuevo_total
+    archivo.flush()
+    os.fsync(archivo.fileno())
 
 
 async def _realizar_peticion_async(
@@ -189,7 +193,7 @@ async def _realizar_peticion_async(
     *,
     datos: dict[str, Any] | None = None,
     permitir_redirecciones: bool = False,
-    destino: Path | None = None,
+    archivo_destino: Any | None = None,
 ) -> str | Path:
     _validar_esquema(url)
     hosts = _obtener_hosts_permitidos()
@@ -207,15 +211,20 @@ async def _realizar_peticion_async(
                     if redirecciones_restantes == 0:
                         raise ValueError("Demasiadas redirecciones")
                     destino_header = resp.headers.get("Location")
-                    url_actual = _resolver_redireccion(url_actual, destino_header, hosts)
+                    url_actual = _resolver_redireccion(
+                        url_actual, destino_header, hosts
+                    )
                     redirecciones_restantes -= 1
                     continue
+                if 300 <= resp.status_code < 400:
+                    raise ValueError("Redirecciones no permitidas")
                 resp.raise_for_status()
                 url_final = str(resp.url)
                 _validar_esquema(url_final)
                 _validar_host(url_final, hosts)
-                if destino is not None:
-                    return await _descargar_a_archivo(resp, destino)
+                if archivo_destino is not None:
+                    await _descargar_a_archivo(resp, archivo_destino)
+                    return Path(archivo_destino.name)
                 return await _leer_respuesta_async(resp)
 
 
@@ -263,19 +272,30 @@ async def descargar_archivo(
     recibida y con las utilidades de archivos locales.
     """
 
-    ruta = Path(destino)
+    ruta = resolver_destino_nuevo(destino)
     if crear_padres:
         ruta.parent.mkdir(parents=True, exist_ok=True)
+    elif not ruta.parent.is_dir():
+        raise FileNotFoundError(ruta.parent)
+
+    temporal: Path | None = None
     try:
-        resultado = await _realizar_peticion_async(
-            "GET", url, permitir_redirecciones=permitir_redirecciones, destino=ruta
-        )
+        with tempfile.NamedTemporaryFile(
+            mode="w+b", prefix=f".{ruta.name}.", dir=ruta.parent, delete=False
+        ) as archivo:
+            temporal = Path(archivo.name)
+            await _realizar_peticion_async(
+                "GET",
+                url,
+                permitir_redirecciones=permitir_redirecciones,
+                archivo_destino=archivo,
+            )
+        os.replace(temporal, ruta)
     except Exception:
-        if ruta.exists():
-            ruta.unlink()
+        if temporal is not None:
+            temporal.unlink(missing_ok=True)
         raise
-    assert isinstance(resultado, Path)
-    return resultado
+    return ruta
 
 
 async def obtener_url_texto(url: str, permitir_redirecciones: bool = False) -> str:

--- a/tests/unit/test_corelibs_async.py
+++ b/tests/unit/test_corelibs_async.py
@@ -356,6 +356,7 @@ async def test_obtener_url_async(monkeypatch):
 @pytest.mark.asyncio
 async def test_descargar_archivo_async_elimina_si_falla(monkeypatch, tmp_path):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
 
     class _ResponseGrande(_FakeResponse):
         async def aiter_bytes(self, chunk_size=8192):
@@ -368,13 +369,14 @@ async def test_descargar_archivo_async_elimina_si_falla(monkeypatch, tmp_path):
 
     destino = tmp_path / "archivo.bin"
     with pytest.raises(ValueError):
-        await red.descargar_archivo("https://example.com", destino)
+        await red.descargar_archivo("https://example.com", "archivo.bin")
     assert not destino.exists()
 
 
 @pytest.mark.asyncio
 async def test_descargar_archivo_async(monkeypatch, tmp_path):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     respuesta = _FakeResponse(body=b"contenido")
     cliente = _FakeAsyncClient([respuesta])
     if red.httpx is None:
@@ -382,7 +384,7 @@ async def test_descargar_archivo_async(monkeypatch, tmp_path):
     monkeypatch.setattr(red.httpx, "AsyncClient", lambda **_kwargs: cliente, raising=False)
 
     destino = tmp_path / "datos.bin"
-    ruta = await red.descargar_archivo("https://example.com", destino)
+    ruta = await red.descargar_archivo("https://example.com", "datos.bin")
     assert ruta.read_bytes() == b"contenido"
 
 

--- a/tests/unit/test_red_descargar_archivo.py
+++ b/tests/unit/test_red_descargar_archivo.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pcobra.corelibs import red
+
+
+class _Respuesta:
+    def __init__(
+        self,
+        *,
+        url: str = "https://permitido.test/archivo",
+        chunks: tuple[bytes, ...] = (b"contenido",),
+        status_code: int = 200,
+        location: str | None = None,
+    ) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.headers = {} if location is None else {"Location": location}
+        self._chunks = chunks
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_bytes(self, chunk_size: int = 8192):
+        del chunk_size
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _Cliente:
+    def __init__(self, respuestas: list[_Respuesta]) -> None:
+        self.respuestas = deque(respuestas)
+        self.llamadas: list[tuple[str, str, bool]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def stream(self, metodo: str, url: str, *, follow_redirects: bool, **_kwargs):
+        self.llamadas.append((metodo, url, follow_redirects))
+        return self.respuestas.popleft()
+
+
+def _preparar(monkeypatch, tmp_path: Path, respuestas: list[_Respuesta]) -> _Cliente:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "permitido.test")
+    cliente = _Cliente(respuestas)
+    if red.httpx is None:
+        monkeypatch.setattr(red, "httpx", SimpleNamespace())
+    monkeypatch.setattr(
+        red.httpx, "AsyncClient", lambda **_kwargs: cliente, raising=False
+    )
+    return cliente
+
+
+@pytest.mark.asyncio
+async def test_descarga_destino_valido_y_crea_directorios(monkeypatch, tmp_path):
+    _preparar(monkeypatch, tmp_path, [_Respuesta()])
+
+    destino = await red.descargar_archivo(
+        "https://permitido.test/archivo", "subdirectorio/archivo.bin"
+    )
+
+    assert destino == tmp_path / "subdirectorio" / "archivo.bin"
+    assert destino.read_bytes() == b"contenido"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("destino", ["/tmp/archivo.bin", "../archivo.bin"])
+async def test_descarga_rechaza_ruta_absoluta_y_traversal(
+    monkeypatch, tmp_path, destino
+):
+    cliente = _preparar(monkeypatch, tmp_path, [_Respuesta()])
+
+    with pytest.raises(ValueError):
+        await red.descargar_archivo("https://permitido.test/archivo", destino)
+
+    assert cliente.llamadas == []
+
+
+@pytest.mark.asyncio
+async def test_descarga_rechaza_symlink_saliente(monkeypatch, tmp_path):
+    exterior = tmp_path.parent / f"{tmp_path.name}-exterior"
+    exterior.mkdir()
+    (tmp_path / "enlace").symlink_to(exterior, target_is_directory=True)
+    cliente = _preparar(monkeypatch, tmp_path, [_Respuesta()])
+
+    with pytest.raises(ValueError):
+        await red.descargar_archivo(
+            "https://permitido.test/archivo", "enlace/archivo.bin"
+        )
+
+    assert cliente.llamadas == []
+    assert not (exterior / "archivo.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_fallo_por_tamano_preserva_archivo_previo(monkeypatch, tmp_path):
+    destino = tmp_path / "archivo.bin"
+    destino.write_bytes(b"original")
+    _preparar(
+        monkeypatch,
+        tmp_path,
+        [_Respuesta(chunks=(b"a" * red._MAX_RESP_SIZE, b"exceso"))],
+    )
+
+    with pytest.raises(ValueError, match="demasiado grande"):
+        await red.descargar_archivo("https://permitido.test/archivo", "archivo.bin")
+
+    assert destino.read_bytes() == b"original"
+    assert list(tmp_path.iterdir()) == [destino]
+
+
+@pytest.mark.asyncio
+async def test_descarga_no_sigue_redireccion_por_defecto(monkeypatch, tmp_path):
+    cliente = _preparar(
+        monkeypatch,
+        tmp_path,
+        [_Respuesta(status_code=302, location="https://permitido.test/final")],
+    )
+
+    with pytest.raises(ValueError, match="Redirecciones no permitidas"):
+        await red.descargar_archivo("https://permitido.test/inicio", "archivo.bin")
+
+    assert cliente.llamadas == [("GET", "https://permitido.test/inicio", False)]
+    assert not (tmp_path / "archivo.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_descarga_valida_cada_redireccion_autorizada(monkeypatch, tmp_path):
+    cliente = _preparar(
+        monkeypatch,
+        tmp_path,
+        [
+            _Respuesta(status_code=302, location="https://permitido.test/final"),
+            _Respuesta(url="https://permitido.test/final", chunks=(b"final",)),
+        ],
+    )
+
+    destino = await red.descargar_archivo(
+        "https://permitido.test/inicio",
+        "archivo.bin",
+        permitir_redirecciones=True,
+    )
+
+    assert destino.read_bytes() == b"final"
+    assert cliente.llamadas == [
+        ("GET", "https://permitido.test/inicio", False),
+        ("GET", "https://permitido.test/final", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_descarga_rechaza_host_inicial_y_redireccion_no_permitidos(
+    monkeypatch, tmp_path
+):
+    cliente = _preparar(monkeypatch, tmp_path, [_Respuesta()])
+    with pytest.raises(ValueError, match="Host no permitido"):
+        await red.descargar_archivo("https://otro.test/archivo", "inicial.bin")
+    assert cliente.llamadas == []
+
+    cliente.respuestas.clear()
+    cliente.respuestas.append(
+        _Respuesta(status_code=302, location="https://otro.test/final")
+    )
+    with pytest.raises(ValueError, match="Host no permitido"):
+        await red.descargar_archivo(
+            "https://permitido.test/inicio",
+            "redireccion.bin",
+            permitir_redirecciones=True,
+        )
+    assert len(cliente.llamadas) == 1
+    assert not (tmp_path / "redireccion.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_descarga_rechaza_esquema_inicial_y_en_redireccion(
+    monkeypatch, tmp_path
+):
+    cliente = _preparar(monkeypatch, tmp_path, [])
+    with pytest.raises(ValueError, match="Esquema de URL no soportado"):
+        await red.descargar_archivo("http://permitido.test/archivo", "inicial.bin")
+    assert cliente.llamadas == []
+
+    cliente.respuestas.append(
+        _Respuesta(status_code=302, location="http://permitido.test/final")
+    )
+    with pytest.raises(ValueError, match="Esquema de URL no soportado"):
+        await red.descargar_archivo(
+            "https://permitido.test/inicio",
+            "redireccion.bin",
+            permitir_redirecciones=True,
+        )
+    assert len(cliente.llamadas) == 1
+    assert not (tmp_path / "redireccion.bin").exists()


### PR DESCRIPTION
### Motivation

- Reproducir y corregir un fallo donde una descarga que excedía el límite podía eliminar o truncar el destino existente.
- Asegurar descargas atómicas y confinadas respetando el sandbox y la lista blanca de hosts, sin tocar el destino previo ante errores.
- Añadir regresiones que cubran rutas inválidas, traversal, symlinks salientes, límites de tamaño, esquemas/hosts y comportamiento de redirecciones.

### Description

- Se amplió la resolución de destinos en las utilidades internas para validar el ancestro existente más próximo y detectar symlinks salientes antes de crear directorios; esto evita crear rutas fuera del sandbox inadvertidamente (`src/pcobra/corelibs/_sandbox_paths.py`).
- `descargar_archivo` ahora resuelve el destino con la utilidad común, crea un temporal exclusivo en el mismo directorio mediante `tempfile.NamedTemporaryFile`, descarga por chunks comprobando el límite acumulado antes de cada escritura, hace `flush` + `os.fsync`, cierra el temporal y publica con `os.replace` únicamente si todo es válido; ante error sólo se borra el temporal y nunca el destino previo (`src/pcobra/corelibs/red.py`).
- Las redirecciones quedan deshabilitadas por defecto y, cuando se autorizan, cada salto se valida por esquema y host usando la lista blanca, con un límite de saltos y rechazo explícito si un salto no está permitido (`src/pcobra/corelibs/red.py`).
- Se añadieron pruebas de regresión y casos de borde que cubren destinos válidos, rutas absolutas y traversal, symlink saliente, preservación de archivo previo, exceso de tamaño, redirecciones y esquemas/hosts no permitidos (`tests/unit/test_red_descargar_archivo.py`), y se ajustaron pruebas asíncronas relacionadas (`tests/unit/test_corelibs_async.py`).

### Testing

- Se ejecutaron las pruebas focales y relacionadas con red/archivo: `pytest -q tests/unit/test_red_descargar_archivo.py tests/unit/test_red.py tests/unit/test_archivo.py tests/unit/test_sandbox_paths.py tests/unit/test_corelibs_async.py tests/unit/test_corelibs.py -k "red or archivo or sandbox_paths or descargar"`, resultado: todas las pruebas objetivo pasaron (86 passed, 55 deselected in the run performed).
- Se ejecutaron las pruebas asíncronas específicas (descarga por chunks) y manuales de reproducción del fallo, y se verificó que la descarga que excede el límite preserva el archivo previo (ejecutadas y pasadas en CI local con `pytest` sobre los tests añadidos).
- Se ejecutaron linters/formatters y checks: `ruff` y `black`/formateo aplicados; comprobación estática pasada y `git diff --check` sin problemas.
- Verificación adicional de cumplimiento de reglas del repositorio: no se modificaron Lexer ni Parser y la fachada pública de `standard_library/red.py` se mantiene compatible (las funciones de la API delegan en `pcobra.corelibs.red`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76f82b46e08327a4cbfdb74f8ed133)