### PR TITLE
ci: allow per-reference historical marker in target audit and add tests

### DIFF
--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -153,6 +153,9 @@ REPO_AUDIT_PUBLIC_TEXT_PREFIXES: tuple[str, ...] = (
     "pcobra.toml",
     "cobra.toml",
 )
+HISTORICAL_TARGET_REFERENCE_PATTERN = re.compile(
+    r"<!-- target-policy: historical-reference -->.*?<!-- /target-policy -->"
+)
 DOC_TABLE_PATHS = (
     "docs/targets_policy.md",
     "docs/matriz_transpiladores.md",
@@ -1135,16 +1138,17 @@ def validate_final_backend_repo_audit() -> list[str]:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
+        auditable_content = HISTORICAL_TARGET_REFERENCE_PATTERN.sub("", content)
         for pattern, description in REPO_AUDIT_FORBIDDEN_TERMS:
-            for match in pattern.finditer(content):
-                line_no = content.count("\n", 0, match.start()) + 1
+            for match in pattern.finditer(auditable_content):
+                line_no = auditable_content.count("\n", 0, match.start()) + 1
                 errors.append(
                     f"{rel}:{line_no}: referencia fuera del conjunto final -> {description}"
                 )
         if rel.startswith(REPO_AUDIT_PUBLIC_TEXT_PREFIXES):
             for pattern, alias in REPO_AUDIT_FORBIDDEN_ALIAS_LITERALS:
-                for match in pattern.finditer(content):
-                    line_no = content.count("\n", 0, match.start()) + 1
+                for match in pattern.finditer(auditable_content):
+                    line_no = auditable_content.count("\n", 0, match.start()) + 1
                     errors.append(
                         f"{rel}:{line_no}: alias legacy literal fuera del conjunto final -> {alias}"
                     )

--- a/tests/unit/test_validate_targets_policy_script.py
+++ b/tests/unit/test_validate_targets_policy_script.py
@@ -128,6 +128,43 @@ def test_ci_validate_targets_fija_ocho_transpilers_y_goldens_exactos():
     assert errors == []
 
 
+def test_auditoria_sintaxis_rechaza_target_publico_invalido(monkeypatch, tmp_path):
+    from scripts.ci import validate_targets as ci_validator
+
+    audit_doc = tmp_path / "docs" / "AUDITORIA_SINTAXIS.md"
+    audit_doc.parent.mkdir()
+    audit_doc.write_text("Target público vigente: llvm\n", encoding="utf-8")
+    monkeypatch.setattr(ci_validator, "ROOT", tmp_path)
+    monkeypatch.setattr(ci_validator, "REPO_AUDIT_SCAN_ROOTS", ("docs",))
+    monkeypatch.setattr(ci_validator, "REPO_AUDIT_ALLOWED_PATH_PREFIXES", tuple())
+    monkeypatch.setattr(ci_validator, "REPO_AUDIT_ALLOWED_FILE_PATHS", frozenset())
+
+    errors = ci_validator.validate_final_backend_repo_audit()
+
+    assert any("docs/AUDITORIA_SINTAXIS.md:1" in error for error in errors)
+    assert any("llvm" in error for error in errors)
+
+
+def test_auditoria_sintaxis_ignora_solo_referencia_historica_marcada(
+    monkeypatch, tmp_path
+):
+    from scripts.ci import validate_targets as ci_validator
+
+    audit_doc = tmp_path / "docs" / "AUDITORIA_SINTAXIS.md"
+    audit_doc.parent.mkdir()
+    audit_doc.write_text(
+        "Referencia retirada: <!-- target-policy: historical-reference -->"
+        "LLVM<!-- /target-policy -->\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ci_validator, "ROOT", tmp_path)
+    monkeypatch.setattr(ci_validator, "REPO_AUDIT_SCAN_ROOTS", ("docs",))
+    monkeypatch.setattr(ci_validator, "REPO_AUDIT_ALLOWED_PATH_PREFIXES", tuple())
+    monkeypatch.setattr(ci_validator, "REPO_AUDIT_ALLOWED_FILE_PATHS", frozenset())
+
+    assert ci_validator.validate_final_backend_repo_audit() == []
+
+
 def test_ci_validate_targets_detecta_documentacion_sdk_divergente(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
### Motivation

- Evitar que referencias históricas en documentos de auditoría sean interpretadas como targets públicos vigentes sin introducir una lista global de exclusiones.
- Añadir cobertura reproducible que verifique que un target público inválido falla el gate y que una referencia marcada como histórica no lo hace.

### Description

- Añade en `scripts/ci/validate_targets.py` el patrón `HISTORICAL_TARGET_REFERENCE_PATTERN` y filtra el contenido encerrado en la marca contextual `<!-- target-policy: historical-reference -->...<!-- /target-policy -->` antes de aplicar las comprobaciones de auditoría de términos y alias prohibidos.
- Modifica la lógica de `validate_final_backend_repo_audit()` para auditar sobre `auditable_content` (contenido con las referencias históricas marcadas removidas) en lugar del texto original completo.
- Añade dos pruebas en `tests/unit/test_validate_targets_policy_script.py`: `test_auditoria_sintaxis_rechaza_target_publico_invalido` que confirma que un target público inválido en `docs/AUDITORIA_SINTAXIS.md` provoca error del gate, y `test_auditoria_sintaxis_ignora_solo_referencia_historica_marcada` que confirma que la referencia delimitada con la anotación no se interpreta como target vigente.
- No se modificó Lexer/Parser, ni se cambió el documento original `docs/AUDITORIA_SINTAXIS.md` ni la sintaxis del lenguaje; los cambios son locales al auditor y a las pruebas.

### Testing

- Ejecuté el gate exacto con `python scripts/validate_targets_policy.py` y su salida confirmó la validación global `OK` para el tree de ejemplo en este entorno.
- Ejecuté las pruebas dirigidas con `pytest -q tests/unit/test_validate_targets_policy_script.py -k 'auditoria_sintaxis'` y ambas pruebas nuevas pasaron (`2 passed`).
- Ejecuté la suite dirigida completa con `pytest -q tests/unit/test_validate_targets_policy_script.py` y quedó una falla preexistente no relacionada (`test_ci_validate_targets_guardrail_permite_exclusiones_de_packaging`) mientras las demás pruebas pasaron (15 passed, 1 failed). 
- Formateo y checks: `python -m black --check scripts/ci/validate_targets.py tests/unit/test_validate_targets_policy_script.py` y `git diff --check` pasaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a1c566dc88327a71518d1eb41b349)