### PR TITLE
test(security): cubre contrato safe_mode en TranspiladorPython para `usar`

### DIFF
--- a/tests/unit/test_to_python_extras.py
+++ b/tests/unit/test_to_python_extras.py
@@ -37,13 +37,24 @@ def test_transpilar_import(tmp_path):
     assert codigo == esperado
 
 
-def test_transpilar_usar():
+@pytest.mark.parametrize(
+    ("transpilador", "safe_mode_esperado"),
+    [
+        (TranspiladorPython(), True),
+        (TranspiladorPython(safe_mode=True), True),
+        (TranspiladorPython(safe_mode=False), False),
+    ],
+    ids=("default-seguro", "seguro-explicito", "inseguro-explicito"),
+)
+def test_transpilar_usar_respeta_contrato_safe_mode(
+    transpilador, safe_mode_esperado
+):
     nodo = NodoUsar("math")
-    codigo = TranspiladorPython().generate_code([nodo])
+    codigo = transpilador.generate_code([nodo])
     esperado = (
         IMPORTS
         + "from pcobra.cobra.usar_loader import usar_modulo\n"
-        + "_usar_exports = usar_modulo('math', safe_mode=True)\n"
+        + f"_usar_exports = usar_modulo('math', safe_mode={safe_mode_esperado})\n"
         + "globals().update(dict(_usar_exports.get('simbolos', [])))\n"
     )
     assert codigo == esperado


### PR DESCRIPTION
### Motivation
- Asegurar que `TranspiladorPython` preserve el comportamiento por defecto de `safe_mode=True` al generar la llamada para `usar`, y añadir pruebas focales que verifiquen explícitamente las tres variantes del constructor.

### Description
- Se parametriza y reemplaza la prueba `test_transpilar_usar` en `tests/unit/test_to_python_extras.py` por `test_transpilar_usar_respeta_contrato_safe_mode` que construye `TranspiladorPython()`, `TranspiladorPython(safe_mode=True)` y `TranspiladorPython(safe_mode=False)` y verifica que la salida incluya `usar_modulo(..., safe_mode=<valor_esperado>)` sin modificar código de producción ni Lexer/Parser.

### Testing
- Se ejecutó `pytest -q tests/unit/test_to_python_extras.py::test_transpilar_usar_respeta_contrato_safe_mode` y pasó las 3 variantes (`3 passed`).
- Se ejecutó `pytest -q tests/unit/test_usar*.py tests/integration/test_usar*.py` para validar suites relacionadas y la ejecución informó `414 passed, 21 failed`, los fallos son preexistentes en contratos amplios de `usar` y no corresponden a la prueba añadida.
- Se verificó `git diff --check` y que no hubo cambios en Lexer/Parser mediante `git diff --name-only | rg -i '(^|/)(lexer|parser)'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a783ae5b4948327b4bf699c730ded24)