### PR TITLE
test(transpiler): run generated artifact without rewriting

### DIFF
--- a/tests/integration/test_transpiladores.py
+++ b/tests/integration/test_transpiladores.py
@@ -1,9 +1,17 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pcobra
 from pcobra.core.ast_nodes import NodoImprimir, NodoValor
 from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
 
 
-def test_transpilador_python_generacion():
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_transpilador_python_generacion(tmp_path):
     ast = [NodoImprimir(NodoValor("'hola'"))]
     codigo = TranspiladorPython().generate_code(ast)
     assert "from pcobra.cobra.core.nativos import *" in codigo
@@ -12,3 +20,19 @@ def test_transpilador_python_generacion():
     assert "print(" in codigo
     assert "hola" in codigo
     compile(codigo, "<cobra-transpilado>", "exec")
+
+    artefacto = tmp_path / "programa.py"
+    artefacto.write_bytes(codigo.encode("utf-8"))
+    assert artefacto.read_bytes() == codigo.encode("utf-8")
+    assert str(ROOT) not in codigo
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    resultado = subprocess.run(
+        [sys.executable, str(artefacto)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    assert resultado.stdout == "'hola'\n"


### PR DESCRIPTION
### Motivation

- Asegurar que los artefactos generados por `TranspiladorPython.generate_code` se ejecuten sin ser reescritos por la propia prueba y evitar falsos positivos por mutaciones del fichero antes del `subprocess`.
- Evitar rutas absolutas del checkout embebidas en el código transpilado y garantizar que la localización del paquete durante la ejecución del artefacto sea provista sólo vía `env=` del `subprocess`.

### Description

- Modifica `tests/integration/test_transpiladores.py` para parametrizar el test con `tmp_path` y añadir `ROOT = Path(__file__).resolve().parents[2]`.
- Escribe los bytes devueltos por `TranspiladorPython.generate_code` en `tmp_path / "programa.py"`, vuelve a leerlos y aserta igualdad con `artefacto.read_bytes()` para garantizar inmutabilidad del artefacto.
- Añade la aserción `assert str(ROOT) not in codigo` y ejecuta el artefacto con `subprocess.run(..., env=env)` donde `env` es una copia explícita de `os.environ` con solo `PYTHONPATH` ajustado a `str(ROOT / "src")`.
- No se tocaron el generador, la sintaxis Cobra, ni los módulos `Lexer`/`Parser`/runtime.

### Testing

- Ejecuté `pytest -q tests/integration/test_transpiladores.py` y el test modificado pasó (`1 passed`).
- Ejecuté una batería más amplia con `pytest -q tests/unit/test_transpile_python.py tests/test_transpilers.py tests/unit/test_integracion_transpiladores.py`, que mostró regresiones preexistentes no relacionadas con esta modificación (varios asserts de expectativas de comillas y cambios en emisores de `usar_modulo`), resultando en múltiples fallos; no se tocaron esos tests para ocultarlos.
- Ejecuté `pytest -q tests/integration/transpilers/test_language_equivalence_contract.py tests/integration/test_transpilador_syntax.py -k 'python or javascript'` y esa selección integrada pasó (`26 passed, 13 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79e3ba951c83279612b82aebfd1e4a)