### PR TITLE
test: retirar `--maxfail=5` para permitir ejecución completa de la suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ addopts = [
     "--capture=fd",
     "--show-capture=all",
     "--durations=10",
-    "--maxfail=5",
 ]
 
 norecursedirs = [


### PR DESCRIPTION
### Motivation
- Permitir que CI ejecute y reporte la suite completa de pruebas en lugar de detenerse tras cinco fallos, respetando el contrato observables de los workflows que ejecutan todos los directorios de pruebas y generan cobertura.

### Description
- Se eliminó únicamente la opción `"--maxfail=5"` de `[tool.pytest.ini_options].addopts` en `pyproject.toml`, preservando `testpaths`, patrones de colección, markers, `norecursedirs` y el resto de opciones; el cambio quedó registrado con el mensaje de commit `test: ejecutar la suite completa antes de fallar`.

### Testing
- Ejecuté `python -m pytest --collect-only -q` que recogió exactamente `4928` casos y finalizó con `exit code 0`.
- Ejecuté `python -m pytest -q` (sin `-x` ni `--maxfail`) y la ejecución completó en `535.36s` con `4348 passed`, `526 failed`, `54 skipped`, `0 xfailed`, `3 errors`, `28 warnings` y `exit code 1`, mostrando fallos preexistentes que antes quedaban ocultos por `--maxfail=5`.
- Verifiqué `git diff --check` y comprobé que no hubo cambios en Lexer/Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a777dbe1cd0832792c54d4891bdfa9b)