### PR TITLE
fix(codeql): corrige query que fallaba por tipo TryStmt no resuelto

### DIFF
--- a/.github/codeql/custom/missing-codegen-exception.ql
+++ b/.github/codeql/custom/missing-codegen-exception.ql
@@ -9,7 +9,7 @@ where
   m.getName() = "generate_code" and
   m.getFile() = f and
   f.getRelativePath().regexp("^src/cobra/transpilers/transpiler/") and
-  not exists(TryStmt t |
+  not exists(Try t |
     t.getEnclosingCallable() = m
   )
 select m, "Falta manejo de excepciones durante la generación de código"

--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CODEQL_CONFIG = ROOT / ".github" / "codeql" / "custom" / "codeql-config.yml"
+MISSING_CODEGEN_EXCEPTION_QUERY = (
+    ROOT / ".github" / "codeql" / "custom" / "missing-codegen-exception.ql"
+)
 
 
 def _codeql_config_text() -> str:
@@ -34,3 +37,11 @@ def test_codeql_custom_queries_resolve_from_repository_root() -> None:
     for query_path in query_paths:
         assert f"  - uses: {query_path}" in config
         assert (ROOT / query_path).is_file(), query_path
+
+
+def test_missing_codegen_exception_uses_supported_try_type() -> None:
+    """Evita reintroducir el tipo inexistente ``TryStmt`` en la query."""
+    query = MISSING_CODEGEN_EXCEPTION_QUERY.read_text(encoding="utf-8")
+
+    assert "exists(Try t |" in query
+    assert "TryStmt" not in query


### PR DESCRIPTION
### Motivation

- La ejecución de CodeQL falló durante `Perform CodeQL Analysis` por el error `could not resolve type TryStmt` en la query `./.github/codeql/custom/missing-codegen-exception.ql`, por lo que la query debía ajustarse a la API QL disponible.

### Description

- Reemplacé el uso no soportado de `TryStmt` por el tipo soportado `Try` en `/.github/codeql/custom/missing-codegen-exception.ql` para evitar el error de compilación QL.
- Añadí la prueba contractual `test_missing_codegen_exception_uses_supported_try_type` en `tests/test_codeql_config.py` que valida que la query contiene `exists(Try t |` y no reintroduce `TryStmt`.
- No modifiqué el filtro de ruta `^src/cobra/transpilers/transpiler/` ni otras queries, metadata o supresiones, y no toqué Lexer/Parser conforme a las reglas de alcance.

### Testing

- Ejecuté `pytest -q tests/test_codeql_config.py` y las pruebas unitarias relacionadas, y ambas corridas pasaron (`3 passed` y `3 passed`).
- Verifiqué localmente que los archivos modificados existen y que no hay cambios en `lexer`/`parser` por `git diff --name-only` y `git diff --check` (sin errores detectados).
- No se ejecutó una compilación/análisis completo de CodeQL en el entorno porque la CLI de `codeql` no está disponible localmente y la descarga completa de logs del run remoto requiere autenticación (GitHub API devolvió 403), por lo que la corrección se basó en las anotaciones del check y en las pruebas automáticas disponibles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7841f91c1c8327a2cf8cf5ef4cbce2)