### PR TITLE
fix(core): restore canonical lexer and parser snapshots

### DIFF
--- a/src/pcobra/cobra/core/lexer.py
+++ b/src/pcobra/cobra/core/lexer.py
@@ -14,7 +14,6 @@ from pcobra.cobra.core.errors import InvalidTokenError, LexerError, UnclosedStri
 
 logger = logging.getLogger(__name__)
 
-
 class TipoToken(Enum):
     """Enumeración de todos los tipos de tokens soportados."""
 
@@ -453,7 +452,9 @@ class Lexer:
 
             matched = False
             for tipo, regex in self.especificacion_tokens:
-                coincidencia = regex.match(self.codigo_fuente[self.posicion_codigo :])
+                coincidencia = regex.match(
+                    self.codigo_fuente[self.posicion_codigo :]
+                )
                 if coincidencia:
                     valor_original = coincidencia.group(0)
                     if tipo:

--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -74,6 +74,7 @@ from pcobra.cobra.core.ast_nodes import (
     NodoBloque,
 )
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -82,7 +83,9 @@ ALIAS_DECLARACION_CLASE = (
     TipoToken.ESTRUCTURA,
     TipoToken.REGISTRO,
 )
-ALIAS_DECLARACION_ENUM = (TipoToken.ENUMERACION,)
+ALIAS_DECLARACION_ENUM = (
+    TipoToken.ENUMERACION,
+)
 
 TOKEN_A_LEXEMA = {
     TipoToken.CLASE: "clase",
@@ -230,8 +233,12 @@ class ClassicParser:
         token = self.token_actual()
         if token.tipo not in tipos_validos:
             alias_permitidos = [TOKEN_A_LEXEMA[t] for t in tipos_validos]
-            esperado = self._formatear_lista_palabras(alias_permitidos, conjuncion="o")
-            raise ParserError(f"Se esperaba {esperado} para declarar {descripcion}")
+            esperado = self._formatear_lista_palabras(
+                alias_permitidos, conjuncion="o"
+            )
+            raise ParserError(
+                f"Se esperaba {esperado} para declarar {descripcion}"
+            )
 
         self.avanzar()
 
@@ -907,21 +914,14 @@ class ClassicParser:
         # Si no es una cadena, debe ser una ruta de módulo con identificadores separados por puntos.
         # Un solo identificador sin comillas no es válido.
         if self.token_actual().tipo != TipoToken.IDENTIFICADOR:
-            raise ParserError(
-                "Se esperaba una ruta de módulo entre comillas o identificadores separados por puntos"
-            )
+            raise ParserError("Se esperaba una ruta de módulo entre comillas o identificadores separados por puntos")
 
         # Verificar si es un identificador simple sin puntos (que ahora es un error)
         # o el inicio de una ruta con puntos.
         # Para verificar si es un identificador simple, necesitamos mirar el siguiente token.
         # Si el siguiente token no es un punto, entonces es un identificador simple.
-        if (
-            self.token_siguiente() is None
-            or self.token_siguiente().tipo != TipoToken.PUNTO
-        ):
-            raise ParserError(
-                "Se esperaba una ruta de módulo entre comillas (ej. 'usar \"modulo\"') o identificadores separados por puntos (ej. 'usar modulo.submodulo'). Un solo identificador sin comillas no es válido."
-            )
+        if self.token_siguiente() is None or self.token_siguiente().tipo != TipoToken.PUNTO:
+            raise ParserError("Se esperaba una ruta de módulo entre comillas (ej. 'usar \"modulo\"') o identificadores separados por puntos (ej. 'usar modulo.submodulo'). Un solo identificador sin comillas no es válido.")
 
         partes = [self.token_actual().valor]
         self.comer(TipoToken.IDENTIFICADOR)
@@ -1240,9 +1240,10 @@ class ClassicParser:
                 raise ParserError("Se esperaba un identificador luego de 'como'")
             alias = self.token_actual().valor
             self.comer(TipoToken.IDENTIFICADOR)
-        if alias_token is not None and (
-            False
-            or (token_con.tipo == TipoToken.CON and alias_token.tipo == TipoToken.COMO)
+        if (
+            alias_token is not None
+            and (False
+                 or (token_con.tipo == TipoToken.CON and alias_token.tipo == TipoToken.COMO))
         ):
             expresion_entrada = f"{token_con.valor} ... {alias_token.valor}"
             self.registrar_advertencia(


### PR DESCRIPTION
### Motivation

- Restaurar la integridad canónica de `src/pcobra/cobra/core/lexer.py` y `src/pcobra/cobra/core/parser.py` tras una modificación de formato que provocó una discrepancia en los hashes de guard y bloqueó la validación automatizada.
- Mantener intacta la semántica del frontend del lenguaje y cumplir la restricción de no cambiar gramática, tokens ni AST por esta corrección.

### Description

- Se restauraron las versiones canónicas de `src/pcobra/cobra/core/lexer.py` y `src/pcobra/cobra/core/parser.py` sin ediciones manuales ni ejecución de formateadores sobre los archivos.
- La restauración fue realizada como un cambio independiente que revierte únicamente la deriva de formato y no altera lógica, nombres de tokens, precedencias ni nodos del AST.
- Se verificó estructuralmente que el cambio es puramente de formato comparando los AST Python de las revisiones antes y después, y confirmando que los árboles son idénticos.

### Testing

- Se ejecutó la comparación estructural con `ast.dump(..., include_attributes=False)` para ambos archivos y ambas comparaciones resultaron iguales. 
- Se calcularon los SHA-256 de los archivos restaurados y coinciden con los valores aprobados por el guard de integridad.
- Se corrió el test focal `tests/integration/test_usar_runtime_contract.py::test_integridad_estatica_lexer_y_parser_sin_diff_inesperado` y pasó correctamente. 
- Se ejecutó el conjunto focal de pruebas relacionadas con lexer/parser identificado por búsqueda; el resultado fue `168 passed, 1 skipped, 22 failed`, y los fallos reportados son preexistentes y no introducidos por esta restauración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae0b0c6e88327af3eccd62b4de8b1)