### PR TITLE
fix(ci): instalar dependencias runtime en job Lint usando acción del repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (a26af69be951a213d495a4c3e4e4022e16d87065)
         with:
           python-version: "3.11"
-      - name: Install project-pinned Black
-        run: pip install "$(grep -E '^black==' requirements-dev.txt)"
+      - name: Install dependencies
+        uses: ./.github/actions/install
       - run: black --check .
       - name: Detect legacy target aliases in public docs
         run: python scripts/lint_legacy_aliases.py


### PR DESCRIPTION
### Motivation

- Clasificación A: `requests` ya figura como dependencia runtime en la metadata del proyecto, pero el job `Lint` solo instalaba `black` antes de ejecutar auditorías que importan código runtime, provocando `ModuleNotFoundError: No module named 'requests'` al ejecutar `python scripts/validate_runtime_contract.py`.

### Description

- Cambio mínimo: en `.github/workflows/lint.yml` se reemplaza la instalación puntual de Black por `uses: ./.github/actions/install` para reutilizar la acción del repositorio que instala `requirements-dev.txt` y el paquete editable, sin tocar `src/pcobra/` ni los scripts de auditoría.

### Testing

- Reproducción y verificación ejecutadas en un `venv` limpio: reproduje el `ModuleNotFoundError` al ejecutar `python scripts/validate_runtime_contract.py`, luego instalé `-r requirements-dev.txt` y `-e .` via la acción y volví a ejecutar la secuencia completa de Lint (incluyendo `black --check .`, `python scripts/lint_legacy_aliases.py`, `python scripts/validate_targets_policy.py`, los linters en `scripts/ci/` y `python scripts/validate_runtime_contract.py`); la falta de `requests` quedó resuelta y la suite avanzó hasta fallar en un desalineamiento preexistente de contrato (`USAR_COBRA_PUBLIC_MODULES`) que no fue modificado; además se ejecutaron `git diff --stat` y `git diff --check` y se confirmó que no hay cambios bajo `src/pcobra/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b3c1f477c83278d17f15ff363f4ef)