### PR TITLE
Permitir E/S confinada en `usar` seguro

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -155,13 +155,27 @@ def _aplicar_capacidades(
             resultado.append((nombre, simbolo))
             continue
 
-        def verificar_permiso(kwargs, __capacidades=capacidades_enforced):
+        def verificar_permiso(
+            args,
+            kwargs,
+            __capacidades=capacidades_enforced,
+            __modulo=modulo,
+            __nombre=nombre,
+        ):
             if safe_mode:
                 if (
                     CapacidadUsar.PROCESS_SPAWN in __capacidades
                     and kwargs.get("shell") is True
                 ):
                     raise PermissionError("capacidad process.shell denegada en modo seguro")
+                capacidades_filesystem = __capacidades & {
+                    CapacidadUsar.FILESYSTEM_READ,
+                    CapacidadUsar.FILESYSTEM_WRITE,
+                }
+                if capacidades_filesystem and _solicitud_filesystem_confinada(
+                    __modulo, __nombre, args
+                ):
+                    return
                 capacidad = sorted(
                     (capacidad.value for capacidad in __capacidades),
                     key=lambda valor: (not valor.startswith("network."), valor),
@@ -175,18 +189,46 @@ def _aplicar_capacidades(
             async def protegido(
                 *args, __simbolo=simbolo, __verificar=verificar_permiso, **kwargs
             ):
-                __verificar(kwargs)
+                __verificar(args, kwargs)
                 return await __simbolo(*args, **kwargs)
         else:
             @wraps(simbolo)
             def protegido(
                 *args, __simbolo=simbolo, __verificar=verificar_permiso, **kwargs
             ):
-                __verificar(kwargs)
+                __verificar(args, kwargs)
                 return __simbolo(*args, **kwargs)
 
         resultado.append((nombre, protegido))
     return resultado
+
+
+def _solicitud_filesystem_confinada(
+    modulo: str, nombre: str, args: tuple[Any, ...]
+) -> bool:
+    """Autoriza efectos demostrablemente contenidos en la raíz de E/S."""
+
+    raiz_configurada = os.environ.get("COBRA_IO_BASE_DIR")
+    if modulo == "temporal" and nombre in {
+        "archivo_temporal",
+        "directorio_temporal",
+    }:
+        return bool(raiz_configurada)
+    if not args:
+        return False
+
+    try:
+        raiz = Path(raiz_configurada or Path.cwd()).expanduser().resolve(strict=True)
+        solicitada = Path(os.fspath(args[0])).expanduser()
+        objetivo = (
+            solicitada.resolve(strict=False)
+            if solicitada.is_absolute()
+            else (raiz / solicitada).resolve(strict=False)
+        )
+        objetivo.relative_to(raiz)
+    except (TypeError, ValueError, OSError):
+        return False
+    return True
 
 
 def normalizar_nombre_usar(nombre: str) -> str:

--- a/src/pcobra/corelibs/ruta.py
+++ b/src/pcobra/corelibs/ruta.py
@@ -75,7 +75,11 @@ def existe(ruta: PathLike) -> bool:
     """Indica si una ruta existe en el sistema de archivos."""
 
     ruta_validada = _validar_ruta(ruta)
-    return Path(ruta_validada).exists()
+    objetivo = Path(ruta_validada)
+    base = os.environ.get("COBRA_IO_BASE_DIR")
+    if base and not objetivo.is_absolute():
+        objetivo = Path(base) / objetivo
+    return objetivo.exists()
 
 
 def es_absoluta(ruta: PathLike) -> bool:

--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -373,7 +373,11 @@ def obtener_env(nombre: str) -> str | None:
 
 def listar_dir(ruta: str) -> list[str]:
     """Lista los archivos de un directorio."""
-    return os.listdir(ruta)
+    objetivo = os.fspath(ruta)
+    base = os.environ.get("COBRA_IO_BASE_DIR")
+    if base and not os.path.isabs(objetivo):
+        objetivo = os.path.join(base, objetivo)
+    return os.listdir(objetivo)
 
 
 def _error_sistema(operacion: str, exc: Exception) -> RuntimeError:

--- a/src/pcobra/corelibs/temporal.py
+++ b/src/pcobra/corelibs/temporal.py
@@ -45,8 +45,14 @@ def archivo_temporal(
     if not isinstance(texto, bool):
         raise TypeError("texto debe ser booleano")
 
+    opciones_directorio = {}
+    if base := os.environ.get("COBRA_IO_BASE_DIR"):
+        opciones_directorio["dir"] = base
     descriptor, ruta = tempfile.mkstemp(
-        prefix=prefijo_validado, suffix=sufijo_validado, text=texto
+        prefix=prefijo_validado,
+        suffix=sufijo_validado,
+        text=texto,
+        **opciones_directorio,
     )
     os.close(descriptor)
     return str(Path(ruta))
@@ -56,7 +62,10 @@ def directorio_temporal(*, prefijo: Optional[str] = None) -> str:
     """Crea un directorio temporal y devuelve su ruta como texto."""
 
     prefijo_validado = _validar_texto_opcional(prefijo, "prefijo")
-    return str(Path(tempfile.mkdtemp(prefix=prefijo_validado)))
+    opciones_directorio = {}
+    if base := os.environ.get("COBRA_IO_BASE_DIR"):
+        opciones_directorio["dir"] = base
+    return str(Path(tempfile.mkdtemp(prefix=prefijo_validado, **opciones_directorio)))
 
 
 def limpiar(ruta: PathLike) -> bool:


### PR DESCRIPTION
### Motivation

- Ejecutando antes de tocar archivos `python -m pytest tests/cli/test_repl_script_parity_contract.py tests/integration/test_repl_usar_entrypoints_contract.py -q` se detectaron 5 fallos relacionados con rechazos por capacidades de filesystem durante la autorización; los tracebacks completos se guardaron en `/tmp/pcobra_cinco_fallos_tracebacks.txt` y el diagnóstico preliminar (tabla y flujo) en `/tmp/pcobra_pr_body.md`.
- El rechazo ocurría en la fase de autorización en `_aplicar_capacidades` antes de que las corelibs resolvieran realmente las rutas, lo que impedía operaciones que de hecho estarían confinadas dentro de `COBRA_IO_BASE_DIR`.

### Description

- Se modificó `_aplicar_capacidades` en `src/pcobra/cobra/usar_loader.py` para que los wrappers reciban los `args` de llamada y permitan, en modo seguro, operaciones filesystem cuando se pueda demostrar que la ruta solicitada queda dentro de la raíz efectiva; se añadió el helper `_solicitud_filesystem_confinada` para esa comprobación.
- Se actualizó `src/pcobra/corelibs/ruta.py` para que `existe` resuelva rutas relativas contra `COBRA_IO_BASE_DIR` cuando está configurada y preserve el comportamiento anterior en otros casos.
- Se actualizó `src/pcobra/corelibs/sistema.py` para que `listar_dir` use `COBRA_IO_BASE_DIR` como raíz efectiva cuando la ruta es relativa, evitando resolver `"."` fuera del sandbox.
- Se actualizó `src/pcobra/corelibs/temporal.py` para que `archivo_temporal` y `directorio_temporal` creen recursos dentro de `COBRA_IO_BASE_DIR` cuando esté definida, y se mantenga el comportamiento por defecto si no lo está; no se tocó Lexer/Parser/AST ni la gramática.

### Testing

- Antes de cambios se ejecutó exactamente `python -m pytest tests/cli/test_repl_script_parity_contract.py tests/integration/test_repl_usar_entrypoints_contract.py -q` y se obtuvieron **5 fallos y 109 Passed**, con los cinco node IDs y tracebacks conservados en `/tmp/pcobra_cinco_fallos_tracebacks.txt`.
- Tras aplicar las correcciones se re-ejecutó `python -m pytest tests/cli/test_repl_script_parity_contract.py tests/integration/test_repl_usar_entrypoints_contract.py -q` y obtuvo **114 passed** (las 5 fallas iniciales resueltas); además se ejecutaron pruebas relevantes agrupadas con resultado **105 passed, 1 skipped**.
- Se ejecutó `python -m ruff check` sobre los archivos modificados y no reportó errores, y `git diff --check` no mostró problemas; una ejecución global completa de `pytest` fue interrumpida pero mostró 990 passed, 23 skipped y 21 fallos no relacionados con estos cambios (importaciones/expectativas legacy).
- Los archivos principalemente modificados son `src/pcobra/cobra/usar_loader.py`, `src/pcobra/corelibs/ruta.py`, `src/pcobra/corelibs/sistema.py` y `src/pcobra/corelibs/temporal.py` y las pruebas dirigidas indicadas arriba confirmaron la corrección.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a783317465483279e7eb899847870fe)