### PR TITLE
fix(packaging): resuelve corelibs como paquetes instalados

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -18,6 +18,7 @@ from pcobra.cobra.usar_capabilities import CapacidadUsar, capacidades_de
 from pcobra.cobra.usar_policy import (
     CANONICAL_MODULE_SURFACE_CONTRACTS,
     REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
+    REPL_COBRA_MODULE_PACKAGE_MAP,
     USAR_BACKEND_BLOCKLIST,
     USAR_COBRA_PUBLIC_MODULES,
     USAR_RUNTIME_EXPORT_OVERRIDES,
@@ -551,44 +552,23 @@ def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
 
 
 def obtener_modulo_cobra_oficial(nombre: str):
-    """Carga módulos oficiales de Cobra desde la ruta interna canónica declarada."""
+    """Importa un módulo oficial desde el paquete ``pcobra`` instalado."""
 
     nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
-    rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP.get(nombre)
-    if not rel_path:
+    nombre_import = REPL_COBRA_MODULE_PACKAGE_MAP.get(nombre)
+    if not nombre_import:
         raise ModuleNotFoundError(
-            f"Módulo oficial Cobra '{nombre}' permitido pero sin ruta interna canónica declarada."
+            f"Módulo oficial Cobra '{nombre}' permitido pero sin paquete interno canónico declarado."
         )
-
-    repo_root = Path(__file__).resolve().parents[3]
-    ruta_modulo = (repo_root / rel_path).resolve()
-    if not ruta_modulo.exists():
-        raise ModuleNotFoundError(
-            "Módulo oficial Cobra permitido no resoluble en runtime: "
-            f"alias='{nombre}' ruta='{rel_path}'."
-        )
-
-    if rel_path.startswith("src/pcobra/corelibs/"):
-        nombre_import = f"pcobra.corelibs.{ruta_modulo.stem}"
-    elif rel_path.startswith("src/pcobra/standard_library/"):
-        nombre_import = f"pcobra.standard_library.{ruta_modulo.stem}"
-    else:
-        nombre_import = ""
-
-    if nombre_import:
-        modulo = importlib.import_module(nombre_import)
-        modulo_file = getattr(modulo, "__file__", None)
-        if modulo_file and Path(modulo_file).resolve() == ruta_modulo:
-            for export_name in getattr(modulo, "__all__", ()):  # Cobra-facing: alias público.
-                export = getattr(modulo, export_name, None)
-                if callable(export) and hasattr(export, "__module__"):
-                    try:
-                        export.__module__ = nombre
-                    except (AttributeError, TypeError):
-                        pass
-            return modulo
-
-    return _cargar_modulo_local_desde_ruta(nombre, ruta_modulo)
+    modulo = importlib.import_module(nombre_import)
+    for export_name in getattr(modulo, "__all__", ()):  # Cobra-facing: alias público.
+        export = getattr(modulo, export_name, None)
+        if callable(export) and hasattr(export, "__module__"):
+            try:
+                export.__module__ = nombre
+            except (AttributeError, TypeError):
+                pass
+    return modulo
 
 
 def _obtener_modulo_cobra_oficial_compat(nombre: str):
@@ -610,11 +590,9 @@ def _obtener_modulo_cobra_oficial_compat(nombre: str):
 
     modulo = obtener_modulo_cobra_oficial(nombre)
 
-    rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP.get(nombre)
-    if rel_path:
-        ruta_oficial = (Path(__file__).resolve().parents[3] / rel_path).resolve()
-        modulo_file = getattr(modulo, "__file__", None)
-        if not modulo_file or Path(modulo_file).resolve() != ruta_oficial:
+    package_name = REPL_COBRA_MODULE_PACKAGE_MAP.get(nombre)
+    if package_name:
+        if getattr(modulo, "__name__", None) != package_name:
             raise PermissionError(
                 "usar_error[modulo_no_permitido]: módulo externo no permitido en REPL estricto "
                 "(solo alias oficiales Cobra)"

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass, field, replace
-from pathlib import Path
 
 
 # Fuente única de verdad de módulos canónicos permitidos por `usar`.
@@ -50,45 +49,27 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
     modulo: True for modulo in USAR_COBRA_PUBLIC_MODULES
 }
 
-_USAR_CANONICAL_INTERNAL_PATHS: dict[str, str] = {
+REPL_COBRA_MODULE_PACKAGE_MAP: dict[str, str] = {
     # `numero` expone el contrato runtime de `usar` desde corelibs.
-    "numero": "src/pcobra/corelibs/numero.py",
+    "numero": "pcobra.corelibs.numero",
     # `texto` expone su API Cobra-facing desde corelibs para evitar inicializar agregadores.
-    "texto": "src/pcobra/standard_library/texto.py",
+    "texto": "pcobra.standard_library.texto",
     # `datos` mantiene la misma estrategia que `numero`: el alias público se
     # resuelve por la ruta interna canónica declarada aquí.  En este caso el
     # contrato runtime apunta explícitamente a standard_library.
-    "datos": "src/pcobra/standard_library/datos.py",
-    "logica": "src/pcobra/corelibs/logica.py",
-    "asincrono": "src/pcobra/corelibs/asincrono.py",
-    "sistema": "src/pcobra/corelibs/sistema.py",
-    "archivo": "src/pcobra/corelibs/archivo.py",
-    "tiempo": "src/pcobra/corelibs/tiempo.py",
-    "red": "src/pcobra/corelibs/red.py",
-    "holobit": "src/pcobra/corelibs/holobit.py",
-    "ruta": "src/pcobra/corelibs/ruta.py",
-    "serializacion": "src/pcobra/corelibs/serializacion.py",
-    "proceso": "src/pcobra/corelibs/proceso.py",
-    "registro": "src/pcobra/corelibs/registro.py",
-    "argumentos": "src/pcobra/corelibs/argumentos.py",
-    "pruebas": "src/pcobra/corelibs/pruebas.py",
-    "temporal": "src/pcobra/corelibs/temporal.py",
-    "cripto": "src/pcobra/corelibs/cripto.py",
-    "regex": "src/pcobra/corelibs/regex.py",
-    "compresion": "src/pcobra/corelibs/compresion.py",
-    "configuracion": "src/pcobra/corelibs/configuracion.py",
+    "datos": "pcobra.standard_library.datos",
+    **{
+        alias: f"pcobra.corelibs.{alias}"
+        for alias in USAR_COBRA_PUBLIC_MODULES
+        if alias not in {"numero", "texto", "datos"}
+    },
 }
 
 
-def _build_repl_cobra_module_internal_path_map() -> dict[str, str]:
-    """Construye el mapeo oficial `alias usar` -> ruta interna por módulo."""
-
-    return dict(_USAR_CANONICAL_INTERNAL_PATHS)
-
-
-# Fuente única de verdad: alias canónico `usar` -> ruta interna oficial.
+# Compatibilidad nominal: el mapa histórico conserva su interfaz pública, pero
+# sus valores son ahora nombres importables, nunca rutas del checkout.
 REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = (
-    _build_repl_cobra_module_internal_path_map()
+    REPL_COBRA_MODULE_PACKAGE_MAP
 )
 
 
@@ -125,20 +106,22 @@ def validar_contrato_modulos_canonicos_usar() -> None:
             f"faltantes={faltantes} sobrantes={sobrantes}."
         )
 
-    repo_root = Path(__file__).resolve().parents[3]
-    for alias, rel_path in REPL_COBRA_MODULE_INTERNAL_PATH_MAP.items():
-        if not rel_path.startswith(
-            ("src/pcobra/corelibs/", "src/pcobra/standard_library/")
+    for alias, package_name in REPL_COBRA_MODULE_PACKAGE_MAP.items():
+        if not package_name.startswith(
+            ("pcobra.corelibs.", "pcobra.standard_library.")
         ):
             raise RuntimeError(
                 "[STARTUP CONTRACT] Las rutas internas oficiales de `usar` deben "
-                f"estar en corelibs/standard_library; alias={alias} ruta={rel_path}."
+                f"estar en corelibs/standard_library; alias={alias} paquete={package_name}."
             )
-        path = repo_root / rel_path
-        if not path.exists():
+        try:
+            spec = importlib.util.find_spec(package_name)
+        except (ImportError, AttributeError, ValueError):
+            spec = None
+        if spec is None:
             raise RuntimeError(
                 "[STARTUP CONTRACT] Falta módulo canónico obligatorio de `usar`: "
-                f"alias={alias} ruta={rel_path}."
+                f"alias={alias} paquete={package_name}."
             )
 
 
@@ -942,13 +925,9 @@ def validar_paridad_superficie_publica_modulos_canonicos() -> None:
                 f"[STARTUP CONTRACT] {module_name} no debe exportar clases en __all__: {leaked_class_like}"
             )
 
-        stdlib_path = (
-            Path(__file__).resolve().parents[1]
-            / "standard_library"
-            / f"{module_name}.py"
-        )
-        if stdlib_path.exists():
-            std_mod = importlib.import_module(f"pcobra.standard_library.{module_name}")
+        stdlib_name = f"pcobra.standard_library.{module_name}"
+        if importlib.util.find_spec(stdlib_name) is not None:
+            std_mod = importlib.import_module(stdlib_name)
             std_exports = tuple(getattr(std_mod, "__all__", ()))
             if std_exports:
                 combined_exports = set(exports) | set(std_exports)

--- a/tests/cli/test_packaging_smoke.py
+++ b/tests/cli/test_packaging_smoke.py
@@ -14,14 +14,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.mark.integration
-def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
-    """Valida artefactos de packaging y `pcobra.cli:main(['--help'])` en entorno limpio."""
+def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
+    """Ejecuta intérprete y corelibs usando exclusivamente el wheel instalado."""
 
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir(parents=True, exist_ok=True)
 
     build_result = subprocess.run(
-        [sys.executable, "-m", "build", "--wheel", "--sdist", "--outdir", str(dist_dir)],
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,
@@ -33,9 +33,7 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     )
 
     wheels = sorted(dist_dir.glob("*.whl"))
-    sdists = sorted(dist_dir.glob("*.tar.gz"))
     assert wheels, "No se generó wheel durante el smoke test de packaging."
-    assert sdists, "No se generó sdist durante el smoke test de packaging."
 
     venv_dir = tmp_path / "venv"
     subprocess.run(
@@ -53,26 +51,41 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
         venv_pip = venv_dir / "bin" / "pip"
 
     subprocess.run(
-        [str(venv_pip), "install", "--no-deps", "--force-reinstall", str(wheels[0])],
+        [str(venv_pip), "install", "--force-reinstall", str(wheels[0])],
         check=True,
         capture_output=True,
         text=True,
     )
 
     smoke_script = (
+        "import pathlib, sys\n"
+        f"checkout = pathlib.Path({str(REPO_ROOT)!r}).resolve()\n"
+        "if any(pathlib.Path(p or '.').resolve() == checkout for p in sys.path):\n"
+        "    raise SystemExit('el checkout está presente en sys.path')\n"
+        "consultas_src = []\n"
+        "def auditar(evento, args):\n"
+        "    if evento == 'open' and args and isinstance(args[0], (str, bytes)):\n"
+        "        ruta = pathlib.Path(args[0]).resolve()\n"
+        "        if 'src' in ruta.parts:\n"
+        "            consultas_src.append(str(ruta))\n"
+        "sys.addaudithook(auditar)\n"
         "import pcobra\n"
-        "import pcobra.cli\n"
-        "from pcobra.cli import main\n"
-        "import sys\n"
-        "antes = set(sys.modules)\n"
-        "code = main(['--help'])\n"
-        "despues = set(sys.modules)\n"
-        "if code != 0:\n"
-        "    raise SystemExit(f'pcobra.cli.main([\\'--help\\']) devolvió {code}')\n"
-        "prohibidos = {'cobra', 'core', 'bindings'}\n"
-        "cargados = sorted(name for name in (despues - antes) if name in prohibidos)\n"
-        "if cargados:\n"
-        "    raise SystemExit(f'Se cargaron paquetes raíz legacy en smoke limpio: {cargados!r}')\n"
+        "from pcobra.cobra.core.lexer import Lexer\n"
+        "from pcobra.cobra.core.parser import Parser\n"
+        "from pcobra.cobra.core.runtime import InterpretadorCobra\n"
+        "from pcobra.cobra.usar_loader import usar_modulo\n"
+        "codigo = 'usar \\\"texto\\\"\\nvariable saludo := mayusculas(\\\"cobra\\\")\\nusar \\\"proceso\\\"'\n"
+        "interprete = InterpretadorCobra(safe_mode=False)\n"
+        "interprete.ejecutar_ast(Parser(Lexer(codigo).tokenizar()).parsear())\n"
+        "assert interprete.obtener_variable('saludo') == 'COBRA'\n"
+        "proceso = usar_modulo('proceso', safe_mode=False)\n"
+        "resultado = proceso['ejecutar']([sys.executable, '-c', 'print(6 * 7)'])\n"
+        "assert resultado['codigo'] == 0 and resultado['salida'].strip() == '42'\n"
+        "for modulo in ('pcobra', 'pcobra.standard_library.texto', 'pcobra.corelibs.proceso'):\n"
+        "    ruta = pathlib.Path(sys.modules[modulo].__file__).resolve()\n"
+        "    assert checkout not in ruta.parents and 'site-packages' in ruta.parts, ruta\n"
+        "if consultas_src:\n"
+        "    raise SystemExit(f'se consultaron carpetas src externas: {consultas_src!r}')\n"
     )
     run_help = subprocess.run(
         [str(venv_python), "-I", "-c", smoke_script],
@@ -83,6 +96,6 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     )
 
     assert run_help.returncode == 0, (
-        "El smoke test aislado de packaging debe validar `import pcobra; import pcobra.cli` y ejecutar --help sin depender de paquetes raíz. "
+        "El smoke test aislado debe ejecutar el wheel sin consultar el checkout ni otro src. "
         f"stdout={run_help.stdout!r} stderr={run_help.stderr!r}"
     )

--- a/tests/unit/test_usar_policy_contract.py
+++ b/tests/unit/test_usar_policy_contract.py
@@ -9,6 +9,7 @@ from pcobra.cobra.usar_policy import (
     CANONICAL_MODULE_SURFACE_CONTRACTS,
     REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
     REPL_COBRA_MODULE_MAP,
+    REPL_COBRA_MODULE_PACKAGE_MAP,
     USAR_COBRA_PUBLIC_MODULES,
     USAR_RUNTIME_EXPORT_OVERRIDES,
     validar_paridad_superficie_publica_modulos_canonicos,
@@ -22,17 +23,14 @@ def test_repl_module_map_contiene_exactamente_modulos_canonicos() -> None:
     assert set(REPL_COBRA_MODULE_INTERNAL_PATH_MAP) == set(canonicos)
 
 
-def test_modulos_oficiales_se_resuelven_a_rutas_internas() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
+def test_modulos_oficiales_se_resuelven_como_paquetes_instalables() -> None:
     for alias, canonical in REPL_COBRA_MODULE_MAP.items():
         modulo = obtener_modulo_cobra_oficial(canonical)
-        modulo_path = Path(modulo.__file__).resolve()
-
-        expected_rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias]
-        expected_path = (repo_root / expected_rel_path).resolve()
-        assert modulo_path == expected_path, (
-            f"alias={alias} canonical={canonical} debe resolver a {expected_rel_path}, "
-            f"obtuvo {modulo_path}"
+        expected_package = REPL_COBRA_MODULE_PACKAGE_MAP[alias]
+        assert REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias] == expected_package
+        assert modulo.__name__ == expected_package
+        assert expected_package.startswith(
+            ("pcobra.corelibs.", "pcobra.standard_library.")
         )
 
 


### PR DESCRIPTION
### Motivation

- Evitar resolver los módulos oficiales `usar` mediante rutas al checkout y en su lugar tratarlos como paquetes instalables bajo `pcobra.corelibs.*` o `pcobra.standard_library.*` para soportar ejecución desde wheels instalados.
- Forzar imports oficiales con el mecanismo estándar de Python (`importlib.import_module`) en vez de crear specs a partir de archivos, manteniendo la política de allowlist y la superficie pública de `usar`.
- Añadir un smoke test que valide la instalación del wheel en un entorno virtual aislado y verifique que el runtime no consulte carpetas `src/` externas.

### Description

- Reemplacé el mapa de rutas internas por `REPL_COBRA_MODULE_PACKAGE_MAP` que mapea alias `usar` a nombres de paquete `pcobra.corelibs.*`/`pcobra.standard_library.*` y mantuve `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` como interfaz de compatibilidad apuntando ahora a esos nombres de paquete.
- Actualicé la validación startup para comprobar prefijos de paquete y usar `importlib.util.find_spec` para verificar que los paquetes canónicos estén disponibles en el entorno instalado, en lugar de comprobar archivos dentro del checkout.
- Modifiqué `obtener_modulo_cobra_oficial` para importar los módulos oficiales con `importlib.import_module`, preservar y sanear `__all__` al surface público de `usar`, y ajusté el wrapper de compatibilidad para comparar `module.__name__` con el paquete esperado.
- Actualicé pruebas contractuales y de packaging: `tests/unit/test_usar_policy_contract.py` para verificar resolución como paquetes instalables y `tests/cli/test_packaging_smoke.py` para construir wheel, crear venv temporal, instalar solo el wheel y ejecutar `import pcobra`, el intérprete, `usar

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77089041548327978d32a53faf3ae2)