### PR TITLE
fix(docs): avoid false-positive 'node' detection in policy drift linter

### DIFF
--- a/scripts/lint_policy_drift.py
+++ b/scripts/lint_policy_drift.py
@@ -43,6 +43,7 @@ assert_public_targets_contract(
 OFFICIAL = set(PUBLIC_BACKENDS)
 CONTEXT = re.compile(r"(?i)(targets?|backends?|destinos?|--tipo|--destino|--origen)")
 TOKEN = re.compile(r"(?<![\w.+/-])([a-z][a-z0-9_+-]{1,20})(?![\w.+/-])", re.IGNORECASE)
+NODE_IDENTIFIER = re.compile(r"\bnode\s+ids?\b", re.IGNORECASE)
 KNOWN_DISALLOWED = {
     "assembly",
     "assembler",
@@ -135,6 +136,8 @@ def _find_policy_drift(path: Path, content: str) -> list[str]:
         for match in TOKEN.finditer(lowered):
             token = match.group(1).strip()
             if token in OFFICIAL or token in STOPWORDS:
+                continue
+            if token == "node" and NODE_IDENTIFIER.search(line):
                 continue
             if token in KNOWN_DISALLOWED and match.span(1) not in python_names:
                 errors.append(

--- a/tests/unit/test_lint_policy_drift.py
+++ b/tests/unit/test_lint_policy_drift.py
@@ -31,6 +31,20 @@ def test_no_confunde_identificador_node_con_target_prohibido(
     assert lint_policy_drift._find_policy_drift(script, script.read_text()) == []
 
 
+def test_no_confunde_node_ids_de_auditoria_con_target_prohibido(
+    tmp_path, monkeypatch
+) -> None:
+    report = tmp_path / "docs" / "auditorias" / "README.md"
+    report.parent.mkdir(parents=True)
+    report.write_text(
+        "Los fallos actuales de targets son los mismos node IDs que en baseline.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(lint_policy_drift, "ROOT", tmp_path)
+
+    assert lint_policy_drift._find_policy_drift(report, report.read_text()) == []
+
+
 def test_sigue_detectando_target_prohibido_en_literal_python(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
### Motivation

- Prevent false positives where the policy drift linter flags the word `node` in audit text like "node IDs" as an out-of-policy backend while preserving detection of `node` when used as an actual backend target.
- Apply a minimal, localized fix to the linter and add a unit test to document the allowed audit phrase without changing lexical/parser code or public target policy.

### Description

- Added a new regex `NODE_IDENTIFIER` and a narrow check in `scripts/lint_policy_drift.py` to ignore `node` when it appears in contexts like "node ID(s)" while keeping existing prohibitions for `node` used as a target token. 
- Added `test_no_confunde_node_ids_de_auditoria_con_target_prohibido` to `tests/unit/test_lint_policy_drift.py` to ensure the linter no longer flags audit text that mentions "node IDs".
- Changes are limited to `scripts/lint_policy_drift.py` and its unit test and do not modify lexer, parser, AST, or optimization sources.

### Testing

- Ran `python scripts/validate_targets_policy.py` and it exited successfully reporting no policy drift.
- Ran `python scripts/lint_policy_drift.py` and it exited successfully reporting no policy drift, and `pytest -q tests/unit/test_lint_policy_drift.py` passed (4 tests, 0 failures).
- Ran `python scripts/ci/validate_targets.py` and it completed successfully for CI validations related to targets.
- Verified SHA-256 hashes of the protected files `src/pcobra/cobra/core/lexer.py`, `src/pcobra/cobra/core/parser.py`, `src/pcobra/core/ast_nodes.py`, and `src/pcobra/core/optimizations/constant_folder.py` remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79a69df7688327952bf785963b5fdc)