### PR TITLE
style(ci): alinea instalación de Black con la versión fijada en requirements-dev

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (a26af69be951a213d495a4c3e4e4022e16d87065)
         with:
           python-version: "3.11"
-      - run: pip install black
+      - name: Install project-pinned Black
+        run: pip install "$(grep -E '^black==' requirements-dev.txt)"
       - run: black --check .
       - name: Detect legacy target aliases in public docs
         run: python scripts/lint_legacy_aliases.py


### PR DESCRIPTION
### Motivation

- El job de Lint falló en `black --check .` porque el workflow instalaba `black` sin fijar versión mientras el proyecto especifica `black==26.5.1` en `requirements-dev.txt`.
- Evitar reformateos masivos no autorizados y preservar archivos sensibles del lenguaje (Lexer/Parser) sin cambiar la configuración de Black en `pyproject.toml`.

### Description

- Actualiza `.github/workflows/lint.yml` para instalar Black leyendo la versión fijada en `requirements-dev.txt` mediante `pip install "$(grep -E '^black==' requirements-dev.txt)"` en lugar de `pip install black`.
- No se modificó la sección `[tool.black]` de `pyproject.toml` y no se cambiaron fuentes de Lexer/Parser ni otros archivos de código.
- El cambio es mínimo y limitado al paso de instalación del workflow para alinear el runner con la dependencia oficial del repositorio.

### Testing

- Reproducción con Python 3.11.15: se creó un entorno virtual, se instaló la versión fijada y `black --version` confirmó `26.5.1` (éxito).
- Ejecución local de `black --check .` con la misma versión mostró que Black marcaría muchos archivos para reformateo (≈280–457 entradas); la lista exacta se guardó en `/tmp/black-files.txt` e incluye, entre otros, `src/pcobra/cobra/core/lexer.py`, `src/pcobra/cobra/core/parser.py` y `src/pcobra/cobra/core/lark_parser.py` (comprobación fallida por diseño; no se aplicaron cambios automáticos).
- Validación del YAML del workflow y aserción programática que el paso de instalación contiene el comando esperado `pip install "$(grep -E '^black==' requirements-dev.txt)"` (éxito).
- Verificación de que no se modificaron archivos de Lexer/Parser como parte del cambio (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a783ffd67b48327ae28269175b555eb)