### PR TITLE
docs(audit): revalidate runtime security baseline

### DIFF
--- a/docs/auditorias/3450_runtime_security/README.md
+++ b/docs/auditorias/3450_runtime_security/README.md
@@ -100,3 +100,74 @@ ocultar ese error ni impedir que pytest ejecutara los demás casos. No se añadi
 Esta auditoría no modifica runtime, Lexer, Parser, gramática, tokens ni tests.
 Solo incorpora este registro reproducible. Se revisaron el diff final y
 `git diff --check` para evitar cambios accidentales.
+
+## Revalidación de la rama `fb1fe100` (2026-08-11)
+
+Se reutilizaron las selecciones por paths descritas arriba, sin marcadores
+temáticos. La comparación se repitió contra el mismo baseline inmutable
+`96d70b1ba00f07608b0fc2a780fca0e7d6b09257` en un worktree separado. La pareja
+REPL/script conservó exactamente **114 tests collected** y **114 passed, 2
+warnings**:
+
+```console
+python -m pytest --collect-only -q tests/cli/test_repl_script_parity_contract.py tests/integration/test_repl_usar_entrypoints_contract.py
+python -m pytest -q tests/cli/test_repl_script_parity_contract.py tests/integration/test_repl_usar_entrypoints_contract.py
+```
+
+Las familias se ejecutaron por separado expandiendo exclusivamente los paths
+documentados. Los resultados actuales y sus nodeids se contrastaron con la
+misma selección en baseline:
+
+| Familia | Current | Baseline | Comparación por nodeid |
+|---|---:|---:|---|
+| seguridad/capacidades | 169 passed, 7 failed, 13 skipped | 168 passed, 8 failed, 13 skipped | ningún fallo nuevo; pasa ahora `test_js_detecta_reemplazo_binario` |
+| filesystem/sandbox/safe mode focal | 106 passed, 2 failed | los dos nodeids ya fallan en baseline | sin regresión |
+| procesos/red | 63 passed, 2 failed | 63 passed, 2 failed | mismos nodeids |
+| AST identity/compatibility/runtime imports | 77 passed, 1 failed | 77 passed, 1 failed | mismo nodeid |
+| packaging | 52 passed, 5 failed, 1 skipped | igual | mismos nodeids |
+| políticas/documentación | 174 passed, 15 failed, 3 skipped | 171 passed, 16 failed, 3 skipped | ningún fallo nuevo; pasa ahora `test_snippets_generados_siguen_sincronizados_con_la_fuente_canonica`; el aumento neto de dos casos corresponde a pruebas añadidas |
+
+Los fallos compartidos no se consideran verdes ni se atribuyen a esta rama.
+En particular siguen compartidos los dos contratos históricos de imports en
+safe mode, los dos de proceso, el contrato de copia de `NodoTipo`, los cinco de
+packaging y los quince nodeids actuales de policy. Los cuatro fallos JavaScript
+por ausencia de `vm2` también aparecen en baseline; el fallo compartido del
+contrato de namespace de sandbox completa los siete actuales del grupo amplio.
+
+La verificación explícita se ejecutó con el import canónico y devolvió
+`TranspiladorPython().safe_mode = True`:
+
+```console
+python - <<'PY'
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+value = TranspiladorPython().safe_mode
+print(f"TranspiladorPython().safe_mode = {value!r}")
+assert value is True
+PY
+```
+
+Los casos aprobados de `test_remediacion_runtime_contracts.py`,
+`test_usar_symbol_policy.py`, `test_sandbox_paths.py` y
+`test_sandbox_restrictions.py` vuelven a confirmar la policy filesystem por
+`(módulo, símbolo)`, el confinamiento mediante `COBRA_IO_BASE_DIR` y el rechazo
+de traversal y symlinks externos. Los casos aprobados de proceso/red confirman
+`process.spawn`, `capturar`, `ejecutar_async`, `ejecutar_stream`, la exigencia
+de autorización de shell, HTTPS/host, validación de redirects, tamaño máximo,
+destino confinado y escritura atómica. No hubo evidencia directa que
+justificase modificar runtime o seguridad.
+
+### Mecanismos reales de CI
+
+Se ejecutaron individualmente los comandos usados por los workflows, y se
+registraron también sus fallos actuales:
+
+| Comando | Resultado |
+|---|---|
+| `python scripts/ci/validate_targets.py` | **pass**; policy oficial `python, javascript, rust` |
+| `python scripts/validate_targets_policy.py` | **pass**; documentación pública de targets alineada |
+| `python scripts/ci/check_manual_ref_generated.py` | **fail**; `docs/MANUAL_COBRA.rst` está desincronizado con su fuente (el archivo generado durante el check se restauró) |
+| `python scripts/ci/validate_public_docs_version.py` | **fail**; no encuentra versión pública en `docs/guia_basica.md` |
+| `python scripts/ci/validate_syntax_report_contract.py` | **fail**; falta `tests/data/snapshots/validar_sintaxis_report_schema_v1.json` |
+
+No se alteraron Lexer, Parser, runtime, seguridad ni pruebas durante esta
+revalidación.


### PR DESCRIPTION
### Motivation
- Registrar la revalidación reproducible de la auditoría focal de runtime/seguridad contra el baseline inmutable para comprobar que no se introdujeron regresiones y dejar constancia en la documentación.

### Description
- Añadida una sección de “Revalidación” en `docs/auditorias/3450_runtime_security/README.md` que documenta las selecciones por path ejecutadas, el resumen por familias de tests, la confirmación de que no se tocaron Lexer/Parser/runtime y los resultados de los chequeos CI ejecutados durante la revalidación.

### Testing
- Ejecutado `python -m pytest --collect-only -q tests/cli/test_repl_script_parity_contract.py tests/integration/test_repl_usar_entrypoints_contract.py` y `python -m pytest -q` para esa pareja, con resultado `114 tests collected` y `114 passed, 2 warnings`; se ejecutaron además las familias documentadas (seguridad/capacidades, filesystem/sandbox/safe mode, procesos/red, AST identity/compatibility/runtime imports, packaging y políticas) y los resultados actuales coincidieron con el baseline (no se detectaron fallos nuevos, persisten varios fallos históricos documentados); verificado `TranspiladorPython().safe_mode is True`; y corridos los scripts CI relevantes (`python scripts/ci/validate_targets.py`, `python scripts/validate_targets_policy.py`, `python scripts/ci/check_manual_ref_generated.py`, `python scripts/ci/validate_public_docs_version.py`, `python scripts/ci/validate_syntax_report_contract.py`) registrando los pases y las comprobaciones fallidas por desincronización de docs o snapshots faltantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b0804c67083279e214d28d5f7ee7f)