### PR TITLE
fix(codeql): update custom query to current Python AST API

### DIFF
--- a/.github/codeql/custom/missing-codegen-exception.ql
+++ b/.github/codeql/custom/missing-codegen-exception.ql
@@ -4,12 +4,12 @@ import python
  * Reporta métodos "generate_code" en los transpiladores que no contienen
  * sentencias try/except para manejar excepciones durante la generación de código.
  */
-from Method m, File f
+from Function m, File f
 where
   m.getName() = "generate_code" and
-  m.getFile() = f and
-  f.getRelativePath().regexp("^src/cobra/transpilers/transpiler/") and
+  m.getLocation().getFile() = f and
+  f.getRelativePath().regexpMatch("^src/cobra/transpilers/transpiler/.*") and
   not exists(Try t |
-    t.getEnclosingCallable() = m
+    t.getScope() = m
   )
 select m, "Falta manejo de excepciones durante la generación de código"

--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -38,9 +38,15 @@ def test_codeql_custom_queries_resolve_from_repository_root() -> None:
         assert (ROOT / query_path).is_file(), query_path
 
 
-def test_missing_codegen_exception_uses_supported_try_type() -> None:
-    """Evita reintroducir el tipo inexistente ``TryStmt`` en la query."""
+def test_missing_codegen_exception_uses_supported_try_api() -> None:
+    """Evita reintroducir tipos o relaciones inexistentes para ``Try``."""
     query = MISSING_CODEGEN_EXCEPTION_QUERY.read_text(encoding="utf-8")
 
+    assert "from Function m, File f" in query
+    assert "m.getLocation().getFile() = f" in query
+    assert 'regexpMatch("^src/cobra/transpilers/transpiler/.*")' in query
     assert "exists(Try t |" in query
+    assert "t.getScope() = m" in query
+    assert "from Method" not in query
     assert "TryStmt" not in query
+    assert "getEnclosingCallable" not in query


### PR DESCRIPTION
### Motivation

- El workflow CodeQL en el commit fijado falló al compilar consultas personalizadas debido a usos de la API AST obsoleta (error: `getEnclosingCallable() cannot be resolved for type Stmts::Try`).
- La intención es adaptar la consulta que falla al API vigente de `codeql/python-all` (CLI `2.26.2`) conservando el predicado de seguridad original y sin tocar otras consultas.

### Description

- Actualiza `.github/codeql/custom/missing-codegen-exception.ql` para usar la API vigente: cambia `from Method` a `from Function`, usa `m.getLocation().getFile() = f`, usa `f.getRelativePath().regexpMatch(...)` y reemplaza `t.getEnclosingCallable() = m` por `t.getScope() = m` para enlazar `Try` al ámbito correcto.
- Modifica `tests/test_codeql_config.py` renombrando la prueba de contrato a `test_missing_codegen_exception_uses_supported_try_api` y añadiendo aserciones que comprueban las cadenas y relaciones usadas (`from Function`, `m.getLocation().getFile() = f`, `regexpMatch(...)`, `t.getScope() = m`) y que evitan reintroducir `Method`, `TryStmt` o `getEnclosingCallable`.
- No se tocan Lexer, Parser, sintaxis Cobra ni documentación normativa; el cambio es incremental y limitado a la consulta que fallaba y su prueba de compilación.

### Testing

- Ejecuté `python -m pytest -q tests/test_codeql_config.py` y la suite pasó: `3 passed`.
- Compilé la consulta con CodeQL CLI `2.26.2`: `codeql query compile --search-path=/tmp/codeql-repo:. .github/codeql/custom/missing-codegen-exception.ql` y la compilación de la consulta corregida completó correctamente.
- Creé base y ejecuté la consulta contra la DB con CodeQL (`codeql database create` y `codeql query run` + `bqrs decode`) y obtuve resultados esperados para la consulta corregida; la evaluación dirigida produjo salida CSV decodificada.
- Intentos de empaquetado/compilación del pack dejaron compilada sólo la consulta corregida; las otras consultas cargadas (`ast-no-type-validation.ql`, `unsafe-eval-exec.ql`) siguen mostrando errores independientes y no fueron modificadas por diseño (señalados como hallazgos separados en los logs de CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a796d79bed48327b1d7e4460cb8779a)