### PR TITLE
ci(black): excluir snapshots Python generados por el transpilador

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,8 @@ target-version = ["py311"]
 extend-exclude = '''(?x)(
   ^docs/frontend/
   | ^docs/build/
+  # Snapshots byte-a-byte del transpilador; Black no debe reescribirlos.
+  | ^/tests/data/expected_examples/[^/]+\.py$
   | ^venv/
   | ^\.venv/
   | ^\.venv-release-test/

--- a/tests/test_tooling_excludes.py
+++ b/tests/test_tooling_excludes.py
@@ -34,6 +34,20 @@ def test_black_excludes_versioned_virtualenvs_and_site_packages() -> None:
         assert matcher.search(path), path
 
 
+def test_black_excludes_only_root_python_transpiler_snapshots() -> None:
+    """Limita la exclusión a los snapshots Python generados del nivel raíz."""
+    black_config = _pyproject()["tool"]["black"]
+    matcher = re.compile(black_config["extend-exclude"], re.VERBOSE)
+
+    assert matcher.search("/tests/data/expected_examples/hola.py")
+    for maintained_path in (
+        "/tests/test_ejemplos_io.py",
+        "/tests/data/expected_examples/features/feature_base/minimal.py",
+        "/src/pcobra/cobra/transpilers/transpiler/to_python.py",
+    ):
+        assert not matcher.search(maintained_path), maintained_path
+
+
 def test_static_validation_tools_exclude_versioned_virtualenvs() -> None:
     """Mantiene alineadas las exclusiones de Ruff, mypy y pytest."""
     tool_config = _pyproject()["tool"]


### PR DESCRIPTION
### Motivation

- Evitar que `black` reformatee snapshots byte-a-byte que son producto del transpilador y que deben compararse exactamente en tests.

### Description

- Añadida una regla mínima a `[tool.black].extend-exclude` en `pyproject.toml` que excluye únicamente archivos `*.py` situados directamente en `tests/data/expected_examples/` y se documenta con un comentario que indica que son "Snapshots byte-a-byte del transpilador".
- Añadida una prueba (`tests/test_tooling_excludes.py`) que valida que la nueva exclusión cubre los snapshots raíz esperados y que no afecta rutas mantenidas (no excluye `tests/`, subárboles de `expected_examples/` ni el código del transpilador).
- Cambios mantenidos mínimos y circunscritos a la configuración de herramientas y a la prueba de verificación de la exclusión; no se tocan `src/`, `Lexer` ni `Parser` ni se listaron archivos individualmente.

### Testing

- Ejecutado `black==26.5.1` con `--check --diff` antes del cambio, que reportó 6 archivos en `tests/data/expected_examples/*.py` que serían reformateados.
- Tras la modificación, `black --check .` devolvió éxito (`RC=0`) y no propone reformateos sobre el árbol del repo.
- Ejecutadas las pruebas automáticas relevantes: `pytest -q tests/test_tooling_excludes.py` (3 passed) y validaciones puntuales de `tests/test_ejemplos_io.py` relacionadas con snapshots; las ejecuciones automáticas vinculadas tuvieron resultado satisfactorio sin fallos.
- `git diff --check` se ejecutó para verificar el parche y no se detectaron problemas de espacio ni cambios no autorizados en Lexer/Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79decc2e4c832789caa639387d401e)