### PR TITLE
fix(packaging): exclude legacy `core` namespace from wheel and document shim in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ package-dir = {"" = "src"}
 where = ["src"]
 include = [
     "pcobra*",
-    "core*",
 ]
 exclude = [
     "*.tests",

--- a/tests/unit/test_cli_startup_import_contract.py
+++ b/tests/unit/test_cli_startup_import_contract.py
@@ -99,6 +99,27 @@ def test_distribucion_publica_no_expone_namespaces_legacy() -> None:
     assert "bindings*" not in include
 
 
+def test_checkout_conserva_core_como_shim_legacy_solo_en_arbol_fuente(
+    tmp_path: Path,
+) -> None:
+    shim_path = Path("src/core/__init__.py")
+
+    assert shim_path.is_file()
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path("src").resolve())
+    completed = subprocess.run(
+        [sys.executable, "-c", "import core; print(core.__file__)"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert Path(completed.stdout.strip()).resolve() == shim_path.resolve()
+
+
 def test_script_entrypoint_cobra_se_mantiene_en_pcobra_cli_main() -> None:
     pyproject_path = Path("pyproject.toml")
     data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
### Motivation

- Evitar que el wheel distribuido incluya los namespaces legacy `core` o `cobra` y reforzar que el contrato público de distribución es `pcobra` bajo `src/pcobra`.
- Mantener el shim histórico `src/core/__init__.py` en el checkout como compatibilidad local sin convertirlo en contrato de distribución.

### Description

- Retiré únicamente `"core*"` de `tool.setuptools.packages.find.include` en `pyproject.toml`, dejando `"pcobra*"` como único patrón incluido en la distribución.
- Conservo intacto el archivo `src/core/__init__.py` como shim histórico para compatibilidad en el árbol fuente y no lo publico en el wheel.
- Añadí la prueba `test_checkout_conserva_core_como_shim_legacy_solo_en_arbol_fuente` en `tests/unit/test_cli_startup_import_contract.py` que verifica la presencia del shim en el checkout y que su importación resuelve desde `src` cuando `PYTHONPATH` apunta al checkout.

### Testing

- Ejecuté `pytest -q tests/unit/test_cli_startup_import_contract.py` y todas las pruebas del archivo pasaron (`5 passed`).
- Construí un wheel con `python -m build --wheel --outdir <dir>` (instalé la herramienta `build` cuando fue necesario) y verifiqué por inspección ZIP que no hay entradas con prefijos top-level `core/` ni `cobra/` en el wheel.
- Instalé el wheel en un entorno virtual aislado y comprobé que `import pcobra` funciona mientras que `import core` falla con `ModuleNotFoundError` fuera del checkout.
- Verifiqué explícitamente que no se modificaron archivos de Lexer/Parser antes de finalizar la PR y que no hubo errores en `git diff --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7761c0fd488327bceff2d0375be436)