### PR TITLE
tests: aislar contrato de importación AST del checkout y smoke del wheel

### DIFF
--- a/tests/cli/test_packaging_smoke.py
+++ b/tests/cli/test_packaging_smoke.py
@@ -57,11 +57,21 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
         text=True,
     )
 
+    isolated_cwd = tmp_path / "wheel-smoke-cwd"
+    isolated_cwd.mkdir()
     smoke_script = (
-        "import pathlib, sys\n"
+        "import importlib, importlib.util, os, pathlib, sys\n"
         f"checkout = pathlib.Path({str(REPO_ROOT)!r}).resolve()\n"
+        "cwd = pathlib.Path.cwd().resolve()\n"
+        "assert cwd != checkout and checkout not in cwd.parents, cwd\n"
+        "assert 'PYTHONPATH' not in os.environ, os.environ.get('PYTHONPATH')\n"
         "if any(pathlib.Path(p or '.').resolve() == checkout for p in sys.path):\n"
         "    raise SystemExit('el checkout está presente en sys.path')\n"
+        "if any(pathlib.Path(p or '.').resolve().name == 'src' for p in sys.path):\n"
+        "    raise SystemExit(f'una carpeta src está presente en sys.path: {sys.path!r}')\n"
+        "ast_nodes = importlib.import_module('pcobra.core.ast_nodes')\n"
+        "assert ast_nodes.NodoAST.__module__ == 'pcobra.core.ast_nodes'\n"
+        "assert importlib.util.find_spec('core') is None, 'el wheel instaló el namespace top-level core'\n"
         "consultas_src = []\n"
         "def auditar(evento, args):\n"
         "    if evento == 'open' and args and isinstance(args[0], (str, bytes)):\n"
@@ -92,7 +102,8 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
         check=False,
         capture_output=True,
         text=True,
-        cwd=tmp_path,
+        cwd=isolated_cwd,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
     )
 
     assert run_help.returncode == 0, (

--- a/tests/unit/test_ast_canonical_import_identity.py
+++ b/tests/unit/test_ast_canonical_import_identity.py
@@ -75,7 +75,9 @@ for canonical_name, module in modules.items():
     assert result.returncode == 0, result.stderr
 
 
-def test_import_legacy_ast_reutiliza_identidad_canonica_en_ambos_ordenes() -> None:
+def test_contrato_checkout_shim_ast_reutiliza_identidad_canonica_en_ambos_ordenes() -> None:
+    """El shim del source tree conserva la identidad AST en ambos órdenes."""
+
     clases = ("NodoAST", "NodoValor", "NodoAsignacion", "NodoFuncion", "NodoUsar")
     ordenes = (
         ("pcobra.core.ast_nodes", "core.ast_nodes"),
@@ -85,6 +87,10 @@ def test_import_legacy_ast_reutiliza_identidad_canonica_en_ambos_ordenes() -> No
     for primero, segundo in ordenes:
         script = f"""
 import importlib
+import importlib.util
+
+if importlib.util.find_spec('core') is None:
+    raise SystemExit('el shim histórico core no está disponible en este checkout')
 
 primero = importlib.import_module({primero!r})
 segundo = importlib.import_module({segundo!r})


### PR DESCRIPTION
### Motivation

- Formalizar la prueba que verifica que el shim histórico del checkout preserva la identidad canónica de las clases AST como un contrato explícito del source tree.
- Evitar falsos positivos en el smoke del wheel debidos a la presencia del checkout o de `src` en `PYTHONPATH` al instalar y ejecutar el wheel en un entorno aislado.

### Description

- Renombré y documenté la prueba de identidad AST en `tests/unit/test_ast_canonical_import_identity.py` para exponerla como contrato del checkout y añadí una comprobación previa que falla si el shim `core` no está disponible en el checkout.
- Modifiqué `tests/cli/test_packaging_smoke.py` para ejecutar el smoke desde un directorio de trabajo aislado, eliminar `PYTHONPATH` del entorno del subprocess y rechazar cualquier entrada `src` en `sys.path` antes de importar desde el wheel.
- En el smoke añadí la importación normal de `pcobra.core.ast_nodes` y la verificación de que su `__module__` es `pcobra.core.ast_nodes` y que no existe el namespace top-level `core` instalado por el wheel.
- No se realizaron cambios en `src/pcobra/core/ast_nodes.py`, en el Lexer ni en el Parser, ni se añadieron aliases ni duplicados de clases.

### Testing

- Ejecuté `python -m pytest tests/unit/test_ast_canonical_import_identity.py -q` y las pruebas dirigidas pasaron: 4 passed.
- Ejecuté el smoke del wheel con `python -m pytest tests/cli/test_packaging_smoke.py -m integration -q` usando un `venv` limpio y `build` instalado, y el test de packaging aislado pasó: 1 passed (duración ~92s in-run).
- Ejecuté `python -m pytest tests/test_packaging_metadata.py tests/cli/test_packaging_smoke.py -q` y ambas suites relacionadas pasaron completamente.
- Verifiqué con las comprobaciones automáticas que no hubo cambios en Lexer/Parser y que `git diff --check` no mostró avisos; los únicos ficheros modificados son las dos pruebas indicadas arriba.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77721693308327b981a7da2c543ecc)