### PR TITLE
fix(security): restore safe transpiler default, allow confined filesystem, preserve AST legacy identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 include = [
     "pcobra*",
+    "core*",
 ]
 exclude = [
     "*.tests",

--- a/src/pcobra/cobra/transpilers/transpiler/to_python.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_python.py
@@ -245,7 +245,7 @@ def visit_diccionario_comprehension(self, nodo):
 
 
 class TranspiladorPython(BaseTranspiler):
-    def __init__(self, *, source_file=None, project_root=None, safe_mode=False):
+    def __init__(self, *, source_file=None, project_root=None, safe_mode=True):
         # Incluir los modulos nativos al inicio del codigo generado
         self.codigo = ""
         self.usa_asyncio = False

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -135,8 +135,6 @@ def _aplicar_capacidades(
             CapacidadUsar.NETWORK_GET,
             CapacidadUsar.NETWORK_POST,
             CapacidadUsar.NETWORK_DOWNLOAD,
-            CapacidadUsar.FILESYSTEM_READ,
-            CapacidadUsar.FILESYSTEM_WRITE,
         }
     )
     resultado: list[tuple[str, Any]] = []

--- a/src/pcobra/core/__init__.py
+++ b/src/pcobra/core/__init__.py
@@ -11,15 +11,11 @@ de implementaciones manuales.
 
 from __future__ import annotations
 
-import sys
-
 from .ast_nodes import *
 from .ast_nodes import NodoListaComprehension, NodoDiccionarioComprehension, NodoEnum
 from .visitor import NodeVisitor
 from .performance import optimizar, perfilar
 from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
-
-sys.modules["core"] = sys.modules[__name__]
 
 __all__ = [
     "NodoAST",

--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -605,10 +605,12 @@ def test_paridad_run_y_repl_usar_archivo_habilita_existe_rutas_relativas() -> No
     )
     variables = ("existe_local", "existe_parent")
 
-    with pytest.raises(PermissionError, match="filesystem.read"):
-        _ejecutar_por_ruta_script(codigo, variables, seguro=True)
-    with pytest.raises(PermissionError, match="filesystem.read"):
-        _ejecutar_por_ruta_repl(codigo, variables, seguro=True)
+    resultado_script = _ejecutar_por_ruta_script(codigo, variables, seguro=True)
+    resultado_repl = _ejecutar_por_ruta_repl(codigo, variables, seguro=True)
+
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == ""
+    assert resultado_script["estado"] == resultado_repl["estado"]
+    assert resultado_script["estado"]["existe_local"] is True
 
 
 @pytest.mark.integration

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -218,11 +218,11 @@ def test_repl_entrypoint_texto_conserva_interprete_e_imprime_cuatro(capsys, monk
 def test_repl_entrypoint_archivo_existe_booleano_sin_error_metadata(capsys):
     cmd = ReplCommandV2()
     cmd._ejecutar_en_modo_normal('usar "archivo"')
-    with pytest.raises(PermissionError, match="filesystem.read"):
-        cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
+    cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
 
     salida = capsys.readouterr().out
     assert "Error: metadata" not in salida
+    assert any(token in salida for token in ("verdadero", "falso"))
 
 
 def test_repl_entrypoint_usar_archivo_sin_comillas_falla_por_sintaxis():
@@ -834,6 +834,7 @@ def test_holobit_corelib_exporta_solo_simbolos_canonicos_publicos():
 
 @pytest.mark.parametrize("modulo", sorted(REPL_COBRA_MODULE_MAP.keys()))
 def test_repl_contract_pipeline_completo_por_modulo_canonico(monkeypatch, tmp_path, modulo):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     mod = ModuleType(modulo)
     expected_symbols = []
 
@@ -1024,29 +1025,39 @@ def test_repl_contract_pipeline_completo_por_modulo_canonico(monkeypatch, tmp_pa
         elif modulo == "texto" and symbol == "quitar_acentos":
             interp.contextos[-1].values[symbol]("canción")
         elif modulo == "sistema" and symbol == "ejecutar":
-            interp.contextos[-1].values[symbol](["cobra"], permitidos=[r"C:\\cobra\\mock.exe"])
+            with pytest.raises(PermissionError, match="process.spawn"):
+                interp.contextos[-1].values[symbol](["cobra"], permitidos=[r"C:\\cobra\\mock.exe"])
         elif modulo == "sistema" and symbol == "ejecutar_async":
-            interp.contextos[-1].values[symbol](["cobra"], permitidos=[r"C:\\cobra\\mock.exe"])
+            with pytest.raises(PermissionError, match="process.spawn"):
+                interp.contextos[-1].values[symbol](["cobra"], permitidos=[r"C:\\cobra\\mock.exe"])
         elif modulo == "sistema" and symbol == "ejecutar_stream":
-            interp.contextos[-1].values[symbol](["cobra"], permitidos=[r"C:\\cobra\\mock.exe"])
+            with pytest.raises(PermissionError, match="process.spawn"):
+                interp.contextos[-1].values[symbol](["cobra"], permitidos=[r"C:\\cobra\\mock.exe"])
         elif modulo == "sistema" and symbol == "obtener_env":
             interp.contextos[-1].values[symbol]("PATH")
         elif modulo == "sistema" and symbol == "listar_dir":
             interp.contextos[-1].values[symbol](".")
         elif modulo == "red" and symbol == "obtener_url":
-            interp.contextos[-1].values[symbol]("https://example.com")
+            with pytest.raises(PermissionError, match="network.get"):
+                interp.contextos[-1].values[symbol]("https://example.com")
         elif modulo == "red" and symbol == "enviar_post":
-            interp.contextos[-1].values[symbol]("https://example.com", {})
+            with pytest.raises(PermissionError, match="network.post"):
+                interp.contextos[-1].values[symbol]("https://example.com", {})
         elif modulo == "red" and symbol == "obtener_url_async":
-            interp.contextos[-1].values[symbol]("http://example.com")
+            with pytest.raises(PermissionError, match="network.get"):
+                interp.contextos[-1].values[symbol]("https://example.com")
         elif modulo == "red" and symbol == "enviar_post_async":
-            interp.contextos[-1].values[symbol]("http://example.com", {})
+            with pytest.raises(PermissionError, match="network.post"):
+                interp.contextos[-1].values[symbol]("https://example.com", {})
         elif modulo == "red" and symbol == "descargar_archivo":
-            interp.contextos[-1].values[symbol]("http://example.com", "dummy_path")
+            with pytest.raises(PermissionError, match="network.download"):
+                interp.contextos[-1].values[symbol]("https://example.com", "dummy_path")
         elif modulo == "red" and symbol == "obtener_url_texto":
-            interp.contextos[-1].values[symbol]("http://example.com")
+            with pytest.raises(PermissionError, match="network.get"):
+                interp.contextos[-1].values[symbol]("https://example.com")
         elif modulo == "red" and symbol == "obtener_json":
-            interp.contextos[-1].values[symbol]("http://example.com")
+            with pytest.raises(PermissionError, match="network.get"):
+                interp.contextos[-1].values[symbol]("https://example.com")
         elif modulo == "asincrono" and symbol == "proteger_tarea":
             interp.contextos[-1].values[symbol](asyncio.Future())
         elif modulo == "asincrono" and symbol == "limitar_tiempo":

--- a/tests/unit/test_ast_canonical_import_identity.py
+++ b/tests/unit/test_ast_canonical_import_identity.py
@@ -75,6 +75,37 @@ for canonical_name, module in modules.items():
     assert result.returncode == 0, result.stderr
 
 
+def test_import_legacy_ast_reutiliza_identidad_canonica_en_ambos_ordenes() -> None:
+    clases = ("NodoAST", "NodoValor", "NodoAsignacion", "NodoFuncion", "NodoUsar")
+    ordenes = (
+        ("pcobra.core.ast_nodes", "core.ast_nodes"),
+        ("core.ast_nodes", "pcobra.core.ast_nodes"),
+    )
+
+    for primero, segundo in ordenes:
+        script = f"""
+import importlib
+
+primero = importlib.import_module({primero!r})
+segundo = importlib.import_module({segundo!r})
+canonical = importlib.import_module('pcobra.core.ast_nodes')
+legacy = importlib.import_module('core.ast_nodes')
+
+assert canonical is legacy, (canonical, legacy)
+for nombre in {clases!r}:
+    assert getattr(canonical, nombre) is getattr(legacy, nombre), nombre
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+
 def test_pruebas_nuevas_no_importan_superficies_legacy() -> None:
     violations: list[str] = []
 

--- a/tests/unit/test_remediacion_runtime_contracts.py
+++ b/tests/unit/test_remediacion_runtime_contracts.py
@@ -28,12 +28,10 @@ from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
             "network.get",
             "network.post",
             "network.download",
-            "filesystem.read",
-            "filesystem.write",
         }
     ],
 )
-def test_todo_simbolo_effectful_usa_la_clasificacion_canonica_y_se_bloquea(modulo, nombre):
+def test_simbolos_restringidos_usan_clasificacion_canonica_y_se_bloquean(modulo, nombre):
     esperadas = CANONICAL_MODULE_SURFACE_CONTRACTS[modulo].symbol_capabilities[nombre]
     assert esperadas
     assert {capacidad.value for capacidad in capacidades_de(modulo, nombre)} == esperadas
@@ -51,6 +49,22 @@ def test_todo_simbolo_effectful_usa_la_clasificacion_canonica_y_se_bloquea(modul
                 asyncio.run(resultado)
         else:
             pytest.fail("un símbolo effectful invocable alcanzó el runtime en safe_mode")
+
+
+@pytest.mark.parametrize(
+    "modulo,nombre",
+    [
+        (modulo, nombre)
+        for modulo, contrato in CANONICAL_MODULE_SURFACE_CONTRACTS.items()
+        for nombre, capacidades in contrato.symbol_capabilities.items()
+        if capacidades & {"filesystem.read", "filesystem.write"}
+    ],
+)
+def test_simbolos_filesystem_conservan_clasificacion_canonica(modulo, nombre):
+    esperadas = CANONICAL_MODULE_SURFACE_CONTRACTS[modulo].symbol_capabilities[nombre]
+
+    assert esperadas
+    assert {capacidad.value for capacidad in capacidades_de(modulo, nombre)} == esperadas
 
 
 @pytest.mark.parametrize(
@@ -73,11 +87,13 @@ def test_modulo_oficial_preinyectado_sin_procedencia_es_rechazado(monkeypatch):
         usar_modulo("numero")
 
 
-@pytest.mark.parametrize("modulo", ("red", "proceso"))
+@pytest.mark.parametrize("modulo", ("red", "proceso", "numero"))
 def test_transpilador_python_propaga_safe_mode_explicito(modulo):
+    predeterminado = TranspiladorPython().generate_code([NodoUsar(modulo)])
     inseguro = TranspiladorPython(safe_mode=False).generate_code([NodoUsar(modulo)])
     seguro = TranspiladorPython(safe_mode=True).generate_code([NodoUsar(modulo)])
 
+    assert f"usar_modulo('{modulo}', safe_mode=True)" in predeterminado
     assert f"usar_modulo('{modulo}', safe_mode=False)" in inseguro
     assert f"usar_modulo('{modulo}', safe_mode=True)" in seguro
 

--- a/tests/unit/test_to_python_extras.py
+++ b/tests/unit/test_to_python_extras.py
@@ -16,7 +16,7 @@ IMPORTS = get_standard_imports("python")
 
 def test_transpilar_try_catch_throw():
     nodo = NodoTryCatch(
-        [NodoThrow(NodoValor("1"))],
+        [NodoThrow(NodoValor(1))],
         "e",
         [NodoImprimir(NodoIdentificador("e"))],
     )
@@ -43,7 +43,7 @@ def test_transpilar_usar():
     esperado = (
         IMPORTS
         + "from pcobra.cobra.usar_loader import usar_modulo\n"
-        + "_usar_exports = usar_modulo('math', safe_mode=False)\n"
+        + "_usar_exports = usar_modulo('math', safe_mode=True)\n"
         + "globals().update(dict(_usar_exports.get('simbolos', [])))\n"
     )
     assert codigo == esperado


### PR DESCRIPTION
### Motivation

- Restaurar contratos de seguridad introducidos por la PR #3430: `TranspiladorPython()` debe ser seguro por defecto y `filesystem` no debe bloquear operaciones confinadas.
- Separar clasificación de efectos (`filesystem.read|write`) de la autorización efectiva y mantener el bloqueo estricto para `process` y `network` en `safe_mode`.
- Resolver la doble carga del AST cuando se importan rutas legacy (`core.ast_nodes`) y asegurar identidad canónica determinista.

### Description

- Restaura el valor por defecto seguro en `TranspiladorPython` cambiando `safe_mode=False` a `safe_mode=True` en `src/pcobra/cobra/transpilers/transpiler/to_python.py` y añade/ajusta pruebas para verificar paridad (`tests/unit/test_remediacion_runtime_contracts.py`).
- Quita `filesystem.read|write` del conjunto global de capacidades denegadas en `src/pcobra/cobra/usar_loader.py`, de modo que la autorización real la resuelvan las corelibs/sandbox; `process` y `network` permanecen restringidos.
- Evita alias prematuro que provocaba doble carga del AST eliminando `sys.modules['core'] = ...` en `src/pcobra/core/__init__.py` y añade prueba en subprocess limpio que verifica identidad canónica entre `pcobra.core.ast_nodes` y `core.ast_nodes` (`tests/unit/test_ast_canonical_import_identity.py`).
- Restaura y refuerza tests afectados por la regresión (paridad REPL/script, uso de `archivo.existe`, expectativas `safe_mode`) en: `tests/cli/test_repl_script_parity_contract.py`, `tests/integration/test_repl_usar_entrypoints_contract.py`, `tests/unit/test_to_python_extras.py` y crea/ajusta `tests/unit/test_remediacion_runtime_contracts.py` para separar efectos filesystem de autorización.

### Testing

- Ejecuté pruebas focales y de integración relacionadas con los cambios; highlights: `tests/unit/test_remediacion_runtime_contracts.py` (casos de `TranspiladorPython` y capabilities) y la batería de I/O sandbox y REPL; las validaciones focales dieron `93 passed` (filesystem/ZIP/REPL focal) y tests de identidad AST `12 passed, 1 warning`.
- Suite completa: `python -m pytest -q` devolvió `5 failed, 548 passed, 8 skipped, 5 warnings` (detenida por `--maxfail=5`); los 5 fallos pertenecen a `tests/integration/test_run_repl_equivalence.py` y no son regresiones introducidas por estos cambios (contaminación de aliases CLI / contratos históricos), por lo que no se modificaron aquí.
- Comprobaciones estáticas: `git diff --check` OK, `python -m compileall src` OK, `ruff` OK on modified files; `mypy` se ejecutó pero el repo presenta numerosos errores preexistentes (informado en salida).
- Wheel / smoke: `python -m build --wheel` generó `pcobra-*.whl`; instalé el wheel en un venv y se verificaron puntos claves: `import pcobra`, `TranspiladorPython()` produce default seguro, `usar_modulo('numero', safe_mode=True)` y `usar_modulo('archivo', safe_mode=True)` con IO confinado, e identidad canónica del AST en el entorno instalado (smoke ok, tras instalar dependencias de prueba en el venv).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77416584608327b147dd6a90ceb87e)