### PR TITLE
fix(ci): evitar falsos positivos en lint_policy_drift al detectar identificadores Python

### DIFF
--- a/scripts/lint_policy_drift.py
+++ b/scripts/lint_policy_drift.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import re
 import sys
+import tokenize
+from io import StringIO
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -66,6 +68,21 @@ STOPWORDS = {
     "reverse",
 }
 
+# Excepciones estrictamente acotadas: este checklist documenta el auditor que
+# impide reintroducir aliases retirados, por lo que necesita enumerar los
+# términos que dicho auditor rechaza. No es una declaración de targets válidos.
+DOCUMENTED_CONTEXT_EXCEPTIONS = {
+    "docs/architecture/backend-pipeline-checklist.md": (
+        "audit_public_backend_exposure_terms.py",
+    ),
+    # Este gate define patrones de rechazo para backends retirados. Sus mensajes
+    # y expresiones regulares son evidencia del control, no oferta pública.
+    "scripts/ci/validate_workflow_target_matrix.py": (
+        "backend retirado",
+        "referencia de target/pipeline retirado",
+    ),
+}
+
 
 def _iter_files() -> list[Path]:
     files: list[Path] = []
@@ -86,23 +103,46 @@ def _iter_files() -> list[Path]:
     return files
 
 
+def _python_name_spans(line: str) -> set[tuple[int, int]]:
+    """Devuelve identificadores Python para no confundir nombres homónimos con backends."""
+    spans: set[tuple[int, int]] = set()
+    try:
+        tokens = tokenize.generate_tokens(StringIO(line).readline)
+        for token in tokens:
+            if token.type == tokenize.NAME:
+                spans.add((token.start[1], token.end[1]))
+    except (IndentationError, tokenize.TokenError):
+        pass
+    return spans
+
+
+def _find_policy_drift(path: Path, content: str) -> list[str]:
+    rel = path.relative_to(ROOT).as_posix()
+    exceptions = DOCUMENTED_CONTEXT_EXCEPTIONS.get(rel, ())
+    errors: list[str] = []
+    for line_no, line in enumerate(content.splitlines(), start=1):
+        lowered = line.lower()
+        if not CONTEXT.search(lowered):
+            continue
+        if any(context in lowered for context in exceptions):
+            continue
+        python_names = _python_name_spans(line) if path.suffix.lower() == ".py" else set()
+        for match in TOKEN.finditer(lowered):
+            token = match.group(1).strip()
+            if token in OFFICIAL or token in STOPWORDS:
+                continue
+            if token in KNOWN_DISALLOWED and match.span(1) not in python_names:
+                errors.append(
+                    f"{rel}:{line_no}: target fuera de policy pública detectado -> {token}"
+                )
+    return errors
+
+
 def main() -> int:
     errors: list[str] = []
     for path in _iter_files():
-        rel = path.relative_to(ROOT).as_posix()
         content = path.read_text(encoding="utf-8", errors="ignore")
-        for line_no, line in enumerate(content.splitlines(), start=1):
-            lowered = line.lower()
-            if not CONTEXT.search(lowered):
-                continue
-            for match in TOKEN.finditer(lowered):
-                token = match.group(1).strip()
-                if token in OFFICIAL or token in STOPWORDS:
-                    continue
-                if token in KNOWN_DISALLOWED:
-                    errors.append(
-                        f"{rel}:{line_no}: target fuera de policy pública detectado -> {token}"
-                    )
+        errors.extend(_find_policy_drift(path, content))
     if errors:
         print("❌ Policy drift detectado (targets no permitidos en rutas públicas):")
         for error in errors:

--- a/tests/unit/test_lint_policy_drift.py
+++ b/tests/unit/test_lint_policy_drift.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scripts import lint_policy_drift
+
 
 def test_lint_policy_drift_script_passes_on_repo() -> None:
     repo_root = Path(__file__).resolve().parents[2]
@@ -14,3 +16,24 @@ def test_lint_policy_drift_script_passes_on_repo() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_no_confunde_identificador_node_con_target_prohibido(tmp_path, monkeypatch) -> None:
+    script = tmp_path / "scripts" / "ci" / "auditor.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("def targets_from_import(node):\n    return node\n", encoding="utf-8")
+    monkeypatch.setattr(lint_policy_drift, "ROOT", tmp_path)
+
+    assert lint_policy_drift._find_policy_drift(script, script.read_text()) == []
+
+
+def test_sigue_detectando_target_prohibido_en_literal_python(tmp_path, monkeypatch) -> None:
+    script = tmp_path / "scripts" / "config.py"
+    script.parent.mkdir(parents=True)
+    script.write_text('target = "node"\n', encoding="utf-8")
+    monkeypatch.setattr(lint_policy_drift, "ROOT", tmp_path)
+
+    errors = lint_policy_drift._find_policy_drift(script, script.read_text())
+
+    assert len(errors) == 1
+    assert "target fuera de policy pública detectado -> node" in errors[0]


### PR DESCRIPTION
### Motivation

- El auditor `scripts/lint_policy_drift.py` estaba reportando policy drift por tokens como `node` o `py` que aparecen como identificadores en código Python, provocando falsos positivos en validaciones automáticas.
- Hay archivos legítimos (checklist y validadores de workflows) que documentan términos retirados como evidencia de control y no deben considerarse una oferta pública de targets.

### Description

- Añade tokenización por `NAME` en `scripts/lint_policy_drift.py` para distinguir identificadores Python de menciones de targets en texto, con la función `_python_name_spans()` que evita interpretar nombres de variables como targets prohibidos.
- Factoriza la lógica de detección en `_find_policy_drift(path, content)` y hace que `main()` la use para mantener el mismo alcance de escaneo sin alterar las raíces ni la lista canónica de términos prohibidos.
- Introduce `DOCUMENTED_CONTEXT_EXCEPTIONS` para permitir, de forma acotada por ruta y contexto, menciones deliberadas de aliases/backends retirados en artefactos de auditoría y checklist sin ampliar ninguna allowlist global.
- Añade pruebas unitarias en `tests/unit/test_lint_policy_drift.py` que verifican que no se confunda un identificador `node` con un target prohibido y que sí se detecte `"node"` cuando aparece como literal de target, sin tocar Lexer/Parser ni la sintaxis del proyecto.

### Testing

- `python scripts/validate_targets_policy.py` — inicialmente devolvía código de salida `1` reportando drift por tokens en múltiples ficheros; tras los cambios devolvió `0` y mostró los targets oficiales esperados (`python, javascript, rust`).
- `python -m pytest -q tests/unit/test_lint_policy_drift.py` — las nuevas y previas pruebas unitarias pasaron (`3 passed`).
- Ejecuté los generadores documentales `python scripts/generate_target_policy_docs.py` y `python scripts/generar_matriz_transpiladores.py` y verifiqué con la comprobación de diff documental que no quedó drift accidental en `docs/...` (resultado final limpio).
- Un test existente en `tests/unit/test_validate_targets_policy_script.py::test_ci_validate_targets_guardrail_permite_exclusiones_de_packaging` falló en ejecuciones combinadas; la falla es reproducible y relacionada con packaging/guardrail, no con los cambios introducidos por este PR, por lo que no se modificó en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a783d5744148327843c78583990638e)