### PR TITLE
fix(imports): limpia módulos parcialmente cargados

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -38,6 +38,7 @@ _PROJECT_MODULE_FORBIDDEN_CHARS = frozenset('/\\@$%*?"\'<>|;`!()[]{}=+,')
 _USAR_PROJECT_MODULE_CACHE: dict[Path, dict[str, Any]] = {}
 _USAR_PROJECT_LOADING_STACK: list[Path] = []
 _IMPORT_COBRA_AST_CACHE: dict[Path, list[Any]] = {} # Nueva caché para ASTs de fuentes .cobra
+_MODULO_AUSENTE = object()
 CobraImportResolver = imports_resolver.CobraImportResolver
 _DEFAULT_COBRA_IMPORT_RESOLVER = CobraImportResolver
 
@@ -511,16 +512,24 @@ def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
     if mod_spec is None or mod_spec.loader is None:
         raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
     modulo = importlib.util.module_from_spec(mod_spec)
+    modulo_previo = sys.modules.get(nombre, _MODULO_AUSENTE)
     sys.modules[nombre] = modulo
-    mod_spec.loader.exec_module(modulo)
+    try:
+        mod_spec.loader.exec_module(modulo)
+    except BaseException:
+        if modulo_previo is _MODULO_AUSENTE:
+            sys.modules.pop(nombre, None)
+        else:
+            sys.modules[nombre] = modulo_previo
+        raise
     return modulo
 
 
 def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
     """Carga un módulo Python desde una ruta absoluta explícita."""
 
-    modulo_existente = sys.modules.get(nombre)
-    if modulo_existente is not None:
+    modulo_existente = sys.modules.get(nombre, _MODULO_AUSENTE)
+    if modulo_existente is not _MODULO_AUSENTE and modulo_existente is not None:
         modulo_file = getattr(modulo_existente, "__file__", None)
         if modulo_file and Path(modulo_file).resolve() == ruta:
             return modulo_existente
@@ -530,7 +539,14 @@ def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
         raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
     modulo = importlib.util.module_from_spec(mod_spec)
     sys.modules[nombre] = modulo
-    mod_spec.loader.exec_module(modulo)
+    try:
+        mod_spec.loader.exec_module(modulo)
+    except BaseException:
+        if modulo_existente is _MODULO_AUSENTE:
+            sys.modules.pop(nombre, None)
+        else:
+            sys.modules[nombre] = modulo_existente
+        raise
     return modulo
 
 

--- a/src/pcobra/core/database.py
+++ b/src/pcobra/core/database.py
@@ -64,6 +64,7 @@ _SQLITEPLUS_AVAILABILITY: bool | None = None
 
 _PATH_PREFIXES = ("path:", "file:")
 LOGGER = logging.getLogger(__name__)
+_MODULO_AUSENTE = object()
 
 
 def _build_sqliteplus_fallback():
@@ -189,7 +190,16 @@ def _load_sqliteplus_class(*, silent_optional: bool = False):
                 "se utilizará SQLite simplificado."
             )
         constants_module = importlib_util.module_from_spec(constants_spec)
-        constants_spec.loader.exec_module(constants_module)
+        constants_module_previo = sys.modules.get(constants_name, _MODULO_AUSENTE)
+        sys.modules[constants_name] = constants_module
+        try:
+            constants_spec.loader.exec_module(constants_module)
+        except BaseException:
+            if constants_module_previo is _MODULO_AUSENTE:
+                sys.modules.pop(constants_name, None)
+            else:
+                sys.modules[constants_name] = constants_module_previo
+            raise
         utils_module = sys.modules.setdefault(
             "sqliteplus.utils", types.ModuleType("sqliteplus.utils")
         )
@@ -199,7 +209,6 @@ def _load_sqliteplus_class(*, silent_optional: bool = False):
             "sqliteplus", types.ModuleType("sqliteplus")
         )
         setattr(package_module, "utils", utils_module)
-        sys.modules[constants_name] = constants_module
 
     spec = importlib_util.spec_from_file_location(
         "sqliteplus_utils_sync", module_path
@@ -212,7 +221,17 @@ def _load_sqliteplus_class(*, silent_optional: bool = False):
         )
 
     module = importlib_util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    module_name = spec.name
+    module_previo = sys.modules.get(module_name, _MODULO_AUSENTE)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        if module_previo is _MODULO_AUSENTE:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = module_previo
+        raise
     sqliteplus_class = getattr(module, "SQLitePlus", None)
     if sqliteplus_class is None:  # pragma: no cover - instalación dañada
         return _use_optional_fallback(

--- a/src/pcobra/core/pybind_bridge.py
+++ b/src/pcobra/core/pybind_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.machinery
 import importlib.util
 import os
+import sys
 import tempfile
 import shutil
 from types import ModuleType
@@ -14,6 +15,7 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import Distribution
 
 _cache: Dict[str, ModuleType] = {}
+_MODULO_AUSENTE = object()
 
 # Prefijos permitidos para cargar extensiones
 _ALLOWED_PREFIXES: list[str] = [
@@ -85,7 +87,16 @@ def cargar_extension(ruta: str) -> ModuleType:
         if spec is None:
             raise ImportError(f"No se pudo obtener un spec para {path}")
         module = importlib.util.module_from_spec(spec)
-        loader.exec_module(module)
+        modulo_previo = sys.modules.get(nombre, _MODULO_AUSENTE)
+        sys.modules[nombre] = module
+        try:
+            loader.exec_module(module)
+        except BaseException:
+            if modulo_previo is _MODULO_AUSENTE:
+                sys.modules.pop(nombre, None)
+            else:
+                sys.modules[nombre] = modulo_previo
+            raise
         _cache[path] = module
     return _cache[path]
 

--- a/tests/unit/test_dynamic_module_loader_rollback.py
+++ b/tests/unit/test_dynamic_module_loader_rollback.py
@@ -1,0 +1,171 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from pcobra.cobra import usar_loader
+from pcobra.core import database, pybind_bridge
+
+
+def test_modulo_nuevo_fallido_no_permanece_en_sys_modules(tmp_path):
+    nombre = "modulo_nuevo_fallido"
+    (tmp_path / f"{nombre}.py").write_text("parcial = True\nraise RuntimeError('fallo')\n")
+
+    with pytest.raises(RuntimeError, match="fallo"):
+        usar_loader._cargar_modulo_local_desde_directorio(nombre, tmp_path)
+
+    assert nombre not in sys.modules
+
+
+@pytest.mark.parametrize("valor_previo", [ModuleType("previo"), None])
+def test_modulo_previamente_existente_se_restaura_exactamente(
+    tmp_path, monkeypatch, valor_previo
+):
+    nombre = "modulo_previamente_existente"
+    ruta = tmp_path / f"{nombre}.py"
+    ruta.write_text("raise ValueError('fallo')\n")
+    monkeypatch.setitem(sys.modules, nombre, valor_previo)
+
+    with pytest.raises(ValueError, match="fallo"):
+        usar_loader._cargar_modulo_local_desde_ruta(nombre, ruta)
+
+    assert sys.modules[nombre] is valor_previo
+
+
+def test_reintento_tras_fallo_carga_el_modulo_correctamente(tmp_path):
+    nombre = "modulo_reintentable"
+    ruta = tmp_path / f"{nombre}.py"
+    ruta.write_text("raise RuntimeError('primer intento')\n")
+
+    with pytest.raises(RuntimeError, match="primer intento"):
+        usar_loader._cargar_modulo_local_desde_directorio(nombre, tmp_path)
+    ruta.write_text("resultado = 42\n")
+
+    modulo = usar_loader._cargar_modulo_local_desde_directorio(nombre, tmp_path)
+
+    assert modulo.resultado == 42
+    assert sys.modules[nombre] is modulo
+    sys.modules.pop(nombre, None)
+
+
+def test_paquete_con_init_fallido_no_permanece_en_sys_modules(tmp_path):
+    nombre = "paquete_fallido"
+    paquete = tmp_path / nombre
+    paquete.mkdir()
+    (paquete / "__init__.py").write_text(
+        "instancia_parcial = object()\nraise LookupError('init fallido')\n"
+    )
+
+    with pytest.raises(LookupError, match="init fallido"):
+        usar_loader._cargar_modulo_local_desde_directorio(nombre, tmp_path)
+
+    assert nombre not in sys.modules
+
+
+def test_instancia_parcial_no_es_observable_tras_el_fallo(tmp_path):
+    nombre = "modulo_parcial"
+    (tmp_path / f"{nombre}.py").write_text(
+        "import sys\ninstancia_parcial = sys.modules[__name__]\nraise RuntimeError('fallo')\n"
+    )
+
+    with pytest.raises(RuntimeError, match="fallo") as error:
+        usar_loader._cargar_modulo_local_desde_directorio(nombre, tmp_path)
+
+    assert nombre not in sys.modules
+    assert not hasattr(error.value, "instancia_parcial")
+
+
+def test_pybind_restaura_entrada_previa_si_falla_el_loader(tmp_path, monkeypatch):
+    ruta = tmp_path / "extension.so"
+    ruta.touch()
+    previo = ModuleType("extension_previa")
+
+    class LoaderFallido:
+        name = "extension"
+
+        def __init__(self, nombre, path):
+            self.name = nombre
+
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            assert sys.modules[self.name] is module
+            raise RuntimeError("extension fallida")
+
+    monkeypatch.setattr(pybind_bridge, "_ALLOWED_PREFIXES", [str(tmp_path)])
+    monkeypatch.setattr(pybind_bridge.importlib.machinery, "ExtensionFileLoader", LoaderFallido)
+    monkeypatch.setitem(sys.modules, "extension", previo)
+
+    with pytest.raises(RuntimeError, match="extension fallida"):
+        pybind_bridge.cargar_extension(str(ruta))
+
+    assert sys.modules["extension"] is previo
+
+
+def test_database_elimina_modulo_principal_parcial_si_falla(monkeypatch, tmp_path):
+    importlib.reload(database)
+    constants = ModuleType("sqliteplus.utils.constants")
+    monkeypatch.setitem(sys.modules, "sqliteplus.utils.constants", constants)
+    monkeypatch.setattr(database, "_SQLITEPLUS_CLASS", None)
+
+    class LoaderFallido:
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            assert sys.modules["sqliteplus_utils_sync"] is module
+            raise RuntimeError("database fallida")
+
+    module_path = tmp_path / "sqliteplus_sync.py"
+    module_path.touch()
+    dist = SimpleNamespace(locate_file=lambda path: module_path)
+    spec = SimpleNamespace(name="sqliteplus_utils_sync", loader=LoaderFallido())
+    monkeypatch.setattr(database, "distribution", lambda name: dist)
+    monkeypatch.setattr(database.importlib_util, "spec_from_file_location", lambda *args: spec)
+    monkeypatch.setattr(
+        database.importlib_util,
+        "module_from_spec",
+        lambda loaded_spec: ModuleType(loaded_spec.name),
+    )
+
+    with pytest.raises(RuntimeError, match="database fallida"):
+        database._load_sqliteplus_class()
+
+    assert "sqliteplus_utils_sync" not in sys.modules
+
+
+def test_database_elimina_modulo_constants_parcial_si_falla(monkeypatch, tmp_path):
+    importlib.reload(database)
+    constants_name = "sqliteplus.utils.constants"
+    monkeypatch.delitem(sys.modules, constants_name, raising=False)
+
+    class LoaderFallido:
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            assert sys.modules[constants_name] is module
+            raise RuntimeError("constants fallido")
+
+    constants_path = tmp_path / "constants.py"
+    constants_path.touch()
+    sync_path = tmp_path / "sqliteplus_sync.py"
+    sync_path.touch()
+    dist = SimpleNamespace(
+        locate_file=lambda path: constants_path if path == "utils/constants.py" else sync_path
+    )
+    spec = SimpleNamespace(name=constants_name, loader=LoaderFallido())
+    monkeypatch.setattr(database, "distribution", lambda name: dist)
+    monkeypatch.setattr(database.importlib_util, "spec_from_file_location", lambda *args: spec)
+    monkeypatch.setattr(
+        database.importlib_util,
+        "module_from_spec",
+        lambda loaded_spec: ModuleType(loaded_spec.name),
+    )
+
+    with pytest.raises(RuntimeError, match="constants fallido"):
+        database._load_sqliteplus_class()
+
+    assert constants_name not in sys.modules


### PR DESCRIPTION
### Motivation

- Evitar que una excepción durante `exec_module` deje entradas parciales o incorrectas en `sys.modules` que puedan contaminar posteriores imports o pruebas.
- Aplicar un rollback mínimo y localizado en los cargadores que realizan `spec.loader.exec_module(...)` directamente, sin alterar los cargadores que delegan en `importlib.import_module` ni tocar Lexer/Parser.

### Description

- Añade un sentinel `_MODULO_AUSENTE` y captura la entrada previa en `sys.modules` antes de insertar el módulo nuevo para distinguir ausencia de un valor `None` y otros valores previos. (modificado: `src/pcobra/cobra/usar_loader.py`, `src/pcobra/core/pybind_bridge.py`, `src/pcobra/core/database.py`).
- Envuelve `exec_module` en un `try/except BaseException` y, ante cualquier excepción, elimina la entrada nueva o restaura exactamente la entrada previa antes de volver a propagar la excepción. (comportamiento aplicado a los cargadores locales de `usar`, al loader de extensiones `pybind` y a las cargas dinámicas en `database`).
- No se crean aliases nuevos en `sys.modules`, no se cambia la semántica de los cargadores que delegan en `importlib.import_module`, y no se modificaron Lexer ni Parser.
- Añade pruebas focales que cubren: módulo nuevo que falla, módulo previamente existente (incluyendo caso `None`) que se restaura, reintento exitoso tras fallo, paquete con `__init__.py` fallido, ausencia de instancia parcial, rollback en pybind y rollback en las cargas dinámicas de `database`. (nuevo archivo de pruebas: `tests/unit/test_dynamic_module_loader_rollback.py`).

### Testing

- `pytest -q tests/unit/test_dynamic_module_loader_rollback.py` — pruebas focales OK (todas las pruebas focales añadidas pasaron).
- `pytest -q tests/unit/test_pybind_bridge_invalid_loader.py tests/unit/test_pybind_bridge_paths.py` — OK en las pruebas de pybind específicas.
- `python -m py_compile src/pcobra/cobra/usar_loader.py src/pcobra/core/pybind_bridge.py src/pcobra/core/database.py tests/unit/test_dynamic_module_loader_rollback.py` — compilado estático de Python OK.
- `python -m ruff check src/pcobra/cobra/usar_loader.py src/pcobra/core/pybind_bridge.py src/pcobra/core/database.py tests/unit/test_dynamic_module_loader_rollback.py` — linters OK.
- `git diff --check` y comprobación de cambios en Lexer/Parser — sin problemas y sin cambios en Lexer/Parser.
- Ejecución de suites vecinas más amplias detectó fallos preexistentes y no relacionados con este cambio: dos fallos por compilación de C++ (prueba que compila código deliberadamente inválido), fallos relacionados con optimizaciones/estructura AST en `ctypes`/transpilador y un conjunto de fallos en tests `usar`/política de símbolos que ya existían y no fueron inducidos por este parche; por tanto no se modificaron esas áreas para no ocultar problemas propios de Parser/AST/contratos de política.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77061849048327836a17428e7e80b4)