### PR TITLE
test(codeql): satisfy harness formatting contract

### DIFF
--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -47,17 +47,10 @@ def test_ast_export_query_uses_formal_isolated_fixtures() -> None:
     """Mantiene los casos deliberados fuera del árbol analizado en producción."""
     config = _codeql_config_text()
     fixture_dir = (
-        ROOT
-        / ".github"
-        / "codeql"
-        / "custom"
-        / "test"
-        / "ast_no_export_validation"
+        ROOT / ".github" / "codeql" / "custom" / "test" / "ast_no_export_validation"
     )
 
-    assert (
-        "  - '.github/codeql/custom/test/ast_no_export_validation/**'" in config
-    )
+    assert "  - '.github/codeql/custom/test/ast_no_export_validation/**'" in config
     assert "  - 'tests/**'" not in config
     assert "  - 'src/**'" not in config
     assert (fixture_dir / "insecure" / "ast-no-export-validation.qlref").read_text(


### PR DESCRIPTION
### Motivation
- Ajustar el formato de `tests/test_codeql_config.py` para que coincida exactamente con la salida de `black` exigida por el harness sin cambiar strings, rutas ni el significado de las aserciones.

### Description
- Se aplicó `black` únicamente a `tests/test_codeql_config.py`, compactando la expresión de `fixture_dir` y una aserción multilínea; no se modificó lógica, fixtures, valores esperados ni archivos de Lexer/Parser, y se creó el commit `165164a7d30e726e76e1180752ee2b01edd81588` con el mensaje `test(codeql): satisfy harness formatting contract`.

### Testing
- Ejecutados `black --check --diff tests/test_codeql_config.py` (salvado en `/tmp/black_test_codeql_config.diff`) y `black tests/test_codeql_config.py` y verificado con `cmp -s` que el archivo resultante coincide byte a byte con la salida de Black; `black --check tests/test_codeql_config.py` indicó `1 file would be left unchanged`, `black --check .` no mostró cambios adicionales (1159 archivos left unchanged), `git diff --check/--stat/--name-status` confirmó que solo `tests/test_codeql_config.py` cambió, y `codeql test run .github/codeql/custom/test/ast_no_export_validation` falló por falta del CLI `codeql` (exit 127), por lo que no se declara CodeQL verde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c568a9af883279eeb126d190c6f57)