### PR TITLE
security(zip): limitar extracción ZIP y proteger contra bombas

### DIFF
--- a/src/pcobra/corelibs/compresion.py
+++ b/src/pcobra/corelibs/compresion.py
@@ -7,12 +7,28 @@ futura; la superficie pública inicial cubre únicamente archivos ZIP.
 from __future__ import annotations
 
 import os
+import shutil
+import stat
+import tempfile
 from pathlib import Path, PurePosixPath
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
+
+from pcobra.corelibs._sandbox_paths import (
+    resolver_destino_nuevo,
+    resolver_ruta_existente,
+)
 
 PathLike = str | os.PathLike[str]
 
 __all__ = ["crear_zip", "extraer_zip", "listar_zip"]
+
+# Límites internos (no forman parte de la API pública) y sustituibles en pruebas o
+# por integradores que necesiten una política más restrictiva.
+_MAX_ENTRADAS = 10_000
+_MAX_BYTES_ENTRADA = 100 * 1024 * 1024
+_MAX_BYTES_TOTALES = 1024 * 1024 * 1024
+_MAX_RATIO_COMPRESION = 100.0
+_TAMANO_CHUNK = 64 * 1024
 
 
 def crear_zip(
@@ -49,35 +65,58 @@ def crear_zip(
 
 
 def extraer_zip(origen: PathLike, destino: PathLike) -> list[str]:
-    """Extrae ``origen`` en ``destino`` evitando path traversal.
+    """Extrae ``origen`` en ``destino`` de forma confinada y limitada.
 
     Devuelve las rutas extraídas como cadenas. Cada miembro del ZIP se resuelve
     contra el directorio destino y se rechaza si queda fuera de él.
     """
 
-    origen_zip = _validar_ruta(origen, "origen")
-    if not origen_zip.exists():
-        raise FileNotFoundError(f"El ZIP de origen no existe: {origen_zip}")
-
-    destino_base = _validar_ruta(destino, "destino").resolve()
+    origen_zip = resolver_ruta_existente(_texto_ruta(origen, "origen"))
+    destino_base = resolver_destino_nuevo(_texto_ruta(destino, "destino"))
+    if destino_base.is_symlink():
+        raise ValueError("El destino de extracción no puede ser un enlace simbólico")
     destino_base.mkdir(parents=True, exist_ok=True)
-    rutas_extraidas: list[str] = []
-
-    with ZipFile(origen_zip, "r") as archivo_zip:
-        for miembro in archivo_zip.infolist():
-            ruta_destino = _ruta_segura_extraccion(destino_base, miembro.filename)
-            if miembro.is_dir():
-                ruta_destino.mkdir(parents=True, exist_ok=True)
-            else:
-                ruta_destino.parent.mkdir(parents=True, exist_ok=True)
+    temporal = Path(tempfile.mkdtemp(prefix=".pcobra-zip-", dir=destino_base))
+    try:
+        with ZipFile(origen_zip, "r") as archivo_zip:
+            miembros = archivo_zip.infolist()
+            rutas = _inspeccionar_miembros(miembros, destino_base)
+            _comprobar_destinos_libres(rutas, destino_base)
+            total_real = 0
+            for miembro, ruta_final in zip(miembros, rutas):
+                relativa = ruta_final.relative_to(destino_base)
+                ruta_temporal = temporal / relativa
+                if miembro.is_dir():
+                    ruta_temporal.mkdir(parents=True, exist_ok=True)
+                    continue
+                ruta_temporal.parent.mkdir(parents=True, exist_ok=True)
+                bytes_entrada = 0
                 with (
-                    archivo_zip.open(miembro, "r") as origen_archivo,
-                    ruta_destino.open("wb") as destino_archivo,
+                    archivo_zip.open(miembro) as entrada,
+                    ruta_temporal.open("xb") as salida,
                 ):
-                    destino_archivo.write(origen_archivo.read())
-            rutas_extraidas.append(str(ruta_destino))
+                    while chunk := entrada.read(_TAMANO_CHUNK):
+                        bytes_entrada += len(chunk)
+                        total_real += len(chunk)
+                        if bytes_entrada > _MAX_BYTES_ENTRADA:
+                            raise ValueError(
+                                "Una entrada ZIP supera el tamaño permitido"
+                            )
+                        if total_real > _MAX_BYTES_TOTALES:
+                            raise ValueError("El ZIP supera el tamaño total permitido")
+                        salida.write(chunk)
 
-    return rutas_extraidas
+        for miembro, ruta_final in zip(miembros, rutas):
+            relativa = ruta_final.relative_to(destino_base)
+            ruta_temporal = temporal / relativa
+            if miembro.is_dir():
+                ruta_final.mkdir(parents=True, exist_ok=True)
+            else:
+                ruta_final.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(ruta_temporal, ruta_final)
+        return [str(ruta) for ruta in rutas]
+    finally:
+        shutil.rmtree(temporal, ignore_errors=True)
 
 
 def listar_zip(origen: PathLike) -> list[str]:
@@ -104,6 +143,10 @@ def _normalizar_rutas(
 
 
 def _validar_ruta(ruta: PathLike, nombre_argumento: str) -> Path:
+    return Path(_texto_ruta(ruta, nombre_argumento))
+
+
+def _texto_ruta(ruta: PathLike, nombre_argumento: str) -> str:
     if not isinstance(ruta, (str, os.PathLike)):
         raise TypeError(
             f"{nombre_argumento} debe ser una ruta de texto o compatible con os.PathLike"
@@ -113,7 +156,7 @@ def _validar_ruta(ruta: PathLike, nombre_argumento: str) -> Path:
         raise TypeError(f"{nombre_argumento} debe representar una ruta de texto")
     if texto == "":
         raise ValueError(f"{nombre_argumento} no puede estar vacía")
-    return Path(texto)
+    return texto
 
 
 def _resolver_base(rutas: list[Path], base: PathLike | None) -> Path:
@@ -171,3 +214,42 @@ def _ruta_segura_extraccion(destino_base: Path, nombre: str) -> Path:
 
 def _parece_ruta_windows_absoluta(nombre: str) -> bool:
     return len(nombre) >= 2 and nombre[1] == ":" and nombre[0].isalpha()
+
+
+def _inspeccionar_miembros(miembros: list[ZipInfo], destino_base: Path) -> list[Path]:
+    if len(miembros) > _MAX_ENTRADAS:
+        raise ValueError("El ZIP supera la cantidad de entradas permitida")
+
+    total_declarado = 0
+    rutas: list[Path] = []
+    for miembro in miembros:
+        ruta = _ruta_segura_extraccion(destino_base, miembro.filename)
+        tipo = stat.S_IFMT(miembro.external_attr >> 16)
+        if tipo not in (0, stat.S_IFREG, stat.S_IFDIR):
+            raise ValueError(f"Tipo de entrada ZIP no permitido: {miembro.filename}")
+        if miembro.file_size > _MAX_BYTES_ENTRADA:
+            raise ValueError("Una entrada ZIP supera el tamaño permitido")
+        total_declarado += miembro.file_size
+        if total_declarado > _MAX_BYTES_TOTALES:
+            raise ValueError("El ZIP supera el tamaño total permitido")
+        if miembro.compress_size:
+            ratio = miembro.file_size / miembro.compress_size
+        else:
+            ratio = float("inf") if miembro.file_size else 1.0
+        if ratio > _MAX_RATIO_COMPRESION:
+            raise ValueError("Una entrada ZIP supera el ratio de compresión permitido")
+        rutas.append(ruta)
+    return rutas
+
+
+def _comprobar_destinos_libres(rutas: list[Path], destino_base: Path) -> None:
+    if len(set(rutas)) != len(rutas):
+        raise ValueError("El ZIP contiene destinos duplicados")
+    for ruta in rutas:
+        if ruta.exists() or ruta.is_symlink():
+            raise FileExistsError(f"El destino ya existe: {ruta}")
+        for padre in ruta.parents:
+            if padre == destino_base:
+                break
+            if padre.is_symlink() or (padre.exists() and not padre.is_dir()):
+                raise FileExistsError(f"Un ancestro del destino no es seguro: {padre}")

--- a/tests/core/test_corelib_compresion.py
+++ b/tests/core/test_corelib_compresion.py
@@ -8,6 +8,11 @@ import pytest
 import pcobra.corelibs.compresion as compresion
 
 
+@pytest.fixture(autouse=True)
+def _sandbox(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+
 def test_import_directo_y_all_presente() -> None:
     modulo = importlib.import_module("pcobra.corelibs.compresion")
 
@@ -26,7 +31,9 @@ def test_crear_listar_y_extraer_zip_con_tmp_path(tmp_path) -> None:
 
     nombres = compresion.crear_zip(zip_path, archivo, base=origen)
     destino = tmp_path / "extraido"
-    extraidas = compresion.extraer_zip(zip_path, destino)
+    extraidas = compresion.extraer_zip(
+        zip_path.relative_to(tmp_path), destino.relative_to(tmp_path)
+    )
 
     assert nombres == ["datos.txt"]
     assert compresion.listar_zip(zip_path) == ["datos.txt"]
@@ -40,4 +47,4 @@ def test_extraer_zip_rechaza_path_traversal(tmp_path) -> None:
         archivo_zip.writestr("../escape.txt", "no")
 
     with pytest.raises(ValueError):
-        compresion.extraer_zip(zip_path, tmp_path / "destino")
+        compresion.extraer_zip(zip_path.name, "destino")

--- a/tests/test_corelibs_compresion.py
+++ b/tests/test_corelibs_compresion.py
@@ -1,9 +1,20 @@
 from pathlib import Path
-from zipfile import ZipFile
+import stat
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
 import pytest
 
+import pcobra.corelibs.compresion as compresion
 from pcobra.corelibs.compresion import crear_zip, extraer_zip, listar_zip
+
+
+@pytest.fixture(autouse=True)
+def _sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+
+def _rel(tmp_path: Path, ruta: Path) -> Path:
+    return ruta.relative_to(tmp_path)
 
 
 def test_crear_listar_y_extraer_zip(tmp_path: Path) -> None:
@@ -20,9 +31,11 @@ def test_crear_listar_y_extraer_zip(tmp_path: Path) -> None:
     assert listar_zip(destino_zip) == nombres
 
     destino = tmp_path / "extraido"
-    rutas = extraer_zip(destino_zip, destino)
+    rutas = extraer_zip(_rel(tmp_path, destino_zip), _rel(tmp_path, destino))
 
-    assert sorted(Path(ruta).relative_to(destino).as_posix() for ruta in rutas) == nombres
+    assert (
+        sorted(Path(ruta).relative_to(destino).as_posix() for ruta in rutas) == nombres
+    )
     assert (destino / "docs" / "uno.txt").read_text(encoding="utf-8") == "uno"
     assert (destino / "docs" / "dos.txt").read_text(encoding="utf-8") == "dos"
 
@@ -38,7 +51,7 @@ def test_validar_origen_para_listar_y_extraer(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         listar_zip(origen)
     with pytest.raises(FileNotFoundError):
-        extraer_zip(origen, tmp_path / "destino")
+        extraer_zip(_rel(tmp_path, origen), "destino")
 
 
 @pytest.mark.parametrize(
@@ -49,6 +62,7 @@ def test_validar_origen_para_listar_y_extraer(tmp_path: Path) -> None:
         "docs/../escape.txt",
         "/tmp/escape.txt",
         "C:/escape.txt",
+        "C:\\escape.txt",
     ],
 )
 def test_extraer_zip_rechaza_path_traversal(tmp_path: Path, nombre: str) -> None:
@@ -57,6 +71,118 @@ def test_extraer_zip_rechaza_path_traversal(tmp_path: Path, nombre: str) -> None
         archivo_zip.writestr(nombre, "peligro")
 
     with pytest.raises(ValueError):
-        extraer_zip(origen, tmp_path / "destino")
+        extraer_zip(_rel(tmp_path, origen), "destino")
 
     assert not (tmp_path / "escape.txt").exists()
+
+
+def test_extraer_zip_rechaza_origen_y_destino_exteriores(tmp_path: Path) -> None:
+    with ZipFile(tmp_path / "archivo.zip", "w"):
+        pass
+    with pytest.raises(ValueError):
+        extraer_zip("../fuera.zip", "destino")
+    with pytest.raises(ValueError):
+        extraer_zip("archivo.zip", "../destino")
+    with pytest.raises(ValueError):
+        extraer_zip("/tmp/archivo.zip", "destino")
+    with pytest.raises(ValueError):
+        extraer_zip("C:\\archivo.zip", "destino")
+
+
+def test_extraer_zip_rechaza_symlink_de_destino(tmp_path: Path) -> None:
+    origen = tmp_path / "archivo.zip"
+    with ZipFile(origen, "w") as archivo_zip:
+        archivo_zip.writestr("dato.txt", "dato")
+    exterior = tmp_path.parent / f"{tmp_path.name}-exterior"
+    exterior.mkdir()
+    (tmp_path / "enlace").symlink_to(exterior, target_is_directory=True)
+
+    with pytest.raises(ValueError):
+        extraer_zip("archivo.zip", "enlace")
+
+    assert not (exterior / "dato.txt").exists()
+
+
+def test_extraer_zip_rechaza_enlaces_y_tipos_especiales(tmp_path: Path) -> None:
+    for tipo in (stat.S_IFLNK, stat.S_IFIFO):
+        origen = tmp_path / f"tipo-{tipo}.zip"
+        info = ZipInfo("entrada")
+        info.create_system = 3
+        info.external_attr = (tipo | 0o644) << 16
+        with ZipFile(origen, "w") as archivo_zip:
+            archivo_zip.writestr(info, "contenido")
+        with pytest.raises(ValueError, match="Tipo"):
+            extraer_zip(origen.name, f"destino-{tipo}")
+
+
+def test_extraer_zip_aplica_limites_de_metadatos(tmp_path: Path, monkeypatch) -> None:
+    casos = [
+        ("_MAX_ENTRADAS", 2, [("a", b"1"), ("b", b"2"), ("c", b"3")]),
+        ("_MAX_BYTES_ENTRADA", 2, [("grande", b"123")]),
+        ("_MAX_BYTES_TOTALES", 3, [("a", b"12"), ("b", b"12")]),
+    ]
+    for indice, (limite, valor, entradas) in enumerate(casos):
+        origen = tmp_path / f"limite-{indice}.zip"
+        with ZipFile(origen, "w") as archivo_zip:
+            for nombre, contenido in entradas:
+                archivo_zip.writestr(nombre, contenido)
+        monkeypatch.setattr(compresion, limite, valor)
+        with pytest.raises(ValueError):
+            extraer_zip(origen.name, f"destino-limite-{indice}")
+        monkeypatch.undo()
+        monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+
+
+def test_extraer_zip_rechaza_ratio_extrema_y_miles_de_entradas(
+    tmp_path: Path, monkeypatch
+) -> None:
+    bomba = tmp_path / "ratio.zip"
+    with ZipFile(bomba, "w", ZIP_DEFLATED) as archivo_zip:
+        archivo_zip.writestr("ceros", b"0" * 10_000)
+    monkeypatch.setattr(compresion, "_MAX_RATIO_COMPRESION", 2)
+    with pytest.raises(ValueError, match="ratio"):
+        extraer_zip(bomba.name, "destino-ratio")
+
+    multitud = tmp_path / "miles.zip"
+    with ZipFile(multitud, "w") as archivo_zip:
+        for indice in range(1_001):
+            archivo_zip.writestr(f"{indice}.txt", b"")
+    monkeypatch.setattr(compresion, "_MAX_ENTRADAS", 1_000)
+    with pytest.raises(ValueError, match="cantidad"):
+        extraer_zip(multitud.name, "destino-miles")
+
+
+def test_error_no_publica_resultados_ni_borra_destino(
+    tmp_path: Path, monkeypatch
+) -> None:
+    origen = tmp_path / "archivo.zip"
+    with ZipFile(origen, "w") as archivo_zip:
+        archivo_zip.writestr("primero.txt", b"12")
+        archivo_zip.writestr("segundo.txt", b"34")
+    destino = tmp_path / "destino"
+    destino.mkdir()
+    conservado = destino / "existente.txt"
+    conservado.write_text("intacto", encoding="utf-8")
+    monkeypatch.setattr(compresion, "_MAX_BYTES_TOTALES", 3)
+
+    with pytest.raises(ValueError):
+        extraer_zip(origen.name, destino.name)
+
+    assert conservado.read_text(encoding="utf-8") == "intacto"
+    assert not (destino / "primero.txt").exists()
+    assert not any(ruta.name.startswith(".pcobra-zip-") for ruta in destino.iterdir())
+
+
+def test_extraer_zip_rechaza_archivo_existente(tmp_path: Path) -> None:
+    origen = tmp_path / "archivo.zip"
+    with ZipFile(origen, "w") as archivo_zip:
+        archivo_zip.writestr("dato.txt", "nuevo")
+    destino = tmp_path / "destino"
+    destino.mkdir()
+    existente = destino / "dato.txt"
+    existente.write_text("anterior", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        extraer_zip(origen.name, destino.name)
+
+    assert existente.read_text(encoding="utf-8") == "anterior"


### PR DESCRIPTION
### Motivation

- Evitar vulnerabilidades en la extracción ZIP como path traversal, bombas de compresión y escrituras fuera del sandbox mediante validaciones y límites en la rutina de extracción.
- Utilizar la resolución centralizada de rutas del sandbox para garantizar confinamiento y detectar orígenes/destinos exteriores o enlaces simbólicos inseguros.
- Añadir protecciones transaccionales para que la extracción no deje el destino en un estado parcial ante errores.

### Description

- Resolución segura de rutas: `extraer_zip` ahora resuelve el `origen` y el `destino` mediante `resolver_ruta_existente` y `resolver_destino_nuevo` del sandbox interno para impedir rutas exteriores y detectar symlinks de destino.
- Límites internos configurables: se añadieron `_MAX_ENTRADAS`, `_MAX_BYTES_ENTRADA`, `_MAX_BYTES_TOTALES`, `_MAX_RATIO_COMPRESION` y `_TAMANO_CHUNK` con valores por defecto seguros.
- Inspección y validación previa: se analizan todos los `ZipInfo` antes de extraer, normalizando `/` y `\`, rechazando rutas absolutas POSIX/Windows, componentes `..`, entradas con tipos especiales mediante `external_attr`/`stat`, destinos duplicados y entradas que superen límites de tamaño o ratio.
- Extracción atómica por directorio temporal y copia por chunks: la extracción se realiza en un directorio temporal dentro del destino validado, cada archivo se escribe por chunks contabilizando bytes por entrada y totales, y los ficheros se promueven al destino con `os.replace` solo si toda la extracción es válida; en error solo se borra el árbol temporal.
- Rechazo de sobrescritura: se rechazan destinos que ya existan o ancestros inseguros; no se expone ninguna nueva opción pública que altere este contrato.
- Cambios en pruebas: se añadieron regresiones que cubren `../`, `\` traversal, rutas POSIX/Windows absolutas, symlink de destino, tipos especiales en `ZipInfo`, límites de entradas/bytes/radio y comportamiento transaccional, y se adaptaron pruebas vecinas para ejecutar bajo la raíz del sandbox.
- No se modificaron Lexer ni Parser ni la gramática del lenguaje.

### Testing

- Ejecuté las pruebas focales con `pytest -q tests/test_corelibs_compresion.py tests/core/test_corelib_compresion.py` y obtuve las pruebas enfocadas exitosas (`19 passed`).
- Ejecuté un conjunto más amplio que incluye `tests/unit/test_corelibs.py` junto con las pruebas focales y todo pasó (`81 passed` en la ejecución combinada empleada durante el desarrollo).
- Lint y formato: se ejecutaron `python -m ruff check` y `python -m ruff format --check` (formateo aplicado cuando fue necesario) y los chequeos de estilo/format pasaron.
- Verifiqué que las pruebas relacionadas con sandbox y rutas usaban `COBRA_IO_BASE_DIR` y confirmé que no se tocaron el Lexer ni el Parser durante los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76fbb975e48327b81c48ff1c43d749)