### PR TITLE
security(network): aplica capacidades a todos los aliases

### DIFF
--- a/src/pcobra/cobra/usar_capabilities.py
+++ b/src/pcobra/cobra/usar_capabilities.py
@@ -9,6 +9,10 @@ from types import MappingProxyType
 class CapacidadUsar(StrEnum):
     PROCESS_SPAWN = "process.spawn"
     PROCESS_SHELL = "process.shell"
+    NETWORK_GET = "network.get"
+    NETWORK_POST = "network.post"
+    NETWORK_DOWNLOAD = "network.download"
+    FILESYSTEM_WRITE = "filesystem.write"
 
 
 _SIMBOLO_CANONICO = MappingProxyType(
@@ -17,6 +21,13 @@ _SIMBOLO_CANONICO = MappingProxyType(
         ("proceso", "capturar"): ("proceso", "ejecutar"),
         ("proceso", "ejecutar_async"): ("proceso", "ejecutar_async"),
         ("proceso", "ejecutar_stream"): ("proceso", "ejecutar_stream"),
+        ("red", "obtener_url"): ("red", "obtener_url"),
+        ("red", "obtener_url_async"): ("red", "obtener_url"),
+        ("red", "obtener_url_texto"): ("red", "obtener_url"),
+        ("red", "obtener_json"): ("red", "obtener_url"),
+        ("red", "enviar_post"): ("red", "enviar_post"),
+        ("red", "enviar_post_async"): ("red", "enviar_post"),
+        ("red", "descargar_archivo"): ("red", "descargar_archivo"),
     }
 )
 
@@ -25,6 +36,11 @@ _CAPACIDADES = MappingProxyType(
         ("proceso", "ejecutar"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
         ("proceso", "ejecutar_async"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
         ("proceso", "ejecutar_stream"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
+        ("red", "obtener_url"): frozenset({CapacidadUsar.NETWORK_GET}),
+        ("red", "enviar_post"): frozenset({CapacidadUsar.NETWORK_POST}),
+        ("red", "descargar_archivo"): frozenset(
+            {CapacidadUsar.NETWORK_DOWNLOAD, CapacidadUsar.FILESYSTEM_WRITE}
+        ),
     }
 )
 

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.util
+import inspect
 import logging
 import os
 import re
@@ -128,17 +129,39 @@ def _aplicar_capacidades(
     resultado: list[tuple[str, Any]] = []
     for nombre, simbolo in simbolos:
         capacidades = capacidades_de(modulo, nombre)
-        if not callable(simbolo) or CapacidadUsar.PROCESS_SPAWN not in capacidades:
+        if not callable(simbolo) or not capacidades:
             resultado.append((nombre, simbolo))
             continue
 
-        @wraps(simbolo)
-        def protegido(*args, __simbolo=simbolo, **kwargs):
+        def verificar_permiso(kwargs, __capacidades=capacidades):
             if safe_mode:
-                if kwargs.get("shell") is True:
+                if (
+                    CapacidadUsar.PROCESS_SPAWN in __capacidades
+                    and kwargs.get("shell") is True
+                ):
                     raise PermissionError("capacidad process.shell denegada en modo seguro")
-                raise PermissionError("capacidad process.spawn denegada en modo seguro")
-            return __simbolo(*args, **kwargs)
+                capacidad = sorted(
+                    (capacidad.value for capacidad in __capacidades),
+                    key=lambda valor: (not valor.startswith("network."), valor),
+                )[0]
+                raise PermissionError(
+                    f"capacidad {capacidad} denegada en modo seguro"
+                )
+
+        if modulo == "red" and inspect.iscoroutinefunction(simbolo):
+            @wraps(simbolo)
+            async def protegido(
+                *args, __simbolo=simbolo, __verificar=verificar_permiso, **kwargs
+            ):
+                __verificar(kwargs)
+                return await __simbolo(*args, **kwargs)
+        else:
+            @wraps(simbolo)
+            def protegido(
+                *args, __simbolo=simbolo, __verificar=verificar_permiso, **kwargs
+            ):
+                __verificar(kwargs)
+                return __simbolo(*args, **kwargs)
 
         resultado.append((nombre, protegido))
     return resultado

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -622,17 +622,19 @@ _EFFECTFUL_PUBLIC_SYMBOLS: dict[str, dict[str, frozenset[str]]] = {
     },
     "red": {
         **{
-            name: frozenset({"network.access"})
+            name: frozenset({"network.get"})
             for name in (
                 "obtener_url",
-                "enviar_post",
                 "obtener_url_async",
-                "enviar_post_async",
                 "obtener_url_texto",
                 "obtener_json",
             )
         },
-        "descargar_archivo": frozenset({"network.access", "filesystem.write"}),
+        **{
+            name: frozenset({"network.post"})
+            for name in ("enviar_post", "enviar_post_async")
+        },
+        "descargar_archivo": frozenset({"network.download", "filesystem.write"}),
     },
     "ruta": {
         "existe": frozenset({"filesystem.read"}),

--- a/tests/unit/test_usar_red_capabilities.py
+++ b/tests/unit/test_usar_red_capabilities.py
@@ -1,0 +1,101 @@
+"""Regresiones de capacidades para la superficie pública ``red``."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from pcobra.cobra.usar_capabilities import (
+    CapacidadUsar,
+    capacidades_de,
+    simbolo_canonico,
+)
+from pcobra.cobra.usar_loader import usar_modulo
+from pcobra.cobra.usar_policy import CANONICAL_MODULE_SURFACE_CONTRACTS
+from pcobra.corelibs import red
+
+
+CASOS_RED = (
+    ("obtener_url", "obtener_url", CapacidadUsar.NETWORK_GET, False, ("url",)),
+    ("enviar_post", "enviar_post", CapacidadUsar.NETWORK_POST, False, ("url", {})),
+    ("obtener_url_async", "obtener_url", CapacidadUsar.NETWORK_GET, True, ("url",)),
+    ("enviar_post_async", "enviar_post", CapacidadUsar.NETWORK_POST, True, ("url", {})),
+    (
+        "descargar_archivo",
+        "descargar_archivo",
+        CapacidadUsar.NETWORK_DOWNLOAD,
+        True,
+        ("url", "salida"),
+    ),
+    ("obtener_url_texto", "obtener_url", CapacidadUsar.NETWORK_GET, True, ("url",)),
+    ("obtener_json", "obtener_url", CapacidadUsar.NETWORK_GET, False, ("url",)),
+)
+
+
+@pytest.mark.parametrize("nombre,canonico,capacidad,es_async,args", CASOS_RED)
+def test_metadata_canonica_y_resolucion_de_aliases_red(
+    nombre, canonico, capacidad, es_async, args
+):
+    contrato = CANONICAL_MODULE_SURFACE_CONTRACTS["red"]
+
+    assert simbolo_canonico("red", nombre) == ("red", canonico)
+    assert capacidad in capacidades_de("red", nombre)
+    assert capacidad.value in contrato.symbol_capabilities[nombre]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nombre,canonico,capacidad,es_async,args", CASOS_RED)
+async def test_modo_seguro_deniega_por_capacidad_toda_la_superficie_red(
+    nombre, canonico, capacidad, es_async, args
+):
+    simbolo = usar_modulo("red", safe_mode=True)[nombre]
+
+    with pytest.raises(PermissionError, match=capacidad.value):
+        resultado = simbolo(*args)
+        if es_async:
+            await resultado
+
+
+def test_descarga_declara_red_y_escritura():
+    assert capacidades_de("red", "descargar_archivo") == frozenset(
+        {CapacidadUsar.NETWORK_DOWNLOAD, CapacidadUsar.FILESYSTEM_WRITE}
+    )
+
+
+def test_metadata_visible_no_concede_autorizacion():
+    exports = usar_modulo("red", safe_mode=True)
+    exports["metadata"]["obtener_url"]["symbol"] = "inofensivo"
+    red.obtener_url.capacidades = frozenset()  # type: ignore[attr-defined]
+    try:
+        with pytest.raises(PermissionError, match="network.get"):
+            exports["obtener_url"]("url")
+    finally:
+        del red.obtener_url.capacidades  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nombre,canonico,capacidad,es_async,args", CASOS_RED)
+async def test_modo_no_seguro_conserva_resultados_y_forma_publica(
+    monkeypatch, nombre, canonico, capacidad, es_async, args
+):
+    esperado = object()
+    original = getattr(red, nombre)
+
+    if es_async:
+
+        async def doble(*_args, **_kwargs):
+            return esperado
+    else:
+
+        def doble(*_args, **_kwargs):
+            return esperado
+
+    monkeypatch.setattr(red, nombre, doble)
+    simbolo = usar_modulo("red", safe_mode=False)[nombre]
+    resultado = simbolo(*args)
+    if es_async:
+        resultado = await resultado
+
+    assert resultado is esperado
+    assert inspect.iscoroutinefunction(simbolo) is inspect.iscoroutinefunction(original)


### PR DESCRIPTION
### Motivation

- Cerrar una brecha donde las operaciones de red (sincrónicas y asíncronas) quedaban sin enforcement porque la tabla de capacidades no diferenciaba `get`, `post` o `download`.
- Normalizar resolución de aliases/wrappers hacia símbolos canónicos antes de evaluar permisos para evitar bypasses por aliases o metadata mutada.
- Hacer cambios mínimos y locales al layer de políticas/runtime para que el `safe_mode` deniegue correctamente las variantes síncronas y asíncronas sin alterar forma ni resultados en modo no seguro.

### Description

- Se añadieron capacidades inmutables `network.get`, `network.post`, `network.download` y `filesystem.write` y se mapeó cada alias de `red` a su símbolo canónico en `src/pcobra/cobra/usar_capabilities.py`.
- Se actualizaron las clasificaciones canónicas de la superficie `red` en `src/pcobra/cobra/usar_policy.py` para declarar explícitamente `network.get`, `network.post` y `network.download` (y `filesystem.write` para `descargar_archivo`).
- Se generalizó el enforcement en `src/pcobra/cobra/usar_loader.py` para: resolver capacidades por símbolo canónico antes de aplicar wrappers, ligar inmutablemente el conjunto de capacidades al verificador (evitando closures defectuosos), priorizar mensajes de capacidad y preservar la naturaleza `async` de los wrappers de `red`.
- Se agregó la suite focal `tests/unit/test_usar_red_capabilities.py` que parametriza pruebas para `obtener_url`, `enviar_post`, `obtener_url_async`, `enviar_post_async`, `descargar_archivo`, `obtener_url_texto` y `obtener_json` y verifica metadata, aliasing, `safe_mode` y comportamiento en modo no seguro.
- No se tocaron Lexer, Parser, gramática, ejemplos ni documentación y el cambio fue consolidado en un único commit con el mensaje exacto solicitado: `security(network): aplica capacidades a todos los aliases` (hash: `8b6b222...`).

### Testing

- Ejecuté `pytest -q tests/unit/test_usar_red_capabilities.py tests/unit/test_usar_proceso_capabilities.py tests/unit/test_usar_policy_contract.py` y las pruebas focales relevantes pasaron: `63 passed`.
- Ejecuté comprobaciones de estilo y compilación con `ruff check` y `python -m compileall` sobre los módulos modificados, y ambas pasaron sin errores relevantes.
- Intenté ejecutar la suite de pruebas de seguridad más amplia; la colección falló por un `ImportError` preexistente en `tests/unit/test_safe_mode.py` (export ausente en la superficie legacy), y una ejecución parcial posterior mostró fallos en pruebas de import path / AST structure / sandbox (`vm2` no disponible), los cuales son problemas existentes fuera del alcance de este cambio y no fueron introducidos por esta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76fdba299c8327bd39b61fc7c4d9c7)