### PR TITLE
fix(examples): restaurar snapshots de salida del transpiler y añadir auditoría de suite completa

### DIFF
--- a/docs/auditorias/3448_suite_completa/README.md
+++ b/docs/auditorias/3448_suite_completa/README.md
@@ -1,0 +1,95 @@
+# Auditoría diferencial de la suite completa — cierre posterior a #3448
+
+## Alcance y entorno reproducible
+
+Se auditó el HEAD inicial `6331ec3b` contra el baseline solicitado
+`96d70b1ba00f07608b0fc2a780fca0e7d6b09257`. Ambos árboles se ejecutaron de
+forma secuencial con el mismo intérprete (`Python 3.12.13`), ejecutable
+(`/root/.pyenv/shims/python`), dependencias instaladas (`pytest 9.0.3`,
+`pluggy 1.6.0`, `flet 0.86.1`, `anyio 4.13.0`), variables heredadas y comando.
+No se usó `--maxfail`.
+
+```bash
+# current, desde /workspace/pCobra en 6331ec3b
+python --version
+python -m pytest --version
+python -m pytest
+
+# baseline solicitado
+git worktree add --detach /tmp/pcobra-baseline-96d70b1b \
+  96d70b1ba00f07608b0fc2a780fca0e7d6b09257
+(cd /tmp/pcobra-baseline-96d70b1b && python -m pytest)
+
+# normalización local (los archivos /tmp no se versionan)
+awk '/^=+ short test summary info =+/{p=1;next} p && /^=/{exit} \
+  p && /^(FAILED|ERROR) /{sub(/ - .*/,""); sub(/^(FAILED|ERROR) /,""); print}' \
+  /tmp/pcobra-current-pytest.log | sort -u > /tmp/current-nodes.txt
+comm -13 /tmp/baseline-nodes.txt /tmp/current-nodes.txt
+comm -23 /tmp/baseline-nodes.txt /tmp/current-nodes.txt
+```
+
+La suite base terminó con `507 failed, 4372 passed, 54 skipped, 3 errors`
+(510 node IDs no satisfactorios); current inicial terminó con `514 failed,
+4365 passed, 54 skipped, 3 errors` (517). No hubo errores de colección en
+ninguno de los dos árboles: los tres `ERROR` son errores de setup de la caché
+SQLite, presentes en ambos. Tras corregir los seis snapshots dañados, current
+normalizado queda en 511 node IDs: no se vuelve a presentar una suite completa
+como verde ni se deduce ausencia de regresiones del total agregado.
+
+## Comparaciones adicionales de la familia responsable
+
+El cambio responsable de los daños nuevos es la familia de formateo
+`92e3291d` (integrada por `728e3633`). Se seleccionó también su commit
+inmediatamente anterior, `f92f5f5863ef51d9722cdaea7a1c42619135e9a8`, en
+vez de usar `master` como sustituto del baseline. `master` queda únicamente
+como comparación secundaria y no fue necesaria para decidir causalidad.
+
+```bash
+git worktree add --detach /tmp/pcobra-pre-format \
+  f92f5f5863ef51d9722cdaea7a1c42619135e9a8
+(cd /tmp/pcobra-pre-format && \
+  python -m pytest -q tests/test_ejemplos_io.py::test_build_coincide_con_archivo)
+python -m pytest -q tests/test_ejemplos_io.py::test_build_coincide_con_archivo
+```
+
+Los seis casos pasan en el commit anterior (6/6), fallan en el HEAD inicial
+(0/6) y vuelven a pasar después de restaurar los snapshots (6/6).
+
+## Resultados normalizados por causa raíz
+
+La clasificación se realizó sobre node IDs únicos, no sobre el número de
+líneas `F` ni sobre el agregado de pytest. “Current” refleja el estado después
+de la única remediación permitida; por ello totaliza 511.
+
+| Familia | Baseline | Current | Delta | Clasificación | Evidencia |
+|---|---:|---:|---:|---|---|
+| Colección/imports | 4 | 4 | 0 | Histórica | Mismos cuatro node IDs de importación; 0 errores de colección. Los 3 `ERROR` SQLite también coinciden exactamente. |
+| Contratos deliberadamente endurecidos | 25 | 25 | 0 | Mixta: histórica, una mejora y una regresión bloqueada | Desaparece `test_snippets_generados_siguen_sincronizados_con_la_fuente_canonica` (mejora), pero aparece el guard de hash de Lexer/Parser. Los demás contratos son compartidos y se consideran históricos o pruebas obsoletas por contrato deliberado según sus mensajes de policy. |
+| Dependencias/herramientas externas | 25 | 25 | 0 | Histórica | Mismos node IDs de Jupyter, AGIX, Qualia, Flet y bridges en ambos árboles. |
+| Plataforma | 0 | 1 | +1 | Histórica/intermitente, no atribuible | `test_js_detecta_reemplazo_binario` alterna incluso en baseline (dos fallos y un pase en tres repeticiones); depende de una carrera al reemplazar el ejecutable falso. |
+| Transpilers | 189 | 189 | 0 | Histórica | Conjunto normalizado compartido después de retirar los seis snapshots alterados accidentalmente. |
+| Runtime/sandbox | 144 | 144 | 0 | Histórica o prueba obsoleta por contrato deliberado | Mismos node IDs de REPL, `usar`, intérprete, safe mode y límites en ambos árboles. |
+| Packaging | 10 | 10 | 0 | Histórica | Mismos node IDs de wheel, installer y empaquetado. |
+| Defectos funcionales | 113 | 113 | 0 | Histórica | Resto exacto del conjunto compartido, sin node IDs exclusivos. |
+| **Total** | **510** | **511** | **+1** | **Una regresión bloqueada; seis regresiones corregidas** | La diferencia residual es el guard de integridad de Lexer/Parser; el caso JS es intermitente histórico aunque no apareciera en aquella ejecución completa del baseline. |
+
+## Investigación exhaustiva de node IDs exclusivos de current inicial
+
+| Node ID/familia | Investigación y clasificación | Decisión |
+|---|---|---|
+| `test_integridad_estatica_lexer_y_parser_sin_diff_inesperado` | El hash de `src/pcobra/cobra/core/lexer.py` cambió solo por formateo en `92e3291d`; `parser.py` también fue reformateado. Regresión real atribuible a la rama. | **Bloqueada**: la orden prohíbe modificar Lexer y Parser. No se cambia el guard ni sus hashes para ocultarla. |
+| Los seis parámetros de `tests/test_ejemplos_io.py::test_build_coincide_con_archivo` | Black reformateó snapshots byte-a-byte, pero el transpilador sigue emitiendo el formato canónico anterior. El commit inmediatamente anterior pasa 6/6. Regresión real de artefactos de salida. | **Corregida** en un commit independiente restaurando exactamente los snapshots previos; no se cambia el código Cobra ni la prueba. |
+| `tests/unit/test_security_sandbox.py::test_js_detecta_reemplazo_binario` | La misma prueba falla 2/3 y pasa 1/3 en baseline; en current falla 3/3. El diff de la familia solo reformatea el test y sandbox sin cambio semántico. | Histórica/intermitente de plataforma; no atribuible a la rama y no corregida en este cierre incremental. |
+
+El único node ID exclusivo de baseline,
+`test_snippets_generados_siguen_sincronizados_con_la_fuente_canonica`, pasa en
+current gracias a la sincronización documental y se clasifica como **mejora**.
+
+## Restricciones verificadas
+
+No se modificaron Lexer, Parser, gramática, tokens, `constant_folder` ni
+`src/pcobra/core/ast_nodes.py` durante esta remediación. En particular, la
+regresión de hashes se deja documentada como bloqueo en lugar de infringir la
+restricción. Los logs completos y las listas normalizadas permanecen solo en
+`/tmp`; este artefacto contiene resultados, comandos y evidencia resumida, no
+outputs temporales.

--- a/tests/data/expected_examples/async_await.py
+++ b/tests/data/expected_examples/async_await.py
@@ -2,29 +2,10 @@ import asyncio
 from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
-
-globals().update(
-    {
-        name: getattr(_pcobra_corelibs, name)
-        for name in dir(_pcobra_corelibs)
-        if not name.startswith("_")
-    }
-)
-globals().update(
-    {
-        name: getattr(_pcobra_standard_library, name)
-        for name in dir(_pcobra_standard_library)
-        if not name.startswith("_")
-    }
-)
-
-
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 async def saluda():
     print(1)
-
-
 async def principal():
     await saluda()
-
-
 asyncio.run(principal())

--- a/tests/data/expected_examples/ejemplo.py
+++ b/tests/data/expected_examples/ejemplo.py
@@ -1,19 +1,6 @@
 from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
-
-globals().update(
-    {
-        name: getattr(_pcobra_corelibs, name)
-        for name in dir(_pcobra_corelibs)
-        if not name.startswith("_")
-    }
-)
-globals().update(
-    {
-        name: getattr(_pcobra_standard_library, name)
-        for name in dir(_pcobra_standard_library)
-        if not name.startswith("_")
-    }
-)
-print("hola")
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
+print('hola')

--- a/tests/data/expected_examples/factorial_recursivo.py
+++ b/tests/data/expected_examples/factorial_recursivo.py
@@ -1,28 +1,11 @@
 from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
-
-globals().update(
-    {
-        name: getattr(_pcobra_corelibs, name)
-        for name in dir(_pcobra_corelibs)
-        if not name.startswith("_")
-    }
-)
-globals().update(
-    {
-        name: getattr(_pcobra_standard_library, name)
-        for name in dir(_pcobra_standard_library)
-        if not name.startswith("_")
-    }
-)
-
-
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def factorial(n):
     if n <= 1:
         return 1
     else:
         return n * factorial(n - 1)
-
-
 print(factorial(5))

--- a/tests/data/expected_examples/hola.py
+++ b/tests/data/expected_examples/hola.py
@@ -1,19 +1,6 @@
 from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
-
-globals().update(
-    {
-        name: getattr(_pcobra_corelibs, name)
-        for name in dir(_pcobra_corelibs)
-        if not name.startswith("_")
-    }
-)
-globals().update(
-    {
-        name: getattr(_pcobra_standard_library, name)
-        for name in dir(_pcobra_standard_library)
-        if not name.startswith("_")
-    }
-)
-print("Hola Cobra")
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
+print('Hola Cobra')

--- a/tests/data/expected_examples/suma.py
+++ b/tests/data/expected_examples/suma.py
@@ -1,26 +1,9 @@
 from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
-
-globals().update(
-    {
-        name: getattr(_pcobra_corelibs, name)
-        for name in dir(_pcobra_corelibs)
-        if not name.startswith("_")
-    }
-)
-globals().update(
-    {
-        name: getattr(_pcobra_standard_library, name)
-        for name in dir(_pcobra_standard_library)
-        if not name.startswith("_")
-    }
-)
-
-
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def sumar(a, b):
     c = a + b
     print(c)
-
-
 sumar(2, 3)

--- a/tests/data/expected_examples/suma_matrices.py
+++ b/tests/data/expected_examples/suma_matrices.py
@@ -1,23 +1,8 @@
 from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
-
-globals().update(
-    {
-        name: getattr(_pcobra_corelibs, name)
-        for name in dir(_pcobra_corelibs)
-        if not name.startswith("_")
-    }
-)
-globals().update(
-    {
-        name: getattr(_pcobra_standard_library, name)
-        for name in dir(_pcobra_standard_library)
-        if not name.startswith("_")
-    }
-)
-
-
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def sumar_matriz():
     a11 = 1
     a12 = 2
@@ -31,6 +16,4 @@ def sumar_matriz():
     print(a12 + b12)
     print(a21 + b21)
     print(a22 + b22)
-
-
 sumar_matriz()


### PR DESCRIPTION
### Motivation

- Corregir una regresión en seis snapshots de ejemplos generados que fueron reformateados accidentalmente por el flujo de formateo y que rompían pruebas de comparación de salida sin cambiar la emisión real del transpiler.
- Documentar de forma reproducible la comparación entre el árbol actual y el baseline solicitado para justificar qué fallos son regresiones reales y cuáles son históricas o intermitentes.
- Respetar la regla de no tocar Lexer, Parser, gramática ni nodos AST y dejar bloqueadas las regresiones que solo podrían resolverse violando esa restricción.

### Description

- Se restauraron los snapshots esperados generados por el transpiler en seis ficheros de ejemplos bajo `tests/data/expected_examples/` para coincidir exactamente con la salida del transpiler (archivos actualizados: `async_await.py`, `ejemplo.py`, `factorial_recursivo.py`, `hola.py`, `suma.py`, `suma_matrices.py`).
- Se añadió `docs/auditorias/3448_suite_completa/README.md` que contiene la auditoría diferencial completa, la tabla normalizada por node ID, la clasificación por causa raíz y comandos reproducibles para replicar los análisis locales.
- Verifiqué explícitamente que no se modificaron Lexer, Parser, tokens, `constant_folder` ni `src/pcobra/core/ast_nodes.py` como parte de esta remediación y dejé documentada la regresión de integridad como bloqueo cuando así aplicó.
- La intervención se limitó a restaurar snapshots y añadir la auditoría; no se relajaron aserciones ni se eliminaron pruebas.

### Testing

- Ejecuté la suite completa con `python -m pytest` sobre el árbol actual y registré el resultado: 514 failed, 4365 passed, 54 skipped, 3 errors; la ejecución se hizo sin `--maxfail` y se exportaron los node IDs fallidos para normalización.
- Ejecuté la misma suite sobre el baseline solicitado con el mismo intérprete y dependencias y obtuve: 507 failed, 4372 passed, 54 skipped, 3 errors; los errores de setup de cache SQLite son coincidentes en ambos árboles.
- Verifiqué la familia responsable comparando también el padre inmediato y ejecuté `tests/test_ejemplos_io.py::test_build_coincide_con_archivo`, que pasó 6/6 en el padre inmediato y vuelve a pasar 6/6 tras restaurar los snapshots, confirmando la corrección focalizada.
- Probé `tests/unit/test_security_sandbox.py::test_js_detecta_reemplazo_binario` para validar comportamiento intermitente y confirmé que ese caso es histórico/plataforma (fallos intermitentes tanto en baseline como en current) y por tanto no fue modificado como parte de esta remediación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79782f559c8327804057eec2505bb5)