### PR TITLE
style(ci): alinea integración del transpiler con Black

### DIFF
--- a/tests/integration/test_transpiladores.py
+++ b/tests/integration/test_transpiladores.py
@@ -7,7 +7,6 @@ import pcobra
 from pcobra.core.ast_nodes import NodoImprimir, NodoValor
 from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 


### PR DESCRIPTION
### Motivation
- Arreglar el fallo del gate de CI de Black causado por una línea en blanco extra en el test de integración del transpiler.

### Description
- Eliminar una línea en blanco en `tests/integration/test_transpiladores.py` para cumplir la comprobación de `black`.
- Cambio mínimo y localizado únicamente al fichero de test sin tocar Lexer, Parser, gramática, tokens, `constant_folder` ni `src/pcobra/core/ast_nodes.py`.
- Las aserciones y el comportamiento del test que genera y ejecuta el artefacto transpiliado se mantienen intactos.

### Testing
- `pytest -q tests/integration/test_transpiladores.py` pasó tras el cambio (1 passed).
- `python -m black --check .` pasó y `git diff --check` no reportó problemas después del arreglo.
- Tests estabilizados ejecutados: `--collect-only` recogió 120 tests y la ejecución arrojó 119 passed y 1 skipped.
- Intenté publicar la rama/crear la PR remota pero el entorno no dispone de credenciales GitHub, por lo que la PR no se pudo crear ni verificar en los checks remotos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79e7c7d354832790993d59b8ce9f8f)