### PR TITLE
ci: fix validate_targets shim import issue and CodeQL Assert query; add audit file to allowed list

### DIFF
--- a/.github/codeql/custom/ast-no-type-validation.ql
+++ b/.github/codeql/custom/ast-no-type-validation.ql
@@ -19,7 +19,7 @@ where
         fc.getTarget().hasQualifiedName("isinstance")
       ) or
       // Búsqueda de sentencia assert
-      exists(AssertStmt ast |
+      exists(Assert ast |
         ast.getEnclosingCallable() = m
       )
     )

--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -101,6 +101,7 @@ REPO_AUDIT_ALLOWED_FILE_PATHS = frozenset(
         "scripts/validate_targets_policy.py",
         "scripts/ci/validate_targets.py",
         "scripts/ci/audit_targets_contract.py",
+        "scripts/ci/audit_public_backend_exposure_terms.py",
         "scripts/audit_retired_targets.py",
         "scripts/ci/validate_workflow_target_matrix.py",
         "tests/unit/test_cli_target_aliases.py",
@@ -510,8 +511,14 @@ def validate_critical_signature_alignment() -> list[str]:
     """Compara firmas/constantes críticas entre árbol canónico y shims publicados."""
     errors: list[str] = []
 
-    import cli.cli as shim_cli_entry
+    # ``pcobra`` publica aliases legacy en ``sys.modules`` al importarse. Retirarlos
+    # aquí permite que la comprobación cargue los shims físicos que quiere comparar.
+    for module_name in tuple(sys.modules):
+        if module_name == "cobra" or module_name.startswith("cobra."):
+            sys.modules.pop(module_name)
+
     import cobra.cli.cli as shim_cobra_entry
+    import cli.cli as shim_cli_entry
     import cobra.cli.target_policies as shim_policies
     import cobra.transpilers.compatibility_matrix as shim_matrix
     import cobra.transpilers.registry as shim_registry


### PR DESCRIPTION
### Motivation

- El proceso de validación de targets fallaba al importar los shims porque el paquete `pcobra` dejaba aliases `cobra`/`cobra.*` en `sys.modules`, impidiendo cargar las rutas shim físicas que la comprobación compara. 
- La consulta CodeQL personalizada usaba el tipo `AssertStmt` no resoluble por la librería estándar de CodeQL para Python, provocando errores fatales en `codeql database run-queries`.

### Description

- Se añadió `scripts/ci/audit_public_backend_exposure_terms.py` a `REPO_AUDIT_ALLOWED_FILE_PATHS` para que el auditor reconozca explícitamente ese archivo como fuente legítima de términos históricos/aliases en inventario de auditoría.
- En `validate_critical_signature_alignment()` (en `scripts/ci/validate_targets.py`) se eliminan temporalmente de `sys.modules` los módulos `cobra` y `cobra.*` antes de importar los shims para forzar la carga física de los archivos shim y evitar el `ImportError` de delegación de alias.  
- Se ajustó el orden de imports para cargar primero `cobra.cli.cli` y después `cli.cli` tal que la comparación entre shims y árbol canónico se realice correctamente.
- Se corrigió la consulta CodeQL `.github/codeql/custom/ast-no-type-validation.ql` reemplazando `AssertStmt` por la clase pública `Assert` utilizada en la librería CodeQL Python para evitar el fallo de resolución de tipo.
- No se modificó Lexer ni Parser, ni se tocaron workflows ni reglas generales de gating.

### Testing

- Ejecuté `PYENV_VERSION=3.13.13 python -m black --check .` con `black 26.5.1` y no reportó archivos a reformatear (pasó sin cambios). 
- Ejecuté inicialmente `python scripts/ci/validate_targets.py` y reproducí el `ImportError` que ocultaba la regla real, luego tras la corrección volví a ejecutar `python scripts/ci/validate_targets.py` y obtuvo `✅ Validación CI de targets: OK` mostrando `OFFICIAL_TARGETS: python, javascript, rust`.
- Ejecuté `pytest -q tests/unit/test_ci_audit_public_backend_exposure_terms.py tests/unit/test_official_targets_consistency.py` y todas las pruebas unitarias ejecutadas pasaron (`14 passed`).
- Ejecuté `git diff --check` y comprobé que no hay cambios en Lexer/Parser, y ejecuté la comprobación local de CodeQL query syntax (sustitución de `AssertStmt` por `Assert`) para eliminar la causa del error detectado en los runs remotos.
- `make lint` falló por 2 errores F821 preexistentes no relacionados con este cambio y `make typecheck` falló por 1.751 errores preexistentes en el árbol, por lo que esas fallas no se deben a los cambios introducidos aquí.
- Intentos de inspeccionar runs/artefactos remotos de CodeQL estuvieron limitados por autenticación remota y permisos, por lo que la verificación final de la ejecución remota queda pendiente hasta disponer de credenciales para acceder a los artefactos del runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78279ae60c8327a9c01a8ce8182489)