### PR TITLE
fix(codeql): restore custom CodeQL query compatibility

### DIFF
--- a/.github/codeql/custom/unsafe-eval-exec.ql
+++ b/.github/codeql/custom/unsafe-eval-exec.ql
@@ -5,11 +5,11 @@ import python
  */
 from Call c, File f
 where
-  (
-    c.getTarget().hasQualifiedName("builtins", "eval") or
-    c.getTarget().hasQualifiedName("builtins", "exec")
+  exists(GlobalVariable builtin |
+    builtin = c.getFunc().(Name).getVariable() and
+    builtin.getId() in ["eval", "exec"]
   ) and
-  f = c.getFile() and
-  f.getRelativePath().regexp("^src/") and
-  not f.getRelativePath().regexp("^src/core/sandbox.py$")
+  f = c.getLocation().getFile() and
+  f.getRelativePath().regexpMatch("^src/.*") and
+  not f.getRelativePath().regexpMatch("^src/core/sandbox.py$")
 select c, "Uso potencialmente inseguro de eval/exec"

--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -9,6 +9,9 @@ CODEQL_CONFIG = ROOT / ".github" / "codeql" / "custom" / "codeql-config.yml"
 MISSING_CODEGEN_EXCEPTION_QUERY = (
     ROOT / ".github" / "codeql" / "custom" / "missing-codegen-exception.ql"
 )
+UNSAFE_EVAL_EXEC_QUERY = (
+    ROOT / ".github" / "codeql" / "custom" / "unsafe-eval-exec.ql"
+)
 
 
 def _codeql_config_text() -> str:
@@ -50,3 +53,21 @@ def test_missing_codegen_exception_uses_supported_try_api() -> None:
     assert "from Method" not in query
     assert "TryStmt" not in query
     assert "getEnclosingCallable" not in query
+
+
+def test_unsafe_eval_exec_preserves_positive_and_negative_fixtures() -> None:
+    """La query conserva una violación y excluye únicamente el sandbox."""
+    query = UNSAFE_EVAL_EXEC_QUERY.read_text(encoding="utf-8")
+    fixtures = ROOT / "tests" / "unit" / "codeql_fixtures" / "unsafe_eval_exec"
+
+    assert 'regexpMatch("^src/.*")' in query
+    assert 'not f.getRelativePath().regexpMatch("^src/core/sandbox.py$")' in query
+    assert 'builtin.getId() in ["eval", "exec"]' in query
+    assert "f = c.getLocation().getFile()" in query
+    assert 'select c, "Uso potencialmente inseguro de eval/exec"' in query
+    assert "eval(expression)" in (fixtures / "src" / "violation.py").read_text(
+        encoding="utf-8"
+    )
+    assert "eval(expression)" in (
+        fixtures / "src" / "core" / "sandbox.py"
+    ).read_text(encoding="utf-8")

--- a/tests/unit/codeql_fixtures/unsafe_eval_exec/src/core/sandbox.py
+++ b/tests/unit/codeql_fixtures/unsafe_eval_exec/src/core/sandbox.py
@@ -1,0 +1,2 @@
+def evaluate_in_sandbox(expression):
+    return eval(expression)

--- a/tests/unit/codeql_fixtures/unsafe_eval_exec/src/violation.py
+++ b/tests/unit/codeql_fixtures/unsafe_eval_exec/src/violation.py
@@ -1,0 +1,2 @@
+def evaluate(expression):
+    return eval(expression)


### PR DESCRIPTION
### Motivation

- El job de CodeQL en la rama falló porque una query personalizada usaba constructos no soportados por la versión del bundle ejecutada (CodeQL 2.26.2), provocando un error de compilación durante la fase `Perform CodeQL Analysis`.
- Era necesario adaptar únicamente la query incompatible para que use la API proporcionada por `codeql/python-all` sin cambiar el ámbito, la severidad ni el mensaje de la alerta.

### Description

- Reescribí la detección de llamadas a `eval`/`exec` en `.github/codeql/custom/unsafe-eval-exec.ql` usando la API soportada: se reemplazó la comprobación basada en `getTarget().hasQualifiedName(...)` por la resolución del identificador global mediante `c.getFunc().(Name).getVariable()` y `builtin.getId() in ["eval","exec"]`, y se obtuvo el archivo con `c.getLocation().getFile()`; las expresiones regulares pasan a `regexpMatch` para compatibilidad con el pack instalado.
- Conservé el alcance de la query sobre `src` y la exclusión explícita de `src/core/sandbox.py`, así como el mensaje `Uso potencialmente inseguro de eval/exec` y la condición capaz de generar resultados.
- Añadí fixtures de prueba positivos y negativos en `tests/unit/codeql_fixtures/unsafe_eval_exec/src/violation.py` y `.../core/sandbox.py` para que la query detecte la violación y excluya el sandbox.
- Añadí una prueba en `tests/test_codeql_config.py` que verifica la presencia de los cambios API y la existencia de los fixtures para evitar regresiones y que la query no quede vacía.
- No se modificaron Lexer ni Parser ni la documentación de sintaxis; los cambios se limitaron a la query y a las pruebas contractuales.

### Testing

- Descargué y usé el mismo bundle de Actions: CodeQL `2.26.2` (paquetes `codeql/python-all` 7.2.2 y extractor Python 7.1.8) para validar localmente la compatibilidad.
- `codeql query compile --search-path=... .github/codeql/custom/unsafe-eval-exec.ql` — compiló correctamente la query corregida (OK).
- Creación de base y ejecución de la query con `codeql database create` y `codeql query run` sobre los fixtures añadidos — la ejecución generó un único resultado esperado para el fixture positivo y no denunció el archivo del sandbox (OK).
- `codeql bqrs decode` mostró la alerta esperada: la violación se detectó en `tests/unit/codeql_fixtures/unsafe_eval_exec/src/violation.py` (OK).
- `python -m pytest tests/test_codeql_config.py` — todas las pruebas pasaron (4 passed) (OK).
- Intento de compilar el pack completo (`.github/codeql/custom/*.ql`) con CodeQL 2.26.2 falló por incompatibilidades independientes en `ast-no-type-validation.ql` (errores sobre `regexp` y tipos no resueltos), por lo que resolví solo el hallazgo que bloqueaba en esta PR según la regla de resolución incremental.
- Nota: no se abrió PR remoto desde este entorno porque no hay credenciales remotas configuradas; los cambios aplicados están en el repositorio local para revisión y subida desde una sesión autenticada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aeaf89f208327a405afcf94a08332)