### PR TITLE
fix(docs): synchronize generated CLI examples to use .cobra

### DIFF
--- a/docs/_generated/cli_backend_examples.rst
+++ b/docs/_generated/cli_backend_examples.rst
@@ -1,5 +1,5 @@
 .. code-block:: bash
 
-   cobra compilar programa.co --tipo python
-   cobra compilar programa.co --tipo javascript
-   cobra compilar programa.co --tipo rust
+   cobra compilar programa.cobra --tipo python
+   cobra compilar programa.cobra --tipo javascript
+   cobra compilar programa.cobra --tipo rust


### PR DESCRIPTION
### Motivation

- Sincronizar el fragmento RST generado de ejemplos CLI para que use la extensión normativa `.cobra` y así cerrar la regresión detectada en la etapa “Regenerate targets docs and verify clean diff” del job CI.

### Description

- Se actualizó únicamente el artefacto generado `docs/_generated/cli_backend_examples.rst` reemplazando `programa.co` por `programa.cobra`, sin tocar Lexer/Parser ni modificar la lógica de los generadores.

### Testing

- Se ejecutaron los generadores con Python 3.11 (`python scripts/generate_target_policy_docs.py` y `python scripts/generar_matriz_transpiladores.py`) y la segunda ejecución fue idéntica byte a byte; la prueba dirigida `python -m pytest tests/unit/test_targets_docs_generated_blocks_snapshot.py` pasó (4 tests); el script `scripts/ci/ensure_generated_targets_docs_clean.py` confirmó que no quedan cambios sin sincronizar; `git diff --check` no mostró problemas y no se modificaron archivos de Lexer/Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7887896abc83278bd96d585bce434c)