### PR TITLE
test(packaging): audit wheel namespace in isolation

### DIFF
--- a/tests/cli/test_packaging_smoke.py
+++ b/tests/cli/test_packaging_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,23 @@ pytest.importorskip("build")
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _paquetes_importables_top_level(wheel: Path) -> set[str]:
+    """Separa paquetes importables de metadatos y datos internos del wheel."""
+
+    extensiones_importables = (".py", ".pyc", ".so", ".pyd")
+    with zipfile.ZipFile(wheel) as archivo:
+        nombres = [Path(nombre) for nombre in archivo.namelist()]
+
+    paquetes = set()
+    for ruta in nombres:
+        top_level = ruta.parts[0]
+        if top_level.endswith((".dist-info", ".data")):
+            continue
+        if ruta.as_posix().endswith(extensiones_importables):
+            paquetes.add(top_level if len(ruta.parts) > 1 else ruta.stem)
+    return paquetes
+
+
 @pytest.mark.integration
 def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
     """Ejecuta intérprete y corelibs usando exclusivamente el wheel instalado."""
@@ -21,7 +39,15 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
     dist_dir.mkdir(parents=True, exist_ok=True)
 
     build_result = subprocess.run(
-        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--sdist",
+            "--outdir",
+            str(dist_dir),
+        ],
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,
@@ -34,6 +60,11 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
 
     wheels = sorted(dist_dir.glob("*.whl"))
     assert wheels, "No se generó wheel durante el smoke test de packaging."
+    assert list(dist_dir.glob("*.tar.gz")), "No se generó sdist durante el smoke test."
+    assert _paquetes_importables_top_level(wheels[0]) == {"pcobra"}, (
+        "El wheel debe publicar exclusivamente el namespace top-level pcobra; "
+        "los directorios .dist-info y .data se clasifican como metadatos/datos."
+    )
 
     venv_dir = tmp_path / "venv"
     subprocess.run(
@@ -51,7 +82,12 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
         venv_pip = venv_dir / "bin" / "pip"
 
     subprocess.run(
-        [str(venv_pip), "install", "--force-reinstall", str(wheels[0])],
+        [
+            str(venv_pip),
+            "install",
+            "--force-reinstall",
+            str(wheels[0]),
+        ],
         check=True,
         capture_output=True,
         text=True,
@@ -71,7 +107,14 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
         "    raise SystemExit(f'una carpeta src está presente en sys.path: {sys.path!r}')\n"
         "ast_nodes = importlib.import_module('pcobra.core.ast_nodes')\n"
         "assert ast_nodes.NodoAST.__module__ == 'pcobra.core.ast_nodes'\n"
-        "assert importlib.util.find_spec('core') is None, 'el wheel instaló el namespace top-level core'\n"
+        "for legacy in ('core', 'cobra'):\n"
+        "    assert importlib.util.find_spec(legacy) is None, f'el wheel instaló el namespace top-level {legacy}'\n"
+        "    try:\n"
+        "        importlib.import_module(legacy)\n"
+        "    except ModuleNotFoundError:\n"
+        "        pass\n"
+        "    else:\n"
+        "        raise AssertionError(f'import {legacy} se resolvió desde el wheel')\n"
         "consultas_src = []\n"
         "def auditar(evento, args):\n"
         "    if evento == 'open' and args and isinstance(args[0], (str, bytes)):\n"
@@ -80,6 +123,7 @@ def test_wheel_instalado_resuelve_usar_sin_checkout(tmp_path: Path) -> None:
         "            consultas_src.append(str(ruta))\n"
         "sys.addaudithook(auditar)\n"
         "import pcobra\n"
+        "assert {'cobra', 'core', 'cli', 'gui', 'lsp'} <= set(pcobra.__all__)\n"
         "from pcobra.cobra.core.lexer import Lexer\n"
         "from pcobra.cobra.core.parser import Parser\n"
         "from pcobra.cobra.core.runtime import InterpretadorCobra\n"


### PR DESCRIPTION
### Motivation

- Asegurar que el wheel publicado contiene únicamente el namespace importable `pcobra` y no introduce paquetes top-level inesperados como `core` o `cobra`.
- Reforzar el smoke test de packaging para construir y validar tanto `wheel` como `sdist` usando el procedimiento de CI (`python -m build`) y evitar resoluciones desde el checkout durante la instalación.
- Detectar fugas de `src/` o importaciones no intencionadas desde el artifact instalado en un entorno aislado.

### Description

- Añadida la función de utilidad `_paquetes_importables_top_level(wheel: Path)` que inspecciona el contenido del wheel y distingue paquetes importables de metadatos y datos internos usando `zipfile`.
- Modificado `tests/cli/test_packaging_smoke.py` para construir `--wheel` y `--sdist`, exigir la presencia del sdist y verificar que el único top-level importable sea `pcobra`.
- Añadidas comprobaciones que aseguran que `import core` y `import cobra` no se resuelven desde la distribución (se usa `importlib.util.find_spec` y un intento efectivo de importación controlado), además de validar `pcobra.__all__` para las superficies públicas esperadas.
- Solo se modificó el test `tests/cli/test_packaging_smoke.py`; no se tocaron `Lexer` ni `Parser` y los cambios son una prueba adicional de auditoría de packaging.

### Testing

- Ejecutado `rm -rf build dist; python -m build --wheel --sdist --outdir dist` y la construcción produjo `pcobra-10.1.1-py3-none-any.whl` y `pcobra-10.1.1.tar.gz` con salida esperada.
- Inspección del wheel con `zipfile.ZipFile(...).namelist()` confirmó que los únicos top-level fueron `pcobra` y el directorio de metadatos `.dist-info` y que no hubo `core/` ni `cobra/` en el artefacto.
- Ejecutado `python -m pytest tests/cli/test_packaging_smoke.py -m integration -q` con resultado `1 passed in 76.24s`.
- Ejecutado `python -m py_compile tests/cli/test_packaging_smoke.py` y `git diff --check` y ambos checks pasaron; además se limpió `build/`, `dist/`, `.pytest_cache` y `src/pcobra.egg-info` antes del commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a798e4db6ac8327865bb25bd5c3c1e8)