### PR TITLE
fix(ci): align runtime dependency contract with canonical imports

### DIFF
--- a/scripts/validate_runtime_contract.py
+++ b/scripts/validate_runtime_contract.py
@@ -47,6 +47,17 @@ USAR_COBRA_PUBLIC_MODULES_EXPECTED: tuple[str, ...] = (
     "tiempo",
     "red",
     "holobit",
+    "ruta",
+    "serializacion",
+    "proceso",
+    "registro",
+    "argumentos",
+    "pruebas",
+    "temporal",
+    "cripto",
+    "regex",
+    "compresion",
+    "configuracion",
 )
 
 


### PR DESCRIPTION
### Motivation
- The runtime contract validator compared `USAR_COBRA_PUBLIC_MODULES` against an out-of-date expectation of 10 modules, causing CI gates that run `scripts/validate_runtime_contract.py` to fail; the canonical list is defined in `src/pcobra/cobra/usar_policy.py` and must be reflected in the validator expectation.

### Description
- Updated `USAR_COBRA_PUBLIC_MODULES_EXPECTED` in `scripts/validate_runtime_contract.py` to include the full set of 21 canonical modules (added `"ruta"`, `"serializacion"`, `"proceso"`, `"registro"`, `"argumentos"`, `"pruebas"`, `"temporal"`, `"cripto"`, `"regex"`, `"compresion"`, `"configuracion"`) so the script compares against the authoritative contract declared in `src/pcobra/cobra/usar_policy.py`.
- No changes were made to runtime code, core libraries, `src/pcobra/**`, Lexer/Parser sources, packaging files, or top-level modules; this is strictly a CI/validator expectation alignment.

### Testing
- Reproduced the original failure by running `python scripts/validate_runtime_contract.py` on the baseline, which failed with a `RuntimeError` due to the mismatched `USAR_COBRA_PUBLIC_MODULES` expectation. 
- After updating the expectation, running `python scripts/validate_runtime_contract.py` advanced past the expectation check but surfaced an independent `ContractValidationError` in the stdlib validator (different issue, left for a separate incremental fix). 
- Ran the integration tests `pytest -q tests/integration/test_usar_public_contract_regression.py tests/integration/test_usar_core_contract_full.py`, which completed successfully (39 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c549483448327b7b13d087cff0f78)