### PR TITLE
fix(py311): preservar compatibilidad de Black con Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ cobra = "pcobra.cli:main"
 
 [tool.black]
 line-length = 88
-target-version = ["py311", "py312", "py313"]
+target-version = ["py311"]
 extend-exclude = '''(?x)(
   ^docs/frontend/
   | ^docs/build/


### PR DESCRIPTION
### Motivation
- Evitar que Black, al ejecutarse con Python 3.11, intente validar código formateado para objetivos superiores (py312/py313) y produzca errores de parseo o advertencias sin modificar código fuente ni el `requires-python`.

### Description
- Se actualizó `pyproject.toml` en `[tool.black]` cambiando `target-version = ["py311", "py312", "py313"]` por `target-version = ["py311"]` y se creó el commit `fix(py311): preserva compatibilidad sintáctica del tooling`.

### Testing
- `PYENV_VERSION=3.11.15 python -m compileall -q src` pasó correctamente; `rg -n 'except\s*\*'` no encontró cláusulas `except*`; `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_tooling_excludes.py` pasó con `2 passed`; `PYENV_VERSION=3.11.15 python -m black --check .` terminó con salida no cero porque `684 files would be reformatted`, lo cual es esperado y no se reformateó masivamente por alcance del cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7853b72d30832796505fdcf5165e53)