### PR TITLE
fix(ci): cierra regresión filesystem y gates residuales post-3443

### DIFF
--- a/src/pcobra/cobra/cli/services/test_service.py
+++ b/src/pcobra/cobra/cli/services/test_service.py
@@ -5,9 +5,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
-from pcobra.cobra.extensions import COBRA_SOURCE_EXTENSIONS
+from pcobra.cobra.extensions import COBRA_SOURCE_EXTENSIONS, es_fuente_cobra
 from pcobra.cobra.core.interpreter import InterpretadorCobra
-from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.core.sandbox import (
+    ejecutar_en_contenedor,
+    ejecutar_en_sandbox,
+    ejecutar_en_sandbox_js,
+)
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
@@ -61,7 +65,8 @@ class TestService:
             diferencias: Dict[str, str] = {}
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 futuros = {
-                    executor.submit(self.verify_language, lang, ast, esperado): lang for lang in lenguajes
+                    executor.submit(self.verify_language, lang, ast, esperado): lang
+                    for lang in lenguajes
                 }
 
                 for futuro in concurrent.futures.as_completed(futuros):
@@ -93,7 +98,9 @@ class TestService:
         unsupported = set(languages) - set(self.SUPPORTED_LANGUAGES)
         if unsupported:
             raise ValueError(
-                _("Lenguajes no soportados: {unsupported}. Soportados: {supported}").format(
+                _(
+                    "Lenguajes no soportados: {unsupported}. Soportados: {supported}"
+                ).format(
                     unsupported=", ".join(sorted(unsupported)),
                     supported=", ".join(self.SUPPORTED_LANGUAGES),
                 )
@@ -102,10 +109,18 @@ class TestService:
     def validate_file(self, file_path: str) -> None:
         path = Path(file_path)
         if not es_fuente_cobra(path):
-            raise ValueError(_("Extensión de archivo no válida. Debe ser: {}").format(", ".join(sorted(VALID_EXTENSIONS))))
+            raise ValueError(
+                _("Extensión de archivo no válida. Debe ser: {}").format(
+                    ", ".join(sorted(VALID_EXTENSIONS))
+                )
+            )
 
         if path.stat().st_size > MAX_FILE_SIZE:
-            raise ValueError(_("El archivo es demasiado grande (máximo {} MB)").format(MAX_FILE_SIZE // (1024 * 1024)))
+            raise ValueError(
+                _("El archivo es demasiado grande (máximo {} MB)").format(
+                    MAX_FILE_SIZE // (1024 * 1024)
+                )
+            )
 
     def read_source_file(self, file_path: str) -> str:
         validar_archivo_existente(file_path)
@@ -114,12 +129,18 @@ class TestService:
         try:
             return read_cobra_source(file_path)
         except PermissionError:
-            raise PermissionError(_("No hay permisos para leer el archivo '{}'").format(file_path))
+            raise PermissionError(
+                _("No hay permisos para leer el archivo '{}'").format(file_path)
+            )
         except UnicodeDecodeError as e:
             self._logger.error("Error decodificando archivo: %s", str(e))
-            raise ValueError(_("Error al decodificar el archivo '{}'").format(file_path))
+            raise ValueError(
+                _("Error al decodificar el archivo '{}'").format(file_path)
+            )
 
-    def compile_and_execute(self, ast: Any, lang: str) -> Tuple[Optional[str], Optional[str]]:
+    def compile_and_execute(
+        self, ast: Any, lang: str
+    ) -> Tuple[Optional[str], Optional[str]]:
         try:
             codigo_gen = backend_pipeline.transpile(ast, lang)
 
@@ -140,7 +161,9 @@ class TestService:
             self._logger.error("Error en %s: %s", lang, str(e))
             return None, str(e)
 
-    def verify_language(self, lang: str, ast: Any, esperado: str) -> Tuple[str, Optional[str]]:
+    def verify_language(
+        self, lang: str, ast: Any, esperado: str
+    ) -> Tuple[str, Optional[str]]:
         salida, error = self.compile_and_execute(ast, lang)
 
         if error:

--- a/src/pcobra/cobra/cli/services/verification_service.py
+++ b/src/pcobra/cobra/cli/services/verification_service.py
@@ -5,17 +5,20 @@ from io import StringIO
 from typing import Any
 from unittest.mock import patch
 
-from pcobra.cobra.extensions import COBRA_SOURCE_EXTENSIONS
+from pcobra.cobra.extensions import COBRA_SOURCE_EXTENSIONS, es_fuente_cobra
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
 from pcobra.cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 from pcobra.cobra.core import Lexer, Parser
 from pcobra.cobra.core.interpreter import InterpretadorCobra
-from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.core.sandbox import (
+    ejecutar_en_contenedor,
+    ejecutar_en_sandbox,
+    ejecutar_en_sandbox_js,
+)
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.qa.syntax_validation import SUPPORTED_VALIDATOR_TARGETS
-
 
 MAX_FILE_SIZE = 10 * 1024 * 1024
 VALID_EXTENSIONS = {".cobra"}
@@ -36,12 +39,18 @@ def parse_verification_targets(targets_raw: str) -> list[str]:
         raise ValueError(_("La lista --targets está vacía"))
     invalid = sorted(set(parsed) - set(SUPPORTED_VALIDATOR_TARGETS))
     if invalid:
-        raise ValueError(_("Targets no soportados en --targets: {}.").format(", ".join(invalid)))
+        raise ValueError(
+            _("Targets no soportados en --targets: {}.").format(", ".join(invalid))
+        )
     return parsed
 
 
 def resolve_executable_targets(requested_targets: list[str]) -> list[str]:
-    return [target for target in requested_targets if target in VERIFICATION_EXECUTABLE_TARGETS]
+    return [
+        target
+        for target in requested_targets
+        if target in VERIFICATION_EXECUTABLE_TARGETS
+    ]
 
 
 def _compile_and_execute(ast: Any, lang: str) -> tuple[str | None, str | None]:
@@ -77,9 +86,17 @@ def execute_runtime_verification(archivo: str, lenguajes: list[str]) -> int:
 
     path = validar_archivo_existente(archivo)
     if not es_fuente_cobra(path):
-        raise ValueError(_("Extensión de archivo no válida. Debe ser: {}").format(", ".join(sorted(VALID_EXTENSIONS))))
+        raise ValueError(
+            _("Extensión de archivo no válida. Debe ser: {}").format(
+                ", ".join(sorted(VALID_EXTENSIONS))
+            )
+        )
     if path.stat().st_size > MAX_FILE_SIZE:
-        raise ValueError(_("El archivo es demasiado grande (máximo {} MB)").format(MAX_FILE_SIZE // (1024 * 1024)))
+        raise ValueError(
+            _("El archivo es demasiado grande (máximo {} MB)").format(
+                MAX_FILE_SIZE // (1024 * 1024)
+            )
+        )
 
     code = path.read_text(encoding="utf-8")
     tokens = Lexer(code).tokenizar()

--- a/tests/unit/test_run_transpiler_pool.py
+++ b/tests/unit/test_run_transpiler_pool.py
@@ -3,6 +3,8 @@ import types
 
 import pytest
 
+_modules_before = sys.modules.copy()
+
 # Prepara stubs mínimos para los módulos pesados que `compile_cmd` importa.
 # Esto evita dependencias innecesarias en las pruebas unitarias.
 cobra_transpilers = types.ModuleType("cobra.transpilers")
@@ -14,10 +16,12 @@ transpiler_pkg = types.ModuleType("cobra.transpilers.transpiler")
 transpiler_pkg.__path__ = []
 sys.modules.setdefault("cobra.transpilers.transpiler", transpiler_pkg)
 
+
 def _stub(mod_name: str, cls_name: str) -> None:
     mod = types.ModuleType(f"cobra.transpilers.transpiler.{mod_name}")
     setattr(mod, cls_name, type(cls_name, (), {}))
     sys.modules[f"cobra.transpilers.transpiler.{mod_name}"] = mod
+
 
 for name, cls in [
     ("to_js", "TranspiladorJavaScript"),
@@ -27,19 +31,27 @@ for name, cls in [
     _stub(name, cls)
 
 # Stubs adicionales requeridos por ``compile_cmd``.
-sys.modules.setdefault("cobra.cli.commands.base", types.SimpleNamespace(BaseCommand=object))
+sys.modules.setdefault(
+    "cobra.cli.commands.base", types.SimpleNamespace(BaseCommand=object)
+)
 sys.modules.setdefault("cobra.cli.i18n", types.SimpleNamespace(_=lambda s: s))
 sys.modules.setdefault(
     "cobra.cli.utils.messages",
-    types.SimpleNamespace(mostrar_error=lambda *a, **k: None, mostrar_info=lambda *a, **k: None),
+    types.SimpleNamespace(
+        mostrar_error=lambda *a, **k: None, mostrar_info=lambda *a, **k: None
+    ),
 )
-sys.modules.setdefault("core.ast_cache", types.SimpleNamespace(obtener_ast=lambda code: None))
+sys.modules.setdefault(
+    "core.ast_cache", types.SimpleNamespace(obtener_ast=lambda code: None)
+)
 sys.modules.setdefault(
     "core.sandbox", types.SimpleNamespace(validar_dependencias=lambda *a, **k: None)
 )
 sys.modules.setdefault(
     "core.semantic_validators",
-    types.SimpleNamespace(PrimitivaPeligrosaError=Exception, construir_cadena=lambda: None),
+    types.SimpleNamespace(
+        PrimitivaPeligrosaError=Exception, construir_cadena=lambda: None
+    ),
 )
 
 # Pre-importa ``cobra.core`` para estabilizar las dependencias internas.
@@ -50,6 +62,13 @@ from cobra.cli.commands.compile_cmd import (
     MAX_LANGUAGES,
     PROCESS_TIMEOUT,
 )
+
+# Los stubs son locales a la importación de ``compile_cmd`` y no deben contaminar
+# la colección de otros módulos de prueba.
+for _module_name in set(sys.modules) - set(_modules_before):
+    del sys.modules[_module_name]
+sys.modules.update(_modules_before)
+del _modules_before
 
 
 def dummy_executor(params):


### PR DESCRIPTION
### Motivation

- Cerrar la regresión de CI introducida tras #3443 que hacía fallar lint/colección por stubs globales y faltas de importación usadas en validaciones de extensiones. 
- Aplicar cambios mínimos e incrementales que restauren la verificación de extensiones y el aislamiento de la colección de tests sin tocar Lexer/Parser, gramática, tokens, `constant_folder` ni `src/pcobra/core/ast_nodes.py`.

### Description

- Restaura la importación de `es_fuente_cobra` en `src/pcobra/cobra/cli/services/test_service.py` y `src/pcobra/cobra/cli/services/verification_service.py` para corregir los errores `F821` detectados por `ruff`.
- Aísla los stubs que el test `tests/unit/test_run_transpiler_pool.py` crea en `sys.modules` capturando el snapshot previo y restaurándolo tras importar `compile_cmd`, evitando contaminación global durante la colección de pytest.
- Ajustes menores de formato y wrapping en las funciones y llamadas afectadas para cumplir `black` en los archivos modificados; no se hizo reformateo masivo del repositorio.

### Testing

- Ejecutadas comprobaciones estáticas y de empaquetado: `python -m compileall src` (OK), `ruff check .` (OK), y `black --check` restringido a los archivos modificados (OK); `black --check .` global sigue reportando archivos fuera de formato y no se corrigieron por alcance incremental.
- Pytest: `python -m pytest --collect-only -q` sobre el árbol modificado recogió **4934** tests; ejecución completa `python -m pytest -q` en el entorno mostró **4372 passed, 508 failed, 53 skipped, 30 warnings, 3 errors** (duración total ~7m39s) y los tests específicamente dirigidos (`tests/unit/test_run_transpiler_pool.py` y `tests/unit/test_to_python_extras.py`) pasaron localmente (`8 passed, 1 warning`).
- Empaquetado y smoke: `python -m build` generó `dist/pcobra-10.1.1-py3-none-any.whl` y `tar.gz`; instalación en un venv limpio e import/ejecución fuera del repo completadas satisfactoriamente y la ejecución mínima `cobra run minimo.cobra` devolvió `wheel-ok` bajo `SQLITE_DB_KEY=smoke-test-key`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78588884748327be8a180ff3425de5)