### PR TITLE
fix(process): hereda descriptor de ejecutable validado

### DIFF
--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -156,8 +156,13 @@ def ejecutar(
     try:
         _verificar_descriptor(fd, st_dev, st_ino)
         _verificar_ruta(exe_real, st_dev, st_ino)
+        opciones_descriptor = {}
         if os.name == "posix" and sys.platform.startswith("linux"):
+            if not os.path.exists("/proc/self/fd"):
+                raise RuntimeError("No está disponible /proc/self/fd")
             args_exec[0] = f"/proc/self/fd/{fd}"
+            # pass_fds hace heredable el fd abierto con O_CLOEXEC solo en el hijo.
+            opciones_descriptor = {"pass_fds": (fd,), "close_fds": True}
 
         resultado = subprocess.run(
             args_exec,
@@ -166,6 +171,7 @@ def ejecutar(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,
+            **opciones_descriptor,
         )
         _verificar_descriptor(fd, st_dev, st_ino)
         _verificar_ruta(exe_real, st_dev, st_ino)
@@ -204,13 +210,19 @@ async def ejecutar_async(
     try:
         _verificar_descriptor(fd, st_dev, st_ino)
         _verificar_ruta(exe_real, st_dev, st_ino)
+        opciones_descriptor = {}
         if os.name == "posix" and sys.platform.startswith("linux"):
+            if not os.path.exists("/proc/self/fd"):
+                raise RuntimeError("No está disponible /proc/self/fd")
             args_exec[0] = f"/proc/self/fd/{fd}"
+            # pass_fds hace heredable el fd abierto con O_CLOEXEC solo en el hijo.
+            opciones_descriptor = {"pass_fds": (fd,), "close_fds": True}
 
         proc = await asyncio.create_subprocess_exec(
             *args_exec,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            **opciones_descriptor,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
@@ -283,14 +295,20 @@ async def ejecutar_stream(
     try:
         _verificar_descriptor(fd, st_dev, st_ino)
         _verificar_ruta(exe_real, st_dev, st_ino)
+        opciones_descriptor = {}
         if os.name == "posix" and sys.platform.startswith("linux"):
+            if not os.path.exists("/proc/self/fd"):
+                raise RuntimeError("No está disponible /proc/self/fd")
             args_exec[0] = f"/proc/self/fd/{fd}"
+            # pass_fds hace heredable el fd abierto con O_CLOEXEC solo en el hijo.
+            opciones_descriptor = {"pass_fds": (fd,), "close_fds": True}
         try:
             async with asyncio.timeout(timeout):
                 proc = await asyncio.create_subprocess_exec(
                     *args_exec,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    **opciones_descriptor,
                 )
                 cola_stdout: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=1)
                 tareas_lectura = [
@@ -304,21 +322,23 @@ async def ejecutar_stream(
         except asyncio.TimeoutError as exc:
             timeout_error = exc
     finally:
-        if proc is not None and proc.returncode is None:
-            proc.kill()
-        if proc is not None:
-            await proc.wait()
-        for tarea in tareas_lectura:
-            if not tarea.done():
-                tarea.cancel()
-        if tareas_lectura:
-            await asyncio.gather(*tareas_lectura, return_exceptions=True)
-        _verificar_descriptor(fd, st_dev, st_ino)
-        _verificar_ruta(exe_real, st_dev, st_ino)
         try:
-            os.close(fd)
-        except OSError:
-            pass
+            if proc is not None and proc.returncode is None:
+                proc.kill()
+            if proc is not None:
+                await proc.wait()
+            for tarea in tareas_lectura:
+                if not tarea.done():
+                    tarea.cancel()
+            if tareas_lectura:
+                await asyncio.gather(*tareas_lectura, return_exceptions=True)
+            _verificar_descriptor(fd, st_dev, st_ino)
+            _verificar_ruta(exe_real, st_dev, st_ino)
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
     stderr_bytes = b"".join(stderr_chunks)
     if timeout_error is not None:

--- a/tests/unit/test_corelibs_sistema.py
+++ b/tests/unit/test_corelibs_sistema.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import importlib
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -66,7 +67,7 @@ def test_ejecutar_permitido_con_ruta(monkeypatch):
 def test_ejecutar_reemplaza_y_copia_argumentos(monkeypatch):
     permitido = core_sistema.os.path.realpath("/usr/bin/env")
     comando = ["env", "VAR=1"]
-    llamado: dict[str, list[str]] = {}
+    llamado: dict[str, Any] = {}
 
     monkeypatch.setattr(core_sistema.os, "name", "posix", raising=False)
     monkeypatch.setattr(core_sistema.sys, "platform", "linux", raising=False)
@@ -76,6 +77,7 @@ def test_ejecutar_reemplaza_y_copia_argumentos(monkeypatch):
 
     def fake_run(args, **kwargs):
         llamado["args"] = args
+        llamado["kwargs"] = kwargs
         comando[0] = "otro"
         return SimpleNamespace(stdout="", stderr="")
 
@@ -86,6 +88,9 @@ def test_ejecutar_reemplaza_y_copia_argumentos(monkeypatch):
 
     assert salida == ""
     assert llamado["args"][0].startswith("/proc/self/fd/")
+    fd = int(llamado["args"][0].rsplit("/", 1)[1])
+    assert llamado["kwargs"]["pass_fds"] == (fd,)
+    assert llamado["kwargs"]["close_fds"] is True
     assert llamado["args"] is not comando
     assert comando[0] == "otro"
 
@@ -116,7 +121,7 @@ def test_ejecutar_no_usa_proc_self_en_darwin(monkeypatch, tmp_path):
 async def test_ejecutar_async_reemplaza_y_copia_argumentos(monkeypatch):
     permitido = core_sistema.os.path.realpath("/usr/bin/env")
     comando = ["env"]
-    llamado: dict[str, list[str]] = {}
+    llamado: dict[str, Any] = {}
 
     monkeypatch.setattr(core_sistema.os, "name", "posix", raising=False)
     monkeypatch.setattr(core_sistema.sys, "platform", "linux", raising=False)
@@ -134,6 +139,7 @@ async def test_ejecutar_async_reemplaza_y_copia_argumentos(monkeypatch):
 
     async def fake_create_subprocess_exec(*args, **kwargs):
         llamado["args"] = list(args)
+        llamado["kwargs"] = kwargs
         comando[0] = "otro"
         return FakeProc()
 
@@ -146,7 +152,26 @@ async def test_ejecutar_async_reemplaza_y_copia_argumentos(monkeypatch):
 
     assert salida == ""
     assert llamado["args"][0].startswith("/proc/self/fd/")
+    fd = int(llamado["args"][0].rsplit("/", 1)[1])
+    assert llamado["kwargs"]["pass_fds"] == (fd,)
+    assert llamado["kwargs"]["close_fds"] is True
     assert comando[0] == "otro"
+
+
+@pytest.mark.skipif(
+    not (os.name == "posix" and core_sistema.sys.platform.startswith("linux")),
+    reason="Requiere Linux con /proc/self/fd",
+)
+def test_ejecutar_linux_hereda_descriptor_del_ejecutable(tmp_path):
+    ejecutable = tmp_path / "descriptor_abierto"
+    ejecutable.write_text('#!/bin/sh\ncat "$0"\n')
+    ejecutable.chmod(0o755)
+
+    salida = core_sistema.ejecutar(
+        [str(ejecutable)], permitidos=[str(ejecutable)]
+    )
+
+    assert 'cat "$0"' in salida
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Evitar TOCTOU al reemplazar `argv[0]` por `/proc/self/fd/<fd>` haciendo que el hijo herede explícitamente el descriptor ya verificado. 
- Mantener las comprobaciones de `st_dev`/`st_ino` antes y después de la ejecución sin degradar a una ruta no revalidada en plataformas Linux.
- Asegurar que el descriptor se cierre siempre en el padre incluso si ocurren errores durante el streaming o las verificaciones.

### Description
- Las llamadas que sustituyen `args_exec[0]` por `/proc/self/fd/{fd}` en las rutas síncrona (`subprocess.run`), asíncrona (`asyncio.create_subprocess_exec`) y de streaming ahora pasan `pass_fds=(fd,)` y `close_fds=True` explícitamente. 
- Se agregó una verificación explícita de existencia de `/proc/self/fd` en Linux y se lanza `RuntimeError` si no está disponible, evitando ejecutar una ruta no revalidada. 
- Se mantuvo el uso de `O_CLOEXEC` al abrir el ejecutable y se añadió un comentario mínimo explicando que `pass_fds` permite que el hijo herede el fd a pesar de `O_CLOEXEC`. 
- Se reforzó la limpieza en la ruta de streaming para garantizar el cierre del descriptor en un `finally` anidado y así asegurar que el descriptor se cierra siempre en el padre. 
- Se añadieron aserciones en las pruebas unitarias para comprobar los `kwargs` (`pass_fds` y `close_fds`) y se introdujo una prueba Linux que crea un ejecutable temporal permitido y confirma que el hijo puede abrir el descriptor vía `$0`.

### Testing
- `pytest -q tests/unit/test_corelibs_sistema.py` — OK: `15 passed, 1 skipped` (la omisión es por condición de plataforma). 
- Prueba focal ejecutada: `pytest -q tests/unit/test_corelibs_sistema.py -k 'reemplaza_y_copia_argumentos or hereda_descriptor_del_ejecutable or detecta_reemplazo'` — OK: `5 passed`.
- Compilación estática de archivos: `python -m py_compile src/pcobra/corelibs/sistema.py tests/unit/test_corelibs_sistema.py` — OK.
- `git diff --check` y verificación de que no se modificaron Lexer/Parser — OK.
- Suite vecina ejecutada (`tests/unit/test_corelibs_sistema.py tests/test_corelibs_proceso.py tests/core/test_corelib_proceso.py`) — resultado: la mayoría de tests pasaron, pero se detectaron 2 fallos preexistentes en `tests/test_corelibs_proceso.py` (expectativa desactualizada de `proceso.__all__` y una prueba que requiere autorización explícita para `shell=True`), los cuales son ajenos a los cambios aplicados aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7701b91fd083279456d8008fa6f489)