### PR TITLE
security(validators): aislar validadores externos en worker spawn y protocolo cerrado

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -6,6 +6,7 @@ import os
 import hashlib
 import inspect
 import math
+import multiprocessing
 import threading
 import warnings
 from pathlib import Path
@@ -340,8 +341,7 @@ class InterpretadorCobra:
 
     @staticmethod
     def _cargar_validadores(ruta):
-        """Carga una lista de validadores desde un archivo Python."""
-        import ast
+        """Carga descriptores en un worker aislado y construye clases admitidas."""
 
         ruta_abs = os.path.abspath(ruta)
         if not _ruta_import_permitida(ruta_abs):
@@ -363,222 +363,80 @@ class InterpretadorCobra:
             ) from e
         hash_corto = hashlib.sha256(source.encode("utf-8")).hexdigest()[:12]
 
+        from .validator_worker import run_validator_worker
+
+        context = multiprocessing.get_context("spawn")
+        parent, child = context.Pipe(duplex=False)
+        process = context.Process(
+            target=run_validator_worker,
+            args=(child, {"source": source, "filename": ruta_real}),
+        )
+        process.start()
+        child.close()
+        timeout = float(os.getenv("PCOBRA_VALIDATOR_TIMEOUT", "2"))
+        response = None
         try:
-            tree = ast.parse(source, filename=ruta_real)
-        except SyntaxError as e:
-            InterpretadorCobra._registrar_auditoria_validador(
-                ruta_real,
-                "rechazado",
-                "sintaxis_invalida",
-                hash_corto=hash_corto,
-                fase="parse",
-            )
-            raise ImportError(
-                "El archivo de validadores tiene sintaxis inválida."
-            ) from e
+            if parent.poll(timeout):
+                response = parent.recv()
+            else:
+                process.terminate()
+                process.join(0.5)
+                if process.is_alive():
+                    process.kill()
+                raise ImportError("El validador adicional superó el tiempo permitido.")
+        except EOFError:
+            response = None
+        finally:
+            if process.is_alive():
+                process.terminate()
+            process.join()
+            parent.close()
 
-        magia_permitida = {"__name__"}
-        tokens_sensibles = {
-            "__subclasses__",
-            "__globals__",
-            "__dict__",
-            "__mro__",
-            "__bases__",
-            "__getattribute__",
-            "__setattr__",
-            "__delattr__",
-            "__code__",
-            "__closure__",
-            "__func__",
-            "__self__",
+        if not isinstance(response, dict) or response.get("estado") != "ok":
+            codigo = response.get("codigo") if isinstance(response, dict) else "worker_terminado"
+            if response is None and process.exitcode is not None and process.exitcode < 0:
+                codigo = "cpu_excedida"
+            mensajes = {
+                "import_no_permitido": "No se permiten importaciones en validadores adicionales.",
+                "atributo_magico_no_permitido": "Se detectó un atributo mágico no permitido.",
+                "introspeccion_no_permitida": "Se detectó introspección no permitida.",
+                "memoria_excedida": "El validador adicional excede los límites de memoria permitidos.",
+                "cpu_excedida": "El validador adicional superó el tiempo permitido.",
+                "resultado_no_serializable": "El resultado del validador no es serializable.",
+                "descriptor_invalido": "El validador adicional devolvió un descriptor inválido.",
+                "worker_terminado": "El proceso del validador terminó sin resultado.",
+            }
+            raise ImportError(mensajes.get(codigo, "No se pudo cargar el validador adicional de forma segura."))
+
+        from .semantic_validators import (
+            ValidadorImportSeguro,
+            ValidadorPrimitivaPeligrosa,
+            ValidadorProhibirReflexion,
+            ValidadorSistemaArchivos,
+        )
+
+        registry = {
+            "import_seguro": ValidadorImportSeguro,
+            "primitiva_peligrosa": ValidadorPrimitivaPeligrosa,
+            "reflexion_segura": ValidadorProhibirReflexion,
+            "sistema_archivos": ValidadorSistemaArchivos,
         }
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.Import, ast.ImportFrom)):
-                InterpretadorCobra._registrar_auditoria_validador(
-                    ruta_real,
-                    "rechazado",
-                    "import_no_permitido",
-                    hash_corto=hash_corto,
-                    fase="policy_check",
-                )
-                raise ImportError(
-                    "ImportError: no se permiten importaciones en validadores adicionales."
-                )
-            if isinstance(node, ast.Attribute):
-                if (
-                    node.attr.startswith("__")
-                    and node.attr.endswith("__")
-                    and node.attr not in magia_permitida
-                ):
-                    InterpretadorCobra._registrar_auditoria_validador(
-                        ruta_real,
-                        "rechazado",
-                        "atributo_magico_no_permitido",
-                        hash_corto=hash_corto,
-                        fase="policy_check",
-                    )
-                    raise ImportError(
-                        "ImportError: se detectó acceso a atributo mágico no permitido en el validador adicional."
-                    )
-            if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                if any(token in node.value for token in tokens_sensibles):
-                    InterpretadorCobra._registrar_auditoria_validador(
-                        ruta_real,
-                        "rechazado",
-                        "cadena_introspeccion_sensible",
-                        hash_corto=hash_corto,
-                        fase="policy_check",
-                    )
-                    raise ImportError(
-                        "ImportError: se detectó un patrón de introspección no permitido en el validador adicional."
-                    )
-            if isinstance(node, ast.Call):
-                func = node.func
-                if isinstance(func, ast.Name) and func.id == "__import__":
-                    InterpretadorCobra._registrar_auditoria_validador(
-                        ruta_real,
-                        "rechazado",
-                        "dunder_import_bloqueado",
-                        hash_corto=hash_corto,
-                        fase="policy_check",
-                    )
-                    raise ImportError(
-                        "ImportError: el uso de __import__ está bloqueado en validadores adicionales."
-                    )
-                if isinstance(func, ast.Name) and func.id == "getattr":
-                    primer_arg = node.args[0] if node.args else None
-                    objetivo_sensible = isinstance(primer_arg, ast.Name) and primer_arg.id in {
-                        "__builtins__",
-                        "builtins",
-                        "object",
-                        "type",
-                    }
-                    atributo_sensible = (
-                        len(node.args) > 1
-                        and isinstance(node.args[1], ast.Constant)
-                        and isinstance(node.args[1].value, str)
-                        and any(token in node.args[1].value for token in tokens_sensibles)
-                    )
-                    if objetivo_sensible or atributo_sensible:
-                        InterpretadorCobra._registrar_auditoria_validador(
-                            ruta_real,
-                            "rechazado",
-                            "getattr_introspeccion_bloqueado",
-                            hash_corto=hash_corto,
-                            fase="policy_check",
-                        )
-                        raise ImportError(
-                            "ImportError: uso de introspección dinámica no permitido en el validador adicional."
-                        )
-
-        from .sandbox import cargar_simbolos_restrictedpython
-        from .semantic_validators.base import ValidadorBase
-
-        import builtins
-
-        rp_symbols, has_restricted_python = cargar_simbolos_restrictedpython()
-        if not has_restricted_python:
-            raise ImportError(
-                "Los validadores adicionales requieren RestrictedPython instalado "
-                "y compatible con la API de seguridad de Cobra."
-            )
-
-        rp_safe_builtins = rp_symbols["safe_builtins"]
-        safe_builtins = {
-            nombre: rp_safe_builtins[nombre]
-            for nombre in (
-                "len",
-                "range",
-                "__build_class__",
-                "Exception",
-                "object",
-            )
-            if nombre in rp_safe_builtins
-        }
-        safe_builtins.setdefault("len", builtins.len)
-        safe_builtins.setdefault("range", builtins.range)
-        safe_builtins.setdefault("__build_class__", builtins.__build_class__)
-        safe_builtins.setdefault("Exception", builtins.Exception)
-        safe_builtins.setdefault("object", builtins.object)
-
-        namespace = {
-            "__builtins__": safe_builtins,
-            "ValidadorBase": ValidadorBase,
-            "__name__": "validators",
-            "__metaclass__": builtins.type,
-            "_print_": rp_symbols["PrintCollector"],
-            "_getattr_": rp_symbols["default_guarded_getattr"],
-            "_getitem_": rp_symbols["default_guarded_getitem"],
-            "_iter_unpack_sequence_": rp_symbols["guarded_iter_unpack_sequence"],
-            "_unpack_sequence_": rp_symbols["guarded_unpack_sequence"],
-        }
-        compile_restricted = rp_symbols["compile_restricted"]
-        try:
-            byte_code = compile_restricted(source, ruta_abs, "exec")
-        except TimeoutError as e:
-            InterpretadorCobra._registrar_auditoria_validador(
-                ruta_real,
-                "rechazado",
-                "timeout",
-                hash_corto=hash_corto,
-                fase="compile",
-            )
-            raise ImportError(
-                "El validador adicional superó el tiempo permitido."
-            ) from e
-        except (MemoryError, OverflowError) as e:
-            InterpretadorCobra._registrar_auditoria_validador(
-                ruta_real,
-                "rechazado",
-                "memoria_excedida",
-                hash_corto=hash_corto,
-                fase="compile",
-            )
-            raise ImportError(
-                "El validador adicional excede los límites de memoria permitidos."
-            ) from e
-        try:
-            exec(byte_code, namespace)
-        except TimeoutError as e:
-            InterpretadorCobra._registrar_auditoria_validador(
-                ruta_real,
-                "rechazado",
-                "timeout",
-                hash_corto=hash_corto,
-                fase="exec",
-            )
-            raise ImportError(
-                "El validador adicional superó el tiempo permitido."
-            ) from e
-        except (MemoryError, OverflowError) as e:
-            InterpretadorCobra._registrar_auditoria_validador(
-                ruta_real,
-                "rechazado",
-                "memoria_excedida",
-                hash_corto=hash_corto,
-                fase="exec",
-            )
-            raise ImportError(
-                "El validador adicional excede los límites de memoria permitidos."
-            ) from e
-        except Exception as e:
-            InterpretadorCobra._registrar_auditoria_validador(
-                ruta_real,
-                "rechazado",
-                "error_en_ejecucion",
-                hash_corto=hash_corto,
-                fase="exec",
-            )
-            raise ImportError(
-                "No se pudo cargar el validador adicional de forma segura."
-            ) from e
+        validators = []
+        for descriptor in response.get("validadores", []):
+            validator_class = registry.get(descriptor["nombre"])
+            if validator_class is None:
+                raise ImportError("El descriptor solicita un validador no preautorizado.")
+            try:
+                validators.append(validator_class(**descriptor["parametros"]))
+            except (TypeError, ValueError) as exc:
+                raise ImportError("Parámetros inválidos para el validador preautorizado.") from exc
         InterpretadorCobra._registrar_auditoria_validador(
             ruta_real,
             "permitido",
             hash_corto=hash_corto,
             fase="exec",
         )
-        return namespace.get("VALIDADORES_EXTRA", [])
+        return validators
 
     def __init__(
         self,
@@ -596,8 +454,8 @@ class InterpretadorCobra:
             devuelta por :func:`construir_cadena`, restringiendo primitivas
             como ``import`` o ``hilo``.
         extra_validators: list | str, optional
-            Lista de instancias adicionales o ruta a un módulo que defina
-            ``VALIDADORES_EXTRA``.
+            Ruta a un módulo que defina ``VALIDADORES_EXTRA`` mediante
+            descriptores declarativos. Las instancias y callables se rechazan.
         main_file: Path | str, optional
             Archivo principal conocido por CLI/runtime para resolver módulos de
             proyecto con ``usar`` desde la raíz canonicalizada.
@@ -605,6 +463,11 @@ class InterpretadorCobra:
         extra = extra_validators
         if isinstance(extra, str):
             extra = self._cargar_validadores(extra)
+        elif extra:
+            raise TypeError(
+                "Los validadores adicionales deben indicarse mediante una ruta "
+                "con descriptores declarativos; no se admiten instancias ni callables."
+            )
 
         self.safe_mode = safe_mode
         # Regla de fases: analysis = sin efectos, execution = con efectos.

--- a/src/pcobra/core/validator_worker.py
+++ b/src/pcobra/core/validator_worker.py
@@ -1,0 +1,125 @@
+"""Aislamiento y protocolo cerrado para validadores adicionales.
+
+Este módulo no importa el intérprete deliberadamente: el proceso hijo sólo
+compila el archivo autorizado y devuelve descriptores de datos.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import os
+from typing import Any
+
+
+MAX_SOURCE_BYTES = 1_000_000
+MAX_DESCRIPTORS = 32
+MAX_CONTAINER_ITEMS = 128
+
+
+def _apply_resource_limits() -> None:
+    """Aplica límites POSIX; en otras plataformas el padre conserva el timeout."""
+
+    try:
+        import resource
+    except ImportError:  # pragma: no cover - ruta explícita no POSIX
+        return
+
+    memory = 256 * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (memory, memory))
+    resource.setrlimit(resource.RLIMIT_CPU, (1, 1))
+
+
+def _check_policy(source: str, filename: str) -> ast.AST:
+    tree = ast.parse(source, filename=filename)
+    sensitive = {
+        "__subclasses__", "__globals__", "__dict__", "__mro__", "__bases__",
+        "__getattribute__", "__setattr__", "__delattr__", "__code__",
+        "__closure__", "__func__", "__self__",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            raise PermissionError("import_no_permitido")
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__") and node.attr != "__name__":
+            raise PermissionError("atributo_magico_no_permitido")
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if any(token in node.value for token in sensitive):
+                raise PermissionError("introspeccion_no_permitida")
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id == "__import__":
+                raise PermissionError("import_no_permitido")
+            if node.func.id == "getattr":
+                raise PermissionError("introspeccion_no_permitida")
+    return tree
+
+
+def _primitive(value: Any, *, depth: int = 0) -> Any:
+    if depth > 4:
+        raise TypeError("resultado_no_serializable")
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, list) and len(value) <= MAX_CONTAINER_ITEMS:
+        return [_primitive(item, depth=depth + 1) for item in value]
+    if isinstance(value, dict) and len(value) <= MAX_CONTAINER_ITEMS:
+        if not all(isinstance(key, str) for key in value):
+            raise TypeError("resultado_no_serializable")
+        return {key: _primitive(item, depth=depth + 1) for key, item in value.items()}
+    raise TypeError("resultado_no_serializable")
+
+
+def _normalize_descriptors(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or len(value) > MAX_DESCRIPTORS:
+        raise TypeError("resultado_no_serializable")
+    result = _primitive(value)
+    for descriptor in result:
+        if not isinstance(descriptor, dict) or set(descriptor) != {"nombre", "parametros"}:
+            raise TypeError("descriptor_invalido")
+        if not isinstance(descriptor["nombre"], str) or not isinstance(descriptor["parametros"], dict):
+            raise TypeError("descriptor_invalido")
+    return result
+
+
+def run_validator_worker(connection, request: dict[str, Any]) -> None:
+    """Punto de entrada ``spawn``: siempre intenta responder datos primitivos."""
+
+    try:
+        if set(request) != {"source", "filename"}:
+            raise TypeError("solicitud_invalida")
+        source, filename = request["source"], request["filename"]
+        if not isinstance(source, str) or not isinstance(filename, str):
+            raise TypeError("solicitud_invalida")
+        if len(source.encode("utf-8")) > MAX_SOURCE_BYTES:
+            raise MemoryError
+        _check_policy(source, filename)
+
+        from .sandbox import cargar_simbolos_restrictedpython
+
+        symbols, available = cargar_simbolos_restrictedpython()
+        if not available:
+            connection.send({"estado": "error", "codigo": "restrictedpython_no_disponible"})
+            return
+        # La importación confiable puede consumir una parte apreciable del
+        # presupuesto; los límites protegen exclusivamente el código externo.
+        _apply_resource_limits()
+        safe = symbols["safe_builtins"]
+        allowed_builtins = {
+            name: safe[name] for name in ("len", "range") if name in safe
+        }
+        namespace = {"__builtins__": allowed_builtins, "__name__": "validators"}
+        byte_code = symbols["compile_restricted"](source, filename, "exec")
+        exec(byte_code, namespace)
+        descriptors = _normalize_descriptors(namespace.get("VALIDADORES_EXTRA", []))
+        connection.send({"estado": "ok", "validadores": descriptors})
+    except PermissionError as exc:
+        connection.send({"estado": "error", "codigo": str(exc)})
+    except SyntaxError:
+        connection.send({"estado": "error", "codigo": "sintaxis_invalida"})
+    except (MemoryError, OverflowError):
+        connection.send({"estado": "error", "codigo": "memoria_excedida"})
+    except TypeError as exc:
+        codigo = str(exc) if str(exc) in {"resultado_no_serializable", "descriptor_invalido"} else "protocolo_invalido"
+        connection.send({"estado": "error", "codigo": codigo})
+    except BaseException:
+        connection.send({"estado": "error", "codigo": "error_en_ejecucion"})
+    finally:
+        connection.close()

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -12,25 +12,29 @@ class DummyValidator(ValidadorBase):
         raise DummyError('validado')
 
 
+def _nombres_cadena(validador):
+    nombres = []
+    while validador is not None:
+        nombres.append(type(validador).__name__)
+        validador = validador.siguiente
+    return nombres
+
+
 def test_interpreter_extra_validators_list():
-    interp = InterpretadorCobra(extra_validators=[DummyValidator()])
-    with pytest.raises(DummyError):
-        interp.ejecutar_ast([NodoValor(1)])
+    with pytest.raises(TypeError, match="instancias ni callables"):
+        InterpretadorCobra(extra_validators=[DummyValidator()])
 
 
 def test_interpreter_extra_validators_file(tmp_path):
     mod = tmp_path / 'vals.py'
     mod.write_text(
-        'class V(ValidadorBase):\n'
-        '    def visit_valor(self, nodo):\n'
-        '        raise Exception("file")\n'
-        'VALIDADORES_EXTRA = [V()]\n'
+        "VALIDADORES_EXTRA = "
+        "[{'nombre': 'reflexion_segura', 'parametros': {}}]\n"
     )
     IMPORT_WHITELIST.add(str(tmp_path))
     try:
         interp = InterpretadorCobra(extra_validators=str(mod))
-        with pytest.raises(Exception):
-            interp.ejecutar_ast([NodoValor(2)])
+        assert "ValidadorProhibirReflexion" in _nombres_cadena(interp._validador)
     finally:
         IMPORT_WHITELIST.discard(str(tmp_path))
 
@@ -58,7 +62,7 @@ def test_validator_import_blocked(tmp_path):
     mod.write_text("__import__('os').system('echo hola')\nVALIDADORES_EXTRA = []\n")
     IMPORT_WHITELIST.add(str(tmp_path))
     try:
-        with pytest.raises(ImportError, match="__import__"):
+        with pytest.raises(ImportError, match="importaciones"):
             InterpretadorCobra._cargar_validadores(str(mod))
     finally:
         IMPORT_WHITELIST.discard(str(tmp_path))

--- a/tests/unit/test_import_seguro_validator.py
+++ b/tests/unit/test_import_seguro_validator.py
@@ -25,6 +25,44 @@ def test_validadores_extra_rechaza_cadena_subclasses(tmp_path):
     finally:
         IMPORT_WHITELIST.discard(str(tmp_path))
 
+
+def _cargar_modulo_validador(tmp_path, source, monkeypatch):
+    mod = tmp_path / "validadores.py"
+    mod.write_text(source, encoding="utf-8")
+    IMPORT_WHITELIST.add(str(tmp_path))
+    monkeypatch.setenv("PCOBRA_VALIDATOR_TIMEOUT", "3")
+    try:
+        return InterpretadorCobra._cargar_validadores(str(mod))
+    finally:
+        IMPORT_WHITELIST.discard(str(tmp_path))
+
+
+def test_worker_validador_resultado_valido(tmp_path, monkeypatch):
+    validadores = _cargar_modulo_validador(
+        tmp_path,
+        "VALIDADORES_EXTRA = [{'nombre': 'reflexion_segura', 'parametros': {}}]\n",
+        monkeypatch,
+    )
+    assert len(validadores) == 1
+    assert validadores[0].__class__.__name__ == "ValidadorProhibirReflexion"
+
+
+@pytest.mark.parametrize(
+    ("source", "mensaje"),
+    [
+        ("while True:\n    pass\n", "tiempo permitido"),
+        ("VALIDADORES_EXTRA = [0] * 100_000_000\n", "memoria|proceso"),
+        ("import os\n", "importaciones"),
+        ("x = object.__subclasses__\n", "mágico"),
+        ("raise Exception('detalle privado')\n", "forma segura"),
+        ("VALIDADORES_EXTRA = [lambda: None]\n", "serializable"),
+    ],
+)
+def test_worker_validador_fallos_controlados(tmp_path, monkeypatch, source, mensaje):
+    with pytest.raises(ImportError, match=mensaje):
+        _cargar_modulo_validador(tmp_path, source, monkeypatch)
+
+
 def test_import_relativo_resuelto_desde_archivo_principal(tmp_path):
     proyecto = tmp_path / "proyecto"
     proyecto.mkdir()
@@ -39,4 +77,3 @@ def test_import_relativo_resuelto_desde_archivo_principal(tmp_path):
     nodo = NodoImport("persona.cobra")
 
     nodo.aceptar(interpretador._validador)
-


### PR DESCRIPTION
### Motivation

- Evitar que validadores externos ejecuten código arbitrario en el proceso principal y prevenir herencia de estado mutable al cargar validadores extra.
- Forzar un protocolo declarativo y serializable para describir validadores, limitando superficies de introspección e importación peligrosas.
- Aplicar límites de tiempo y recursos a la carga/ejecución de validadores para mitigar bucles infinitos y consumo excesivo de memoria/CPU.

### Description

- Añade `src/pcobra/core/validator_worker.py` que implementa el worker aislado: validación de AST estática, límites POSIX de memoria/CPU cuando están disponibles, ejecución con `RestrictedPython` y normalización de un protocolo primitivo de descriptores (`VALIDADORES_EXTRA` como lista de dicts con `nombre` y `parametros`).
- Modifica `src/pcobra/core/interpreter.py` para ejecutar la carga de validadores en un proceso separado creado con `multiprocessing.get_context('spawn')`, aplicar timeout desde el padre, forzar `terminate()` y `kill()` si es necesario, y `join()`/cerrado de canal garantizados.
- Cambia el flujo para construir en el padre únicamente validadores de una lista cerrada (registro) de clases preautorizadas y validar parámetros antes de instanciarlos.
- Rechaza las llamadas legacy que pasaban instancias o callables directamente a `InterpretadorCobra.extra_validators`, obligando a usar una ruta con descriptores declarativos.
- Añade y actualiza pruebas unitarias en `tests/unit/test_import_seguro_validator.py` y `tests/unit/test_custom_validators.py` que cubren resultado válido, timeout (bucle infinito / worker terminado), consumo de memoria, imports/introspección prohibidos, excepciones internas, resultado no serializable y comportamiento cuando el worker no devuelve mensaje válido.
- Mantengo explícito que no se modificaron Lexer ni Parser y el cambio fue comiteado como `security(validators): aísla validadores externos`.

### Testing

- Ejecutado: `pytest -q tests/unit/test_import_seguro_validator.py tests/unit/test_cli_secure_validators.py tests/unit/test_custom_validators.py` — estas pruebas focales pasaron después de los ajustes realizados.
- Ejecutado: `python -m py_compile src/pcobra/core/interpreter.py src/pcobra/core/validator_worker.py` — compilación estática OK.
- Ejecutado: `python -m ruff check src/pcobra/core/interpreter.py src/pcobra/core/validator_worker.py` — check de estilo/comprobaciones pasó.
- Ejecutado: `git diff --check` — sin errores en el diff.
- Nota: Corrí suites adicionales relacionadas (`tests/unit/test_safe_mode*`, `tests/unit/test_restricted_exec.py`, etc.); se observaron un par de fallos/errores preexistentes de recolección en tests que dependen de shims (`cobra` vs `pcobra`) y no causados por estos cambios; por tanto fueron marcados como advertencias en la validación amplia del árbol de pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77037534e8832782d72c4e01a8e047)