### PR TITLE
fix(security): unifica contratos de capacidades `usar` y endurece enforcement runtime/sandbox

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -19,6 +19,8 @@ from pcobra.cobra.cli.target_policies import (
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.cli.utils.messages import mostrar_error
 from pcobra.cobra.core.sandbox import validar_dependencias
+from pcobra.cobra.cli.execution_pipeline import analizar_codigo, preparar_interpretador
+from pcobra.cobra.core.runtime import InterpretadorCobra, construir_cadena
 
 sys.modules.setdefault("cli.commands.execute_cmd", sys.modules[__name__])
 RUNTIME_MANAGER = RuntimeManager()
@@ -77,3 +79,21 @@ class ExecuteCommand(BaseCommand):
             allow_insecure_fallback=bool(getattr(args, "allow_insecure_fallback", False)),
         )
         return self._service.run(request)
+
+    def _ejecutar_normal(self, codigo: str, seguro: bool, extra_validators: Any) -> int:
+        """Compatibilidad CLI: usa la construcción canónica del intérprete."""
+
+        try:
+            ast = analizar_codigo(codigo)
+            setup = preparar_interpretador(
+                interpretador_cls=InterpretadorCobra,
+                safe_mode=seguro,
+                extra_validators=extra_validators,
+            )
+            if seguro:
+                construir_cadena(setup.validadores_extra)
+            setup.interpretador.ejecutar_ast(ast)
+            return 0
+        except Exception as exc:
+            mostrar_error(str(exc))
+            return 1

--- a/src/pcobra/cobra/transpilers/transpiler/to_python.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_python.py
@@ -245,7 +245,7 @@ def visit_diccionario_comprehension(self, nodo):
 
 
 class TranspiladorPython(BaseTranspiler):
-    def __init__(self, *, source_file=None, project_root=None):
+    def __init__(self, *, source_file=None, project_root=None, safe_mode=False):
         # Incluir los modulos nativos al inicio del codigo generado
         self.codigo = ""
         self.usa_asyncio = False
@@ -255,6 +255,7 @@ class TranspiladorPython(BaseTranspiler):
         self._async_function_depth = 0
         self._defer_stack: list[str] = []
         self._defer_counter = 0
+        self.safe_mode = bool(safe_mode)
         self.source_file = self._normalizar_ruta_contexto(source_file)
         self.project_root = self._normalizar_ruta_contexto(project_root)
         if self.project_root is None and self.source_file is not None:
@@ -279,7 +280,7 @@ class TranspiladorPython(BaseTranspiler):
     def contexto_usar_kwargs(self):
         """Devuelve argumentos estables para ``usar_modulo`` cuando hay contexto."""
 
-        kwargs = []
+        kwargs = [("safe_mode", self.safe_mode)]
         if self.project_root is not None:
             kwargs.append(("project_root", str(self.project_root)))
         if self.source_file is not None:

--- a/src/pcobra/cobra/usar_capabilities.py
+++ b/src/pcobra/cobra/usar_capabilities.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from types import MappingProxyType
 
 
 class CapacidadUsar(StrEnum):
@@ -13,45 +12,41 @@ class CapacidadUsar(StrEnum):
     NETWORK_POST = "network.post"
     NETWORK_DOWNLOAD = "network.download"
     FILESYSTEM_WRITE = "filesystem.write"
-
-
-_SIMBOLO_CANONICO = MappingProxyType(
-    {
-        ("proceso", "ejecutar"): ("proceso", "ejecutar"),
-        ("proceso", "capturar"): ("proceso", "ejecutar"),
-        ("proceso", "ejecutar_async"): ("proceso", "ejecutar_async"),
-        ("proceso", "ejecutar_stream"): ("proceso", "ejecutar_stream"),
-        ("red", "obtener_url"): ("red", "obtener_url"),
-        ("red", "obtener_url_async"): ("red", "obtener_url"),
-        ("red", "obtener_url_texto"): ("red", "obtener_url"),
-        ("red", "obtener_json"): ("red", "obtener_url"),
-        ("red", "enviar_post"): ("red", "enviar_post"),
-        ("red", "enviar_post_async"): ("red", "enviar_post"),
-        ("red", "descargar_archivo"): ("red", "descargar_archivo"),
-    }
-)
-
-_CAPACIDADES = MappingProxyType(
-    {
-        ("proceso", "ejecutar"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
-        ("proceso", "ejecutar_async"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
-        ("proceso", "ejecutar_stream"): frozenset({CapacidadUsar.PROCESS_SPAWN}),
-        ("red", "obtener_url"): frozenset({CapacidadUsar.NETWORK_GET}),
-        ("red", "enviar_post"): frozenset({CapacidadUsar.NETWORK_POST}),
-        ("red", "descargar_archivo"): frozenset(
-            {CapacidadUsar.NETWORK_DOWNLOAD, CapacidadUsar.FILESYSTEM_WRITE}
-        ),
-    }
-)
+    FILESYSTEM_READ = "filesystem.read"
+    ASYNC_SCHEDULE = "async.schedule"
+    CLOCK_READ = "clock.read"
+    CLOCK_SLEEP = "clock.sleep"
+    ENVIRONMENT_READ = "environment.read"
+    LOGGING_WRITE = "logging.write"
+    RANDOM_READ = "random.read"
 
 
 def simbolo_canonico(modulo: str, nombre: str) -> tuple[str, str]:
-    """Resuelve aliases sin consultar atributos del objeto exportado."""
+    """Resuelve la identidad documental sin mantener otra tabla de capacidades."""
 
-    return _SIMBOLO_CANONICO.get((modulo, nombre), (modulo, nombre))
+    from pcobra.cobra.usar_policy import CANONICAL_MODULE_SURFACE_CONTRACTS
+
+    aliases_semanticos = {
+        ("red", "obtener_url_async"): "obtener_url",
+        ("red", "enviar_post_async"): "enviar_post",
+        ("red", "obtener_json"): "obtener_url",
+    }
+    contract = CANONICAL_MODULE_SURFACE_CONTRACTS.get(modulo)
+    target = aliases_semanticos.get((modulo, nombre), nombre)
+    if contract is not None:
+        target = contract.allowed_aliases.get(nombre, target)
+    return modulo, target
 
 
 def capacidades_de(modulo: str, nombre: str) -> frozenset[CapacidadUsar]:
-    """Devuelve el contrato mantenido por código para el símbolo canónico."""
+    """Consulta directamente la clasificación canónica de ``usar_policy``."""
 
-    return _CAPACIDADES.get(simbolo_canonico(modulo, nombre), frozenset())
+    from pcobra.cobra.usar_policy import CANONICAL_MODULE_SURFACE_CONTRACTS
+
+    contract = CANONICAL_MODULE_SURFACE_CONTRACTS.get(modulo)
+    if contract is None:
+        return frozenset()
+    return frozenset(
+        CapacidadUsar(capability)
+        for capability in contract.symbol_capabilities.get(nombre, frozenset())
+    )

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -128,14 +128,26 @@ def _aplicar_capacidades(
 ) -> list[tuple[str, Any]]:
     """Construye wrappers desde contratos internos, nunca desde atributos Cobra."""
 
+    capacidades_restringidas = frozenset(
+        {
+            CapacidadUsar.PROCESS_SPAWN,
+            CapacidadUsar.PROCESS_SHELL,
+            CapacidadUsar.NETWORK_GET,
+            CapacidadUsar.NETWORK_POST,
+            CapacidadUsar.NETWORK_DOWNLOAD,
+            CapacidadUsar.FILESYSTEM_READ,
+            CapacidadUsar.FILESYSTEM_WRITE,
+        }
+    )
     resultado: list[tuple[str, Any]] = []
     for nombre, simbolo in simbolos:
         capacidades = capacidades_de(modulo, nombre)
-        if not callable(simbolo) or not capacidades:
+        capacidades_enforced = capacidades & capacidades_restringidas
+        if not callable(simbolo) or not capacidades_enforced:
             resultado.append((nombre, simbolo))
             continue
 
-        def verificar_permiso(kwargs, __capacidades=capacidades):
+        def verificar_permiso(kwargs, __capacidades=capacidades_enforced):
             if safe_mode:
                 if (
                     CapacidadUsar.PROCESS_SPAWN in __capacidades
@@ -517,12 +529,11 @@ def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
     sys.modules[nombre] = modulo
     try:
         mod_spec.loader.exec_module(modulo)
-    except BaseException:
+    finally:
         if modulo_previo is _MODULO_AUSENTE:
             sys.modules.pop(nombre, None)
         else:
             sys.modules[nombre] = modulo_previo
-        raise
     return modulo
 
 
@@ -542,12 +553,11 @@ def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
     sys.modules[nombre] = modulo
     try:
         mod_spec.loader.exec_module(modulo)
-    except BaseException:
+    finally:
         if modulo_existente is _MODULO_AUSENTE:
             sys.modules.pop(nombre, None)
         else:
             sys.modules[nombre] = modulo_existente
-        raise
     return modulo
 
 
@@ -561,6 +571,22 @@ def obtener_modulo_cobra_oficial(nombre: str):
             f"Módulo oficial Cobra '{nombre}' permitido pero sin paquete interno canónico declarado."
         )
     modulo = importlib.import_module(nombre_import)
+    spec = getattr(modulo, "__spec__", None)
+    origin = getattr(spec, "origin", None)
+    pcobra_package = importlib.import_module("pcobra")
+    package_roots = tuple(
+        Path(root).resolve() for root in getattr(pcobra_package, "__path__", ())
+    )
+    try:
+        origin_path = Path(origin).resolve(strict=True) if origin else None
+    except (OSError, RuntimeError):
+        origin_path = None
+    if origin_path is None or not any(
+        origin_path.is_relative_to(root) for root in package_roots
+    ):
+        raise PermissionError(
+            "usar_error[procedencia_no_oficial]: el módulo no procede del paquete pcobra instalado"
+        )
     for export_name in getattr(modulo, "__all__", ()):  # Cobra-facing: alias público.
         export = getattr(modulo, export_name, None)
         if callable(export) and hasattr(export, "__module__"):

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -66,11 +66,12 @@ REPL_COBRA_MODULE_PACKAGE_MAP: dict[str, str] = {
 }
 
 
-# Compatibilidad nominal: el mapa histórico conserva su interfaz pública, pero
-# sus valores son ahora nombres importables, nunca rutas del checkout.
-REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = (
-    REPL_COBRA_MODULE_PACKAGE_MAP
-)
+# Contrato legacy para consumidores que resuelven archivos desde la raíz del
+# checkout. Es deliberadamente distinto del mapa de nombres importables.
+REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = {
+    alias: "src/" + package_name.replace(".", "/") + ".py"
+    for alias, package_name in REPL_COBRA_MODULE_PACKAGE_MAP.items()
+}
 
 
 def validar_contrato_modulos_canonicos_usar() -> None:

--- a/src/pcobra/core/database.py
+++ b/src/pcobra/core/database.py
@@ -194,12 +194,11 @@ def _load_sqliteplus_class(*, silent_optional: bool = False):
         sys.modules[constants_name] = constants_module
         try:
             constants_spec.loader.exec_module(constants_module)
-        except BaseException:
+        finally:
             if constants_module_previo is _MODULO_AUSENTE:
                 sys.modules.pop(constants_name, None)
             else:
                 sys.modules[constants_name] = constants_module_previo
-            raise
         utils_module = sys.modules.setdefault(
             "sqliteplus.utils", types.ModuleType("sqliteplus.utils")
         )
@@ -226,12 +225,11 @@ def _load_sqliteplus_class(*, silent_optional: bool = False):
     sys.modules[module_name] = module
     try:
         spec.loader.exec_module(module)
-    except BaseException:
+    finally:
         if module_previo is _MODULO_AUSENTE:
             sys.modules.pop(module_name, None)
         else:
             sys.modules[module_name] = module_previo
-        raise
     sqliteplus_class = getattr(module, "SQLitePlus", None)
     if sqliteplus_class is None:  # pragma: no cover - instalación dañada
         return _use_optional_fallback(

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -75,6 +75,7 @@ from .semantic_validators import (
     construir_cadena,
     PrimitivaPeligrosaError,
 )
+from .semantic_validators.base import ValidadorBase
 from .semantico import AnalizadorSemantico
 from .cobra_config import limite_nodos
 from .import_utils import (
@@ -383,6 +384,9 @@ class InterpretadorCobra:
                 process.join(0.5)
                 if process.is_alive():
                     process.kill()
+                InterpretadorCobra._registrar_auditoria_validador(
+                    ruta_real, "rechazado", "timeout", hash_corto=hash_corto, fase="worker"
+                )
                 raise ImportError("El validador adicional superó el tiempo permitido.")
         except EOFError:
             response = None
@@ -405,7 +409,16 @@ class InterpretadorCobra:
                 "resultado_no_serializable": "El resultado del validador no es serializable.",
                 "descriptor_invalido": "El validador adicional devolvió un descriptor inválido.",
                 "worker_terminado": "El proceso del validador terminó sin resultado.",
+                "sintaxis_invalida": "El validador adicional contiene sintaxis inválida.",
+                "error_en_ejecucion": "El validador adicional falló durante su ejecución aislada.",
             }
+            InterpretadorCobra._registrar_auditoria_validador(
+                ruta_real,
+                "rechazado",
+                str(codigo),
+                hash_corto=hash_corto,
+                fase="worker",
+            )
             raise ImportError(mensajes.get(codigo, "No se pudo cargar el validador adicional de forma segura."))
 
         from .semantic_validators import (
@@ -463,10 +476,15 @@ class InterpretadorCobra:
         extra = extra_validators
         if isinstance(extra, str):
             extra = self._cargar_validadores(extra)
+        elif isinstance(extra, list) and all(
+            isinstance(validador, ValidadorBase) for validador in extra
+        ):
+            extra = list(extra)
         elif extra:
             raise TypeError(
                 "Los validadores adicionales deben indicarse mediante una ruta "
-                "con descriptores declarativos; no se admiten instancias ni callables."
+                "con descriptores declarativos o instancias preautorizadas; "
+                "no se admiten callables arbitrarios."
             )
 
         self.safe_mode = safe_mode

--- a/src/pcobra/core/pybind_bridge.py
+++ b/src/pcobra/core/pybind_bridge.py
@@ -91,12 +91,11 @@ def cargar_extension(ruta: str) -> ModuleType:
         sys.modules[nombre] = module
         try:
             loader.exec_module(module)
-        except BaseException:
+        finally:
             if modulo_previo is _MODULO_AUSENTE:
                 sys.modules.pop(nombre, None)
             else:
                 sys.modules[nombre] = modulo_previo
-            raise
         _cache[path] = module
     return _cache[path]
 

--- a/src/pcobra/core/validator_worker.py
+++ b/src/pcobra/core/validator_worker.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import builtins
+import math
 import os
 from typing import Any
 
@@ -27,7 +28,10 @@ def _apply_resource_limits() -> None:
 
     memory = 256 * 1024 * 1024
     resource.setrlimit(resource.RLIMIT_AS, (memory, memory))
-    resource.setrlimit(resource.RLIMIT_CPU, (1, 1))
+    cpu_consumida = resource.getrusage(resource.RUSAGE_SELF)
+    usada = cpu_consumida.ru_utime + cpu_consumida.ru_stime
+    limite_blando = max(1, math.ceil(usada + 1.0))
+    resource.setrlimit(resource.RLIMIT_CPU, (limite_blando, limite_blando + 1))
 
 
 def _check_policy(source: str, filename: str) -> ast.AST:

--- a/src/pcobra/corelibs/_sandbox_paths.py
+++ b/src/pcobra/corelibs/_sandbox_paths.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import os
 import tempfile
+import threading
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Final
 
 _VARIABLE_RAIZ: Final = "COBRA_IO_BASE_DIR"
 _raiz_privada: Path | None = None
+_bloqueo_raiz = threading.Lock()
 
 
 def _obtener_raiz() -> Path:
@@ -29,7 +31,9 @@ def _obtener_raiz() -> Path:
 
     global _raiz_privada
     if _raiz_privada is None:
-        _raiz_privada = Path(tempfile.mkdtemp(prefix="pcobra-io-"))
+        with _bloqueo_raiz:
+            if _raiz_privada is None:
+                _raiz_privada = Path(tempfile.mkdtemp(prefix="pcobra-io-"))
     return _raiz_privada.resolve(strict=True)
 
 
@@ -75,6 +79,8 @@ def resolver_destino_nuevo(ruta: str | os.PathLike[str]) -> Path:
 
     raiz = _obtener_raiz()
     destino = raiz / _normalizar_ruta_usuario(ruta)
+    if destino.is_symlink():
+        raise ValueError("El destino no puede ser un enlace simbólico")
     ancestro = destino.parent
     partes_pendientes: list[str] = []
     while not ancestro.exists():
@@ -84,4 +90,6 @@ def resolver_destino_nuevo(ruta: str | os.PathLike[str]) -> Path:
     _comprobar_confinamiento(ancestro_real, raiz)
     padre_validado = ancestro_real.joinpath(*reversed(partes_pendientes))
     _comprobar_confinamiento(padre_validado, raiz)
-    return padre_validado / destino.name
+    destino_validado = padre_validado / destino.name
+    _comprobar_confinamiento(destino_validado.resolve(strict=False), raiz)
+    return destino_validado

--- a/src/pcobra/corelibs/compresion.py
+++ b/src/pcobra/corelibs/compresion.py
@@ -50,7 +50,9 @@ def crear_zip(
             raise FileNotFoundError(f"La ruta a comprimir no existe: {ruta}")
 
     base_resuelta = _resolver_base(rutas_normalizadas, base)
-    destino_zip = _validar_ruta(destino, "destino")
+    destino_zip = resolver_destino_nuevo(_ruta_relativa_sandbox(destino, "destino"))
+    if destino_zip.is_symlink():
+        raise ValueError("El destino ZIP no puede ser un enlace simbólico")
     destino_zip.parent.mkdir(parents=True, exist_ok=True)
 
     nombres: list[str] = []
@@ -71,8 +73,8 @@ def extraer_zip(origen: PathLike, destino: PathLike) -> list[str]:
     contra el directorio destino y se rechaza si queda fuera de él.
     """
 
-    origen_zip = resolver_ruta_existente(_texto_ruta(origen, "origen"))
-    destino_base = resolver_destino_nuevo(_texto_ruta(destino, "destino"))
+    origen_zip = resolver_ruta_existente(_ruta_relativa_sandbox(origen, "origen"))
+    destino_base = resolver_destino_nuevo(_ruta_relativa_sandbox(destino, "destino"))
     if destino_base.is_symlink():
         raise ValueError("El destino de extracción no puede ser un enlace simbólico")
     destino_base.mkdir(parents=True, exist_ok=True)
@@ -122,9 +124,7 @@ def extraer_zip(origen: PathLike, destino: PathLike) -> list[str]:
 def listar_zip(origen: PathLike) -> list[str]:
     """Devuelve la lista simple de nombres incluidos en ``origen``."""
 
-    origen_zip = _validar_ruta(origen, "origen")
-    if not origen_zip.exists():
-        raise FileNotFoundError(f"El ZIP de origen no existe: {origen_zip}")
+    origen_zip = resolver_ruta_existente(_ruta_relativa_sandbox(origen, "origen"))
 
     with ZipFile(origen_zip, "r") as archivo_zip:
         return archivo_zip.namelist()
@@ -134,11 +134,12 @@ def _normalizar_rutas(
     rutas: PathLike | list[PathLike] | tuple[PathLike, ...],
 ) -> list[Path]:
     if isinstance(rutas, (str, os.PathLike)):
-        return [_validar_ruta(rutas, "rutas")]
+        return [resolver_ruta_existente(_ruta_relativa_sandbox(rutas, "rutas"))]
     if not isinstance(rutas, (list, tuple)):
         raise TypeError("rutas debe ser una ruta o una lista/tupla de rutas")
     return [
-        _validar_ruta(ruta, f"rutas[{indice}]") for indice, ruta in enumerate(rutas)
+        resolver_ruta_existente(_ruta_relativa_sandbox(ruta, f"rutas[{indice}]"))
+        for indice, ruta in enumerate(rutas)
     ]
 
 
@@ -159,12 +160,30 @@ def _texto_ruta(ruta: PathLike, nombre_argumento: str) -> str:
     return texto
 
 
+def _ruta_relativa_sandbox(ruta: PathLike, nombre_argumento: str) -> str:
+    """Adapta rutas absolutas legacy solo cuando ya están dentro del sandbox."""
+
+    texto = _texto_ruta(ruta, nombre_argumento)
+    candidata = Path(texto).expanduser()
+    if not candidata.is_absolute():
+        return texto
+    base = os.environ.get("COBRA_IO_BASE_DIR")
+    if not base:
+        raise ValueError("Las rutas absolutas requieren COBRA_IO_BASE_DIR")
+    try:
+        return str(
+            candidata.resolve(strict=False).relative_to(Path(base).resolve(strict=True))
+        )
+    except ValueError as exc:
+        raise ValueError("La ruta absoluta queda fuera del sandbox") from exc
+
+
 def _resolver_base(rutas: list[Path], base: PathLike | None) -> Path:
     if not rutas:
         raise ValueError("Debe indicarse al menos una ruta para comprimir")
 
     if base is not None:
-        base_resuelta = _validar_ruta(base, "base").resolve()
+        base_resuelta = resolver_ruta_existente(_ruta_relativa_sandbox(base, "base"))
         if not base_resuelta.exists():
             raise FileNotFoundError(f"La base no existe: {base_resuelta}")
         if not base_resuelta.is_dir():

--- a/src/pcobra/corelibs/red.py
+++ b/src/pcobra/corelibs/red.py
@@ -281,7 +281,7 @@ async def descargar_archivo(
     temporal: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
-            mode="w+b", prefix=f".{ruta.name}.", dir=ruta.parent, delete=False
+            mode="w+b", prefix=".pcobra-download-", dir=ruta.parent, delete=False
         ) as archivo:
             temporal = Path(archivo.name)
             await _realizar_peticion_async(
@@ -291,7 +291,7 @@ async def descargar_archivo(
                 archivo_destino=archivo,
             )
         os.replace(temporal, ruta)
-    except Exception:
+    except BaseException:
         if temporal is not None:
             temporal.unlink(missing_ok=True)
         raise

--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -267,6 +267,18 @@ async def ejecutar_stream(
     stderr_chunks: deque[bytes] = deque()
     stderr_tamano = 0
     limite_stderr = 64 * 1024
+    bucle = asyncio.get_running_loop()
+    deadline = None if timeout is None else bucle.time() + timeout
+
+    async def esperar(esperable):
+        if deadline is None:
+            return await esperable
+        restante = deadline - bucle.time()
+        if restante <= 0:
+            if hasattr(esperable, "close"):
+                esperable.close()
+            raise asyncio.TimeoutError
+        return await asyncio.wait_for(esperable, restante)
 
     async def drenar_stdout(cola: asyncio.Queue[bytes | None]) -> None:
         assert proc is not None and proc.stdout is not None
@@ -303,22 +315,21 @@ async def ejecutar_stream(
             # pass_fds hace heredable el fd abierto con O_CLOEXEC solo en el hijo.
             opciones_descriptor = {"pass_fds": (fd,), "close_fds": True}
         try:
-            async with asyncio.timeout(timeout):
-                proc = await asyncio.create_subprocess_exec(
+            proc = await esperar(asyncio.create_subprocess_exec(
                     *args_exec,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     **opciones_descriptor,
-                )
-                cola_stdout: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=1)
-                tareas_lectura = [
-                    asyncio.create_task(drenar_stdout(cola_stdout)),
-                    asyncio.create_task(drenar_stderr()),
-                ]
-                while (chunk := await cola_stdout.get()) is not None:
-                    yield chunk.decode("utf-8", errors="replace")
-                await tareas_lectura[0]
-                await proc.wait()
+            ))
+            cola_stdout: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=1)
+            tareas_lectura = [
+                asyncio.create_task(drenar_stdout(cola_stdout)),
+                asyncio.create_task(drenar_stderr()),
+            ]
+            while (chunk := await esperar(cola_stdout.get())) is not None:
+                yield chunk.decode("utf-8", errors="replace")
+            await esperar(tareas_lectura[0])
+            await esperar(proc.wait())
         except asyncio.TimeoutError as exc:
             timeout_error = exc
     finally:

--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -59,7 +59,7 @@ def _ejecutar_por_ruta_script(
                     PipelineInput(
                         codigo=prelude,
                         interpretador_cls=interpretador_cls,
-                        safe_mode=False, # Fixed: Use explicit False
+                        safe_mode=seguro,
                         extra_validators=None,
                     )
                 )
@@ -68,7 +68,7 @@ def _ejecutar_por_ruta_script(
                 PipelineInput(
                     codigo=codigo,
                     interpretador_cls=interpretador_cls,
-                    safe_mode=False, # Fixed: Use explicit False
+                    safe_mode=seguro,
                     extra_validators=None,
                     interpretador=interpretador,
                 )
@@ -605,12 +605,10 @@ def test_paridad_run_y_repl_usar_archivo_habilita_existe_rutas_relativas() -> No
     )
     variables = ("existe_local", "existe_parent")
 
-    resultado_script = _ejecutar_por_ruta_script(codigo, variables, seguro=True)
-    resultado_repl = _ejecutar_por_ruta_repl(codigo, variables, seguro=True)
-
-    assert resultado_script["stderr"] == resultado_repl["stderr"] == ""
-    assert resultado_script["estado"] == resultado_repl["estado"]
-    assert resultado_script["estado"]["existe_local"] is True
+    with pytest.raises(PermissionError, match="filesystem.read"):
+        _ejecutar_por_ruta_script(codigo, variables, seguro=True)
+    with pytest.raises(PermissionError, match="filesystem.read"):
+        _ejecutar_por_ruta_repl(codigo, variables, seguro=True)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -218,11 +218,11 @@ def test_repl_entrypoint_texto_conserva_interprete_e_imprime_cuatro(capsys, monk
 def test_repl_entrypoint_archivo_existe_booleano_sin_error_metadata(capsys):
     cmd = ReplCommandV2()
     cmd._ejecutar_en_modo_normal('usar "archivo"')
-    cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
+    with pytest.raises(PermissionError, match="filesystem.read"):
+        cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
 
     salida = capsys.readouterr().out
     assert "Error: metadata" not in salida
-    assert any(token in salida for token in ("verdadero", "falso"))
 
 
 def test_repl_entrypoint_usar_archivo_sin_comillas_falla_por_sintaxis():

--- a/tests/unit/test_dynamic_module_loader_rollback.py
+++ b/tests/unit/test_dynamic_module_loader_rollback.py
@@ -45,8 +45,34 @@ def test_reintento_tras_fallo_carga_el_modulo_correctamente(tmp_path):
     modulo = usar_loader._cargar_modulo_local_desde_directorio(nombre, tmp_path)
 
     assert modulo.resultado == 42
-    assert sys.modules[nombre] is modulo
-    sys.modules.pop(nombre, None)
+    assert nombre not in sys.modules
+
+
+def test_pybind_restaura_entrada_previa_tras_carga_exitosa(tmp_path, monkeypatch):
+    ruta = tmp_path / "extension.so"
+    ruta.touch()
+    previo = ModuleType("extension_previa")
+
+    class LoaderExitoso:
+        name = "extension"
+
+        def __init__(self, nombre, path):
+            self.name = nombre
+
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            module.resultado = 42
+
+    monkeypatch.setattr(pybind_bridge, "_ALLOWED_PREFIXES", [str(tmp_path)])
+    monkeypatch.setattr(pybind_bridge.importlib.machinery, "ExtensionFileLoader", LoaderExitoso)
+    monkeypatch.setitem(sys.modules, "extension", previo)
+
+    cargado = pybind_bridge.cargar_extension(str(ruta))
+
+    assert cargado.resultado == 42
+    assert sys.modules["extension"] is previo
 
 
 def test_paquete_con_init_fallido_no_permanece_en_sys_modules(tmp_path):

--- a/tests/unit/test_execute_cmd_extra_validators_normalization.py
+++ b/tests/unit/test_execute_cmd_extra_validators_normalization.py
@@ -30,9 +30,11 @@ def test_ejecutar_normal_carga_validadores_desde_una_ruta(monkeypatch):
     cargado = [DummyValidator()]
 
     class DummyInterp:
-        def __init__(self, safe_mode=True, extra_validators=None):
+        def __init__(self, safe_mode=True, extra_validators=None, main_file=None):
             self.safe_mode = safe_mode
             self.extra_validators = extra_validators
+            self._usar_symbol_metadata = {}
+            self._validador = SimpleNamespace(_metadata_simbolos_usar={})
 
         def ejecutar_ast(self, _ast):
             return None
@@ -62,8 +64,10 @@ def test_ejecutar_normal_carga_y_acumula_multiples_rutas(monkeypatch):
     class DummyInterp:
         init_extra = None
 
-        def __init__(self, safe_mode=True, extra_validators=None):
+        def __init__(self, safe_mode=True, extra_validators=None, main_file=None):
             DummyInterp.init_extra = extra_validators
+            self._usar_symbol_metadata = {}
+            self._validador = SimpleNamespace(_metadata_simbolos_usar={})
 
         def ejecutar_ast(self, _ast):
             return None
@@ -91,8 +95,10 @@ def test_ejecutar_normal_acepta_lista_vacia_y_none(monkeypatch):
     class DummyInterp:
         llamadas = []
 
-        def __init__(self, safe_mode=True, extra_validators=None):
+        def __init__(self, safe_mode=True, extra_validators=None, main_file=None):
             DummyInterp.llamadas.append(extra_validators)
+            self._usar_symbol_metadata = {}
+            self._validador = SimpleNamespace(_metadata_simbolos_usar={})
 
         def ejecutar_ast(self, _ast):
             return None
@@ -118,9 +124,11 @@ def test_ejecutar_normal_muestra_error_claro_si_falla_una_ruta(monkeypatch):
     errores = []
 
     class DummyInterp:
-        def __init__(self, safe_mode=True, extra_validators=None):
+        def __init__(self, safe_mode=True, extra_validators=None, main_file=None):
             self.safe_mode = safe_mode
             self.extra_validators = extra_validators
+            self._usar_symbol_metadata = {}
+            self._validador = SimpleNamespace(_metadata_simbolos_usar={})
 
         def ejecutar_ast(self, _ast):
             return None

--- a/tests/unit/test_remediacion_runtime_contracts.py
+++ b/tests/unit/test_remediacion_runtime_contracts.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.machinery
+import sys
+from types import ModuleType
+
+import pytest
+
+from pcobra.cobra.usar_capabilities import capacidades_de
+from pcobra.cobra.usar_loader import usar_modulo
+from pcobra.cobra.usar_policy import CANONICAL_MODULE_SURFACE_CONTRACTS
+from pcobra.corelibs import compresion, red, sistema
+from pcobra.core.ast_nodes import NodoUsar
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+
+
+@pytest.mark.parametrize(
+    "modulo,nombre",
+    [
+        (modulo, nombre)
+        for modulo, contrato in CANONICAL_MODULE_SURFACE_CONTRACTS.items()
+        for nombre, capacidades in contrato.symbol_capabilities.items()
+        if capacidades
+        & {
+            "process.spawn",
+            "process.shell",
+            "network.get",
+            "network.post",
+            "network.download",
+            "filesystem.read",
+            "filesystem.write",
+        }
+    ],
+)
+def test_todo_simbolo_effectful_usa_la_clasificacion_canonica_y_se_bloquea(modulo, nombre):
+    esperadas = CANONICAL_MODULE_SURFACE_CONTRACTS[modulo].symbol_capabilities[nombre]
+    assert esperadas
+    assert {capacidad.value for capacidad in capacidades_de(modulo, nombre)} == esperadas
+    simbolo = usar_modulo(modulo, safe_mode=True)[nombre]
+    if callable(simbolo):
+        try:
+            resultado = simbolo()
+        except PermissionError:
+            return
+        if hasattr(resultado, "__anext__"):
+            with pytest.raises(PermissionError):
+                asyncio.run(resultado.__anext__())
+        elif hasattr(resultado, "__await__"):
+            with pytest.raises(PermissionError):
+                asyncio.run(resultado)
+        else:
+            pytest.fail("un símbolo effectful invocable alcanzó el runtime en safe_mode")
+
+
+@pytest.mark.parametrize(
+    "nombre", ("ejecutar_async", "ejecutar_stream", "ejecutar_comando_async")
+)
+def test_sistema_safe_mode_bloquea_allowlist_del_caller(nombre):
+    funcion = usar_modulo("sistema", safe_mode=True)[nombre]
+    with pytest.raises(PermissionError, match="process.spawn"):
+        resultado = funcion([sys.executable], permitidos=[sys.executable])
+        if hasattr(resultado, "close"):
+            resultado.close()
+
+
+def test_modulo_oficial_preinyectado_sin_procedencia_es_rechazado(monkeypatch):
+    falso = ModuleType("pcobra.corelibs.numero")
+    falso.__spec__ = importlib.machinery.ModuleSpec(falso.__name__, loader=None)
+    monkeypatch.setitem(sys.modules, falso.__name__, falso)
+
+    with pytest.raises(PermissionError, match="procedencia_no_oficial"):
+        usar_modulo("numero")
+
+
+@pytest.mark.parametrize("modulo", ("red", "proceso"))
+def test_transpilador_python_propaga_safe_mode_explicito(modulo):
+    inseguro = TranspiladorPython(safe_mode=False).generate_code([NodoUsar(modulo)])
+    seguro = TranspiladorPython(safe_mode=True).generate_code([NodoUsar(modulo)])
+
+    assert f"usar_modulo('{modulo}', safe_mode=False)" in inseguro
+    assert f"usar_modulo('{modulo}', safe_mode=True)" in seguro
+
+
+def test_zip_crear_listar_extraer_comparte_sandbox(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    (tmp_path / "entrada.txt").write_text("contenido", encoding="utf-8")
+
+    assert compresion.crear_zip("a.zip", "entrada.txt") == ["entrada.txt"]
+    assert compresion.listar_zip("a.zip") == ["entrada.txt"]
+    compresion.extraer_zip("a.zip", "salida")
+
+    assert (tmp_path / "salida" / "entrada.txt").read_text(encoding="utf-8") == "contenido"
+
+
+@pytest.mark.asyncio
+async def test_descarga_cancelada_limpia_temporal_y_preserva_destino(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    destino = tmp_path / "destino.bin"
+    destino.write_bytes(b"previo")
+
+    async def cancelar(*args, archivo_destino, **kwargs):
+        archivo_destino.write(b"parcial")
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(red, "_realizar_peticion_async", cancelar)
+    with pytest.raises(asyncio.CancelledError):
+        await red.descargar_archivo("https://example.com", "destino.bin")
+
+    assert destino.read_bytes() == b"previo"
+    assert list(tmp_path.glob(".pcobra-download-*")) == []
+
+
+@pytest.mark.asyncio
+async def test_timeout_stream_no_cancela_await_del_consumidor():
+    generador = sistema.ejecutar_stream(
+        [sys.executable, "-c", "print('primera', flush=True)"],
+        permitidos=[sys.executable],
+        timeout=0.1,
+    )
+
+    assert await generador.__anext__() == "primera\n"
+    await asyncio.sleep(0.2)
+    await generador.aclose()

--- a/tests/unit/test_to_python_extras.py
+++ b/tests/unit/test_to_python_extras.py
@@ -43,7 +43,7 @@ def test_transpilar_usar():
     esperado = (
         IMPORTS
         + "from pcobra.cobra.usar_loader import usar_modulo\n"
-        + "_usar_exports = usar_modulo('math')\n"
+        + "_usar_exports = usar_modulo('math', safe_mode=False)\n"
         + "globals().update(dict(_usar_exports.get('simbolos', [])))\n"
     )
     assert codigo == esperado

--- a/tests/unit/test_usar_policy_contract.py
+++ b/tests/unit/test_usar_policy_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import importlib
 
 import pytest
 
@@ -27,11 +28,16 @@ def test_modulos_oficiales_se_resuelven_como_paquetes_instalables() -> None:
     for alias, canonical in REPL_COBRA_MODULE_MAP.items():
         modulo = obtener_modulo_cobra_oficial(canonical)
         expected_package = REPL_COBRA_MODULE_PACKAGE_MAP[alias]
-        assert REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias] == expected_package
+        legacy_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias]
+        assert legacy_path != expected_package
+        assert (Path(__file__).resolve().parents[2] / legacy_path).is_file()
+        assert importlib.util.find_spec(expected_package) is not None
         assert modulo.__name__ == expected_package
         assert expected_package.startswith(
             ("pcobra.corelibs.", "pcobra.standard_library.")
         )
+
+    assert REPL_COBRA_MODULE_INTERNAL_PATH_MAP is not REPL_COBRA_MODULE_PACKAGE_MAP
 
 
 def test_contrato_superficie_publica_cubre_modulos_canonicos() -> None:


### PR DESCRIPTION
### Motivation
- Unificar la única fuente de verdad para las capacidades expuestas por `usar` y cerrar bypasses que permitían efectos en `safe_mode=True`.
- Preservar compatibilidad legacy de mapas de módulos pero mantener separados PACKAGE_MAP y PATH_MAP para evitar ambigüedad operacional.
- Asegurar procedencia de módulos oficiales, propagar explícitamente `safe_mode` en el transpiler Python y robustecer sandbox/IO y pipeline de validadores.
- Añadir pruebas regresivas que cubran símbolos effectful, cancelación de descargas y paridad Interpreter↔Transpiler sin tocar Lexer/Parser/gramática/tokenización.

### Description
- Reemplaza la tabla local de capacidades por una consulta directa a `CANONICAL_MODULE_SURFACE_CONTRACTS[*].symbol_capabilities` para que `capacidades_de()` sea la fuente canónica y evite divergencias entre catálogo y enforcement.
- Modifica `_aplicar_capacidades()` para aplicar únicamente las capacidades sensibles (process, network, filesystem) y construir wrappers que hagan el `PermissionError` correcto en `safe_mode=True` (incluye `process.shell`).
- Mantiene `REPL_COBRA_MODULE_PACKAGE_MAP` (nombres importables) y restaura `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` como un diccionario legacy separado con rutas históricas de checkout; actualiza validaciones y tests contractuales en consecuencia.
- Añade verificación de procedencia en `obtener_modulo_cobra_oficial()` usando `module.__spec__.origin` y las rutas reales del paquete `pcobra` instalado; reprobará módulos preinyectados en `sys.modules` sin procedencia oficial.
- Transpilador Python ahora recibe y propaga explícitamente `safe_mode` y genera llamadas `usar_modulo(..., safe_mode=...)` para conservar semántica entre Interpreter y código transpilado.
- Robustecimientos runtime/I/O: inicialización de sandbox con lock, rechazo de leaf symlink, coherencia entre crear/listar/extraer ZIP, temporales seguros y limpieza en `red.descargar_archivo` ante `CancelledError`, y `ejecutar_stream` que acota timeouts sin cancelar al consumidor después de un `yield`.
- Pipeline de validadores y worker: normalización para aceptar solo descriptores preautorizados (instancias `ValidadorBase`) y worker que ajusta RLIMIT_CPU según CPU ya usada más auditoría estructurada (timeout, CPU, memoria, sintaxis, excepciones), además de restaurar entradas previas en `sys.modules` en fallo y tras carga exitosa.
- Añadidas pruebas unitarias/integración focales que cubren la matriz de capacidades, paridad transpiler/interpreter, sandbox ZIP end-to-end, cancelación de descargas y streaming timeout determinista.

### Testing
- Ejecuté las baterías focales y contractuales relevantes (grupos A–D y pruebas añadidas): las pruebas unitarias focales añadidas pasan en local (tests unitarios relacionados con `usar`/capacidades, sandbox, compresión y runtime async), concretamente las suites focales mostraron ejecuciones verdes (188 unit tests verdes en la fase focal de validación).
- Suite completa `pytest -q` fue ejecutada y reveló fallos residuales (10 tests fallidos en la ejecución completa): las causas principales son expectativas legacy que permiten efectos de filesystem/clock en `safe_mode=True` y la identidad duplicada de módulos AST cuando se importan superficies legacy; los fallos no se etiquetaron como preexistentes y requieren decisión de alto nivel sobre compatibilidad legacy antes de seguir.
- Construcción de wheel y smoke test de instalación: `python -m build --wheel`, creación de entorno virtual e instalación del wheel resultante se realizaron correctamente y el smoke test validó `import pcobra`, creación de `InterpretadorCobra`, `usar_modulo('numero', safe_mode=False)` y que el módulo proviene de `site-packages` (wheel) en vez del checkout.
- Lint/compile/diff checks: `git diff --check`, `python -m compileall src` y `python -m ruff check` sobre los archivos modificados pasaron sin incidencias.


Notas finales: los cambios son mínimos y dirigidos a los bloques de seguridad/compatibilidad solicitados; no se modificaron Lexer/Parser/gramática/tokens/constant_folder. Queda pendiente resolver la política de compatibilidad legacy para `existe`/I/O en `safe_mode` y la duplicación de identidad AST para completar al 100% los criterios de aceptación antes de abrir la PR pública.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a771ffd6e688327bf1889058e718b32)