### PR TITLE
fix(security): restaura filesystem confinado en safe mode

### DIFF
--- a/docs/auditorias/cierre_runtime_filesystem_post_3443.md
+++ b/docs/auditorias/cierre_runtime_filesystem_post_3443.md
@@ -1,0 +1,33 @@
+# Cierre runtime filesystem posterior a #3443
+
+## Regresión localizada
+
+La comparación con `6ec32c48` (PR #3438) mostró que `usar_loader._aplicar_capacidades`
+dejo de pasar los argumentos a `_solicitud_filesystem_confinada` y eliminó esa función.
+Desde entonces, toda entrada marcada `safe_mode_decision="deny"` se rechazaba antes de
+alcanzar implementaciones que sí podían operar bajo `COBRA_IO_BASE_DIR`.
+
+La corrección no restaura esa heurística del loader: la autoridad sigue siendo
+`FILESYSTEM_SYMBOL_POLICIES`/`filesystem_policy_for`, y sólo cambia una entrada a
+`allow` después de que su implementación resuelva la ruta con el sandbox canónico.
+
+## Auditoría por módulo
+
+| Módulo / símbolos | Capacidad | Confinamiento real bajo `COBRA_IO_BASE_DIR` | `safe_mode` | Resolución |
+|---|---|---|---|---|
+| `archivo.leer`, `existe`, `leer_lineas` | `filesystem.read` | Sí | allow | `_resolver_ruta` |
+| `archivo.escribir`, `eliminar`, `anexar` | `filesystem.write` | Sí | allow | `_resolver_ruta` |
+| `temporal.archivo_temporal`, `directorio_temporal`, `limpiar` | `filesystem.write` | Sí | allow | raíz creada perezosamente y `_resolver_ruta_filesystem_confinado` |
+| `datos.leer_csv`, `leer_json`, `leer_excel`, `leer_parquet`, `leer_feather` | `filesystem.read` | No; backend directo | deny | rutas arbitrarias del backend |
+| `datos.escribir_csv`, `escribir_json`, `escribir_excel`, `escribir_parquet`, `escribir_feather` | `filesystem.write` | No; backend directo | deny | rutas arbitrarias del backend |
+| `configuracion.leer_toml`, `leer_ini`, `leer_configuracion` | `filesystem.read` | Sí | allow | `_resolver_ruta_filesystem_confinado` |
+| `ruta.existe` | `filesystem.read` | Sí | allow | `_resolver_ruta_filesystem_confinado` |
+| `serializacion.leer_json`, `leer_csv` | `filesystem.read` | Sí | allow | `_resolver_ruta_filesystem_confinado` |
+| `serializacion.escribir_json`, `escribir_csv` | `filesystem.write` | Sí | allow | `_resolver_ruta_filesystem_confinado` |
+| `sistema.listar_dir` | `filesystem.read` | Sí | allow | `_resolver_ruta_filesystem_confinado` |
+
+El resolver crea la raíz configurada si aún no existe, rechaza `../`, rutas absolutas
+externas y cualquier symlink en los componentes intermedios o en la hoja, y valida
+con `resolve(strict=False)` tanto destinos existentes como destinos todavía nuevos.
+Sin `COBRA_IO_BASE_DIR`, las corelibs recién confinadas conservan su comportamiento
+público previo; `safe_mode` configura una raíz explícita.

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -702,7 +702,7 @@ _FILESYSTEM_SANDBOX_CONFINEMENT: dict[str, dict[str, bool]] = {
         "escribir_parquet": False,
         "escribir_feather": False,
     },
-    "sistema": {"listar_dir": False},
+    "sistema": {"listar_dir": True},
     "archivo": {
         "leer": True,
         "existe": True,
@@ -712,17 +712,17 @@ _FILESYSTEM_SANDBOX_CONFINEMENT: dict[str, dict[str, bool]] = {
         "anexar": True,
     },
     "red": {"descargar_archivo": True},
-    "ruta": {"existe": False},
+    "ruta": {"existe": True},
     "serializacion": {
-        "leer_json": False,
-        "leer_csv": False,
-        "escribir_json": False,
-        "escribir_csv": False,
+        "leer_json": True,
+        "leer_csv": True,
+        "escribir_json": True,
+        "escribir_csv": True,
     },
     "temporal": {
-        "archivo_temporal": False,
-        "directorio_temporal": False,
-        "limpiar": False,
+        "archivo_temporal": True,
+        "directorio_temporal": True,
+        "limpiar": True,
     },
     "compresion": {
         "crear_zip": True,
@@ -730,9 +730,9 @@ _FILESYSTEM_SANDBOX_CONFINEMENT: dict[str, dict[str, bool]] = {
         "listar_zip": True,
     },
     "configuracion": {
-        "leer_toml": False,
-        "leer_ini": False,
-        "leer_configuracion": False,
+        "leer_toml": True,
+        "leer_ini": True,
+        "leer_configuracion": True,
     },
 }
 

--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -14,6 +14,7 @@ EQUIVALENCIAS_SEMANTICAS_ARCHIVO: dict[str, str] = {
     "readlines": "leer_lineas",
 }
 
+
 def _es_ruta_absoluta_o_sensible_windows(ruta: PathLike) -> bool:
     texto = str(ruta).strip()
     if not texto:
@@ -39,19 +40,43 @@ def _resolver_ruta(
     resuelven dentro del mismo sandbox.
     """
 
-    base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
+    base_sin_resolver = Path(
+        os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()
+    ).expanduser()
+    base_sin_resolver.mkdir(parents=True, exist_ok=True)
+    base = base_sin_resolver.resolve(strict=True)
     objetivo = Path(ruta).expanduser()
     es_absoluta = objetivo.is_absolute() or _es_ruta_absoluta_o_sensible_windows(ruta)
     if es_absoluta and not permitir_absoluta_dentro_base:
         raise ValueError("Las rutas absolutas no están permitidas")
     if ".." in objetivo.parts:
         raise ValueError("La ruta no puede contener '..'")
-    destino = objetivo.resolve() if es_absoluta else (base / objetivo).resolve()
+    candidato = objetivo if es_absoluta else base / objetivo
+    destino = candidato.resolve(strict=False)
     try:
         destino.relative_to(base)
     except ValueError as exc:
         raise ValueError("La ruta queda fuera del directorio permitido") from exc
+    relativo = candidato.relative_to(base)
+    actual = base
+    for parte in relativo.parts:
+        actual /= parte
+        if actual.is_symlink():
+            raise ValueError("La ruta no puede contener enlaces simbólicos")
     return destino
+
+
+def _resolver_ruta_filesystem_confinado(
+    ruta: PathLike, capacidad: str = "filesystem.read"
+) -> Path:
+    """Resuelve rutas de corelibs confinadas cuando existe una raíz explícita."""
+
+    if not os.environ.get("COBRA_IO_BASE_DIR"):
+        return Path(ruta).expanduser()
+    try:
+        return _resolver_ruta(ruta, permitir_absoluta_dentro_base=True)
+    except ValueError as exc:
+        raise PermissionError(f"capacidad {capacidad} denegada: {exc}") from exc
 
 
 def leer(ruta: PathLike) -> str:
@@ -115,7 +140,6 @@ def eliminar(ruta: PathLike) -> None:
             ruta_segura.unlink()
 
 
-
 def anexar(ruta: PathLike, datos: str) -> None:
     """Agrega ``datos`` al final del archivo respetando el sandbox de rutas."""
 
@@ -129,6 +153,7 @@ def leer_lineas(ruta: PathLike, *, mantener_saltos: bool = False) -> list[str]:
 
     contenido = leer(ruta)
     return contenido.splitlines(keepends=mantener_saltos)
+
 
 __all__ = [
     "leer",

--- a/src/pcobra/corelibs/configuracion.py
+++ b/src/pcobra/corelibs/configuracion.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from pcobra.corelibs.archivo import _resolver_ruta_filesystem_confinado
+
 __all__ = [
     "leer_toml",
     "leer_ini",
@@ -82,7 +84,7 @@ def _validar_archivo_existente(ruta: PathLike) -> Path:
         raise TypeError("ruta debe representar una ruta de texto")
     if texto == "":
         raise ValueError("ruta no puede estar vacía")
-    ruta_configuracion = Path(texto)
+    ruta_configuracion = _resolver_ruta_filesystem_confinado(texto)
     if not ruta_configuracion.is_file():
         raise FileNotFoundError(
             f"Archivo de configuración no encontrado: {ruta_configuracion}"

--- a/src/pcobra/corelibs/ruta.py
+++ b/src/pcobra/corelibs/ruta.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from typing import Union
 
+from pcobra.corelibs.archivo import _resolver_ruta_filesystem_confinado
+
 PathLike = Union[str, os.PathLike[str]]
 
 __all__ = [
@@ -75,10 +77,7 @@ def existe(ruta: PathLike) -> bool:
     """Indica si una ruta existe en el sistema de archivos."""
 
     ruta_validada = _validar_ruta(ruta)
-    objetivo = Path(ruta_validada)
-    base = os.environ.get("COBRA_IO_BASE_DIR")
-    if base and not objetivo.is_absolute():
-        objetivo = Path(base) / objetivo
+    objetivo = _resolver_ruta_filesystem_confinado(ruta_validada)
     return objetivo.exists()
 
 

--- a/src/pcobra/corelibs/serializacion.py
+++ b/src/pcobra/corelibs/serializacion.py
@@ -8,6 +8,8 @@ import os
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from pcobra.corelibs.archivo import _resolver_ruta_filesystem_confinado
+
 __all__ = [
     "codificar_json",
     "decodificar_json",
@@ -20,7 +22,11 @@ __all__ = [
 PathLike = str | os.PathLike[str]
 
 
-def _validar_ruta(ruta: PathLike, nombre_argumento: str = "ruta") -> Path:
+def _validar_ruta(
+    ruta: PathLike,
+    nombre_argumento: str = "ruta",
+    capacidad: str = "filesystem.read",
+) -> Path:
     if not isinstance(ruta, (str, os.PathLike)):
         raise TypeError(
             f"{nombre_argumento} debe ser una ruta de texto o compatible con os.PathLike"
@@ -30,7 +36,7 @@ def _validar_ruta(ruta: PathLike, nombre_argumento: str = "ruta") -> Path:
         raise TypeError(f"{nombre_argumento} debe representar una ruta de texto")
     if texto == "":
         raise ValueError(f"{nombre_argumento} no puede estar vacía")
-    return Path(texto)
+    return _resolver_ruta_filesystem_confinado(texto, capacidad)
 
 
 def _validar_delimitador(delimitador: str) -> str:
@@ -80,7 +86,7 @@ def leer_json(ruta: PathLike) -> Any:
 def escribir_json(ruta: PathLike, objeto: Any, *, indentar: int | None = 2) -> None:
     """Codifica ``objeto`` como JSON y lo escribe en ``ruta``."""
 
-    _validar_ruta(ruta).write_text(
+    _validar_ruta(ruta, capacidad="filesystem.write").write_text(
         codificar_json(objeto, indentar=indentar) + "\n",
         encoding="utf-8",
     )
@@ -139,7 +145,9 @@ def escribir_csv(
     filas_normalizadas = _normalizar_filas_csv(filas)
     campos = list(filas_normalizadas[0].keys())
 
-    with _validar_ruta(ruta).open("w", encoding="utf-8", newline="") as archivo:
+    with _validar_ruta(ruta, capacidad="filesystem.write").open(
+        "w", encoding="utf-8", newline=""
+    ) as archivo:
         escritor = csv.DictWriter(
             archivo, fieldnames=campos, delimiter=delimitador_validado
         )

--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -88,9 +88,7 @@ def _verificar_descriptor(fd: int, st_dev: int, st_ino: int) -> None:
     try:
         actual = os.fstat(fd)
     except OSError as exc:
-        raise RuntimeError(
-            "No se pudo verificar el ejecutable autorizado"
-        ) from exc
+        raise RuntimeError("No se pudo verificar el ejecutable autorizado") from exc
 
     if actual.st_dev != st_dev or actual.st_ino != st_ino:
         raise RuntimeError("El ejecutable cambió durante la ejecución")
@@ -100,9 +98,7 @@ def _verificar_ruta(exe_real: str, st_dev: int, st_ino: int) -> None:
     try:
         actual = os.stat(exe_real)
     except OSError as exc:
-        raise RuntimeError(
-            "El ejecutable cambió durante la ejecución"
-        ) from exc
+        raise RuntimeError("El ejecutable cambió durante la ejecución") from exc
 
     if actual.st_dev != st_dev or actual.st_ino != st_ino:
         raise RuntimeError("El ejecutable cambió durante la ejecución")
@@ -315,12 +311,14 @@ async def ejecutar_stream(
             # pass_fds hace heredable el fd abierto con O_CLOEXEC solo en el hijo.
             opciones_descriptor = {"pass_fds": (fd,), "close_fds": True}
         try:
-            proc = await esperar(asyncio.create_subprocess_exec(
+            proc = await esperar(
+                asyncio.create_subprocess_exec(
                     *args_exec,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     **opciones_descriptor,
-            ))
+                )
+            )
             cola_stdout: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=1)
             tareas_lectura = [
                 asyncio.create_task(drenar_stdout(cola_stdout)),
@@ -373,10 +371,9 @@ def obtener_env(nombre: str) -> str | None:
 
 def listar_dir(ruta: str) -> list[str]:
     """Lista los archivos de un directorio."""
-    objetivo = os.fspath(ruta)
-    base = os.environ.get("COBRA_IO_BASE_DIR")
-    if base and not os.path.isabs(objetivo):
-        objetivo = os.path.join(base, objetivo)
+    from pcobra.corelibs.archivo import _resolver_ruta_filesystem_confinado
+
+    objetivo = _resolver_ruta_filesystem_confinado(ruta)
     return os.listdir(objetivo)
 
 
@@ -396,11 +393,11 @@ async def ejecutar_comando_async(
         raise _error_sistema("ejecutar_comando_async", exc) from None
 
 
-
 def directorio_actual() -> str:
     """Devuelve la ruta del directorio de trabajo actual."""
 
     return os.getcwd()
+
 
 __all__ = [
     "obtener_os",

--- a/src/pcobra/corelibs/temporal.py
+++ b/src/pcobra/corelibs/temporal.py
@@ -6,12 +6,19 @@ import tempfile
 from pathlib import Path
 from typing import Optional, Union
 
+from pcobra.corelibs.archivo import (
+    _resolver_ruta,
+    _resolver_ruta_filesystem_confinado,
+)
+
 PathLike = Union[str, os.PathLike[str]]
 
 __all__ = ["archivo_temporal", "directorio_temporal", "limpiar"]
 
 
-def _validar_texto_opcional(valor: Optional[str], nombre_argumento: str) -> Optional[str]:
+def _validar_texto_opcional(
+    valor: Optional[str], nombre_argumento: str
+) -> Optional[str]:
     if valor is None:
         return None
     if not isinstance(valor, str):
@@ -46,8 +53,10 @@ def archivo_temporal(
         raise TypeError("texto debe ser booleano")
 
     opciones_directorio = {}
-    if base := os.environ.get("COBRA_IO_BASE_DIR"):
-        opciones_directorio["dir"] = base
+    if os.environ.get("COBRA_IO_BASE_DIR"):
+        opciones_directorio["dir"] = _resolver_ruta(
+            ".", permitir_absoluta_dentro_base=True
+        )
     descriptor, ruta = tempfile.mkstemp(
         prefix=prefijo_validado,
         suffix=sufijo_validado,
@@ -63,8 +72,10 @@ def directorio_temporal(*, prefijo: Optional[str] = None) -> str:
 
     prefijo_validado = _validar_texto_opcional(prefijo, "prefijo")
     opciones_directorio = {}
-    if base := os.environ.get("COBRA_IO_BASE_DIR"):
-        opciones_directorio["dir"] = base
+    if os.environ.get("COBRA_IO_BASE_DIR"):
+        opciones_directorio["dir"] = _resolver_ruta(
+            ".", permitir_absoluta_dentro_base=True
+        )
     return str(Path(tempfile.mkdtemp(prefix=prefijo_validado, **opciones_directorio)))
 
 
@@ -76,7 +87,7 @@ def limpiar(ruta: PathLike) -> bool:
     """
 
     ruta_validada = _validar_ruta(ruta)
-    objetivo = Path(ruta_validada)
+    objetivo = _resolver_ruta_filesystem_confinado(ruta_validada, "filesystem.write")
 
     if not objetivo.exists():
         return False


### PR DESCRIPTION
### Motivation

- Recuperar comportamiento seguro posterior a la regresión que empezó en la PR #3438, de modo que las implementaciones de corelibs que pueden operar confinadas bajo `COBRA_IO_BASE_DIR` alcancen el runtime en `safe_mode` sin introducir tablas paralelas de decisión.

### Description

- Reintroduce y endurece la resolución canónica de rutas en `src/pcobra/corelibs/archivo.py` mediante la mejora de `_resolver_ruta` (crea perezosamente la raíz, usa `resolve(strict=False)` para destinos nuevos, rechaza `..`, rutas absolutas externas y symlinks intermedios/leaf) y añade `_resolver_ruta_filesystem_confinado` que convierte errores en `PermissionError` con la capacidad implicada.
- Enruta las operaciones filesystem de las corelibs auditadas a ese resolver: `configuracion`, `ruta`, `serializacion`, `temporal` y `sistema.listar_dir` usan ahora la resolución confinada para validar/crear rutas bajo `COBRA_IO_BASE_DIR`, y `temporal` pasa la opción `dir` a `tempfile` cuando procede.
- Mantiene la autoridad contractual: actualiza la matriz canónica `_FILESYSTEM_SANDBOX_CONFINEMENT` en `src/pcobra/cobra/usar_policy.py` para marcar como `allow` (confinado) los símbolos efectivamente confinables y deja en `deny` los símbolos de `datos` que siguen operando sobre rutas arbitrarias; reutiliza `FILESYSTEM_SYMBOL_POLICIES` y `filesystem_policy_for` sin crear tablas paralelas ni eliminar capacidades del conjunto restringido.
- Añade documentación de auditoría `docs/auditorias/cierre_runtime_filesystem_post_3443.md` que detalla por símbolo la capacidad, el confinamiento real y el mecanismo de resolución; no se tocaron Lexer, Parser, gramática, tokens, `constant_folder` ni `src/pcobra/core/ast_nodes.py`.

### Testing

- Reproducción previa: `pytest -vv --tb=long tests/integration/test_repl_usar_entrypoints_contract.py::test_repl_contract_pipeline_completo_por_modulo_canonico` reprodujo los 5 fallos focales y sus trazas completas antes de los cambios (registro guardado localmente durante la auditoría).
- Tras los cambios, `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py::test_repl_contract_pipeline_completo_por_modulo_canonico` pasó (21 tests) y las suites relacionadas `tests/unit/test_remediacion_runtime_contracts.py`, `tests/unit/test_archivo.py`, `tests/unit/test_sandbox_paths.py` y demás focales devolvieron un estado consistente, culminando en `116 passed, 1 warning` en la ejecución combinada indicada en el flujo.
- Se ejecutó `python -m compileall -q src/pcobra/corelibs src/pcobra/cobra/usar_policy.py` y `git diff --check` y ambas verificaciones fueron exitosas.
- Verificación de no-modificación de componentes sintácticos: se comprobó que no hubo cambios en Lexer/Parser/gramática/tokens/`src/pcobra/core/ast_nodes.py` tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a784db9ee54832781392f1c015b1ef7)