### PR TITLE
fix(process): drena stderr durante streaming

### DIFF
--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -8,6 +8,7 @@ import sys
 import platform
 import shutil
 import subprocess
+from collections import deque
 from collections.abc import Iterable
 from typing import AsyncIterator
 
@@ -250,65 +251,68 @@ async def ejecutar_stream(
     args, exe_real, fd, st_dev, st_ino = _resolver_ejecutable(comando, permitidos)
     args_exec = list(args)
     proc: asyncio.subprocess.Process | None = None
-    stderr_bytes = b""
+    tareas_lectura: list[asyncio.Task[None]] = []
+    stderr_chunks: deque[bytes] = deque()
+    stderr_tamano = 0
+    limite_stderr = 64 * 1024
+
+    async def drenar_stdout(cola: asyncio.Queue[bytes | None]) -> None:
+        assert proc is not None and proc.stdout is not None
+        try:
+            while chunk := await proc.stdout.readline():
+                await cola.put(chunk)
+        finally:
+            await cola.put(None)
+
+    async def drenar_stderr() -> None:
+        nonlocal stderr_tamano
+        assert proc is not None and proc.stderr is not None
+        while chunk := await proc.stderr.read(8192):
+            stderr_chunks.append(chunk)
+            stderr_tamano += len(chunk)
+            while stderr_tamano > limite_stderr and stderr_chunks:
+                exceso = stderr_tamano - limite_stderr
+                primero = stderr_chunks[0]
+                if len(primero) <= exceso:
+                    stderr_tamano -= len(stderr_chunks.popleft())
+                else:
+                    stderr_chunks[0] = primero[exceso:]
+                    stderr_tamano -= exceso
+
+    timeout_error: asyncio.TimeoutError | None = None
     try:
         _verificar_descriptor(fd, st_dev, st_ino)
         _verificar_ruta(exe_real, st_dev, st_ino)
         if os.name == "posix" and sys.platform.startswith("linux"):
             args_exec[0] = f"/proc/self/fd/{fd}"
-        proc = await asyncio.create_subprocess_exec(
-            *args_exec,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        loop = asyncio.get_running_loop()
-        inicio = loop.time()
-        assert proc.stdout is not None
-        while True:
-            restante = None
-            if timeout is not None:
-                restante = timeout - (loop.time() - inicio)
-                if restante <= 0:
-                    raise asyncio.TimeoutError
-            try:
-                if restante is None:
-                    chunk = await proc.stdout.readline()
-                else:
-                    chunk = await asyncio.wait_for(proc.stdout.readline(), restante)
-            except asyncio.TimeoutError as exc:
-                proc.kill()
-                _, stderr_bytes = await proc.communicate()
-                if stderr_bytes:
-                    raise RuntimeError(_decodificar(stderr_bytes)) from exc
-                raise RuntimeError(
-                    f"Tiempo de espera agotado al ejecutar '{' '.join(args)}'"
-                ) from exc
-            if not chunk:
-                break
-            yield chunk.decode("utf-8", errors="replace")
-
-        restante = None
-        if timeout is not None:
-            restante = timeout - (loop.time() - inicio)
-            if restante <= 0:
-                raise asyncio.TimeoutError
         try:
-            if restante is None:
+            async with asyncio.timeout(timeout):
+                proc = await asyncio.create_subprocess_exec(
+                    *args_exec,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                cola_stdout: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=1)
+                tareas_lectura = [
+                    asyncio.create_task(drenar_stdout(cola_stdout)),
+                    asyncio.create_task(drenar_stderr()),
+                ]
+                while (chunk := await cola_stdout.get()) is not None:
+                    yield chunk.decode("utf-8", errors="replace")
+                await tareas_lectura[0]
                 await proc.wait()
-            else:
-                await asyncio.wait_for(proc.wait(), restante)
         except asyncio.TimeoutError as exc:
-            proc.kill()
-            _, stderr_bytes = await proc.communicate()
-            if stderr_bytes:
-                raise RuntimeError(_decodificar(stderr_bytes)) from exc
-            raise RuntimeError(
-                f"Tiempo de espera agotado al ejecutar '{' '.join(args)}'"
-            ) from exc
-
-        if proc.stderr is not None:
-            stderr_bytes = await proc.stderr.read()
+            timeout_error = exc
     finally:
+        if proc is not None and proc.returncode is None:
+            proc.kill()
+        if proc is not None:
+            await proc.wait()
+        for tarea in tareas_lectura:
+            if not tarea.done():
+                tarea.cancel()
+        if tareas_lectura:
+            await asyncio.gather(*tareas_lectura, return_exceptions=True)
         _verificar_descriptor(fd, st_dev, st_ino)
         _verificar_ruta(exe_real, st_dev, st_ino)
         try:
@@ -316,12 +320,19 @@ async def ejecutar_stream(
         except OSError:
             pass
 
+    stderr_bytes = b"".join(stderr_chunks)
+    if timeout_error is not None:
+        detalle = _decodificar(stderr_bytes).strip()
+        mensaje = f"Tiempo de espera agotado al ejecutar '{' '.join(args)}'"
+        if detalle:
+            mensaje = f"{mensaje}: {detalle}"
+        raise RuntimeError(mensaje) from timeout_error
+
     if proc is not None and proc.returncode:
+        mensaje = f"Error al ejecutar '{' '.join(args)}': código {proc.returncode}"
         if stderr_bytes:
-            raise RuntimeError(_decodificar(stderr_bytes))
-        raise RuntimeError(
-            f"Error al ejecutar '{' '.join(args)}': código {proc.returncode}"
-        )
+            mensaje = f"{mensaje}: {_decodificar(stderr_bytes)}"
+        raise RuntimeError(mensaje)
 
 
 def obtener_env(nombre: str) -> str | None:

--- a/tests/unit/test_corelibs_async.py
+++ b/tests/unit/test_corelibs_async.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 
 import os
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -466,8 +467,9 @@ class _FakeStderr:
     def __init__(self, data=b""):
         self._data = data
 
-    async def read(self):
-        return self._data
+    async def read(self, _tamano=-1):
+        data, self._data = self._data, b""
+        return data
 
 
 class _FakeProcStream:
@@ -547,6 +549,69 @@ async def test_ejecutar_stream_error_provoca_excepcion(monkeypatch):
         async for _ in gen:
             pass
     assert "fallo" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_ejecutar_stream_drena_stderr_y_entrega_stdout_incrementalmente(
+    monkeypatch,
+):
+    ejecutable = sys.executable
+    monkeypatch.setattr(sistema.sys, "platform", "darwin")
+    codigo = (
+        "import sys, time\n"
+        "print('primera', flush=True)\n"
+        "sys.stderr.write('E' * (1024 * 1024))\n"
+        "sys.stderr.flush()\n"
+        "time.sleep(0.25)\n"
+        "print('segunda', flush=True)\n"
+        "print('tercera', flush=True)\n"
+    )
+    primera_recibida = asyncio.Event()
+    lineas = []
+
+    async def consumir() -> None:
+        async for linea in sistema.ejecutar_stream(
+            [ejecutable, "-c", codigo],
+            permitidos=[ejecutable],
+            timeout=5,
+        ):
+            lineas.append(linea)
+            primera_recibida.set()
+
+    consumo = asyncio.create_task(consumir())
+    await asyncio.wait_for(primera_recibida.wait(), timeout=1)
+    assert lineas == ["primera\n"]
+    assert not consumo.done()
+    await consumo
+    assert lineas == ["primera\n", "segunda\n", "tercera\n"]
+
+
+@pytest.mark.asyncio
+async def test_ejecutar_stream_acota_stderr_y_conserva_codigo_y_final_util(
+    monkeypatch,
+):
+    ejecutable = sys.executable
+    monkeypatch.setattr(sistema.sys, "platform", "darwin")
+    codigo = (
+        "import sys\n"
+        "sys.stderr.write('E' * (1024 * 1024))\n"
+        "sys.stderr.write('detalle-final-util')\n"
+        "sys.stderr.flush()\n"
+        "raise SystemExit(7)\n"
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        async for _ in sistema.ejecutar_stream(
+            [ejecutable, "-c", codigo],
+            permitidos=[ejecutable],
+            timeout=5,
+        ):
+            pass
+
+    mensaje = str(excinfo.value)
+    assert "código 7" in mensaje
+    assert "detalle-final-util" in mensaje
+    assert len(mensaje) < 70 * 1024
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Resolver un problema donde procesos que emiten mucho en `stderr` podían bloquear o provocar pérdida de entrega incremental de `stdout` durante `ejecutar_stream`.
- Garantizar que `stdout` se entregue incrementalmente sin esperar a que termine el proceso y que `stderr` no crezca sin límite pero conserve el detalle final útil.

### Description

- Separamos el drenado de `stdout` y `stderr` en tareas asíncronas independientes para permitir entrega incremental de `stdout` mientras se consume `stderr` en paralelo.
- Añadimos un acumulador acotado (`deque`) para `stderr` con límite de 64 KiB que conserva la parte final más relevante y descarta el exceso sin bloquear la emisión de `stdout`.
- Usamos un único deadline total con `asyncio.timeout` que abarca creación, lectura y espera del proceso, evitando reiniciar timeouts en cada lectura individual.
- En caso de timeout, cancelación o excepción se mata el proceso si aún está vivo, se espera su recolección y se cancela/espera las tareas lectoras, y se preserva el código de retorno y el contenido útil de `stderr` al formar el `RuntimeError` público.

### Testing

- Añadí pruebas unitarias: `test_ejecutar_stream_drena_stderr_y_entrega_stdout_incrementalmente` y `test_ejecutar_stream_acota_stderr_y_conserva_codigo_y_final_util` en `tests/unit/test_corelibs_async.py` que ejercitan un proceso real que escribe 1 MiB en `stderr` y varias líneas en `stdout`.
- Ejecuté `pytest` sobre las pruebas afectadas (`tests/unit/test_corelibs_async.py -k ejecutar_stream`) y sobre las suites relacionadas (`tests/unit/test_corelibs_async.py` y `tests/unit/test_corelibs_sistema.py`) y las pruebas focales pasaron (las nuevas pruebas pasan).
- Ejecuté linter con `ruff` sobre los archivos modificados y `git diff --check` para verificar cambios accidentales; ambos checks pasaron.
- Al ejecutar una batería más amplia que incluye `tests/test_corelibs_proceso.py` aparecieron dos fallos preexistentes en esa área que no fueron introducidos por este cambio; no se modificó `proceso.py`, Lexer ni Parser en esta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76ffdeb5b48327aabad7b539e7c047)