### PR TITLE
fix(codeql): invoke initialized CLI for query tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,7 @@ jobs:
             requirements.txt
             requirements-dev.txt
       - name: Initialize CodeQL
+        id: codeql-init
         uses: github/codeql-action/init@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
         with:
           languages: python
@@ -33,6 +34,8 @@ jobs:
       - name: Autobuild
         uses: github/codeql-action/autobuild@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
       - name: Test custom CodeQL queries
-        run: codeql test run .github/codeql/custom/test/ast_no_export_validation
+        run: >-
+          "${{ steps.codeql-init.outputs.codeql-path }}" test run
+          .github/codeql/custom/test/ast_no_export_validation
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3


### PR DESCRIPTION
### Motivation

- Se detectó que en el run remoto de CodeQL (run `31878494549`) el paso `Test custom CodeQL queries` falló con el mensaje `Process completed with exit code 127` y código de terminación `127`, lo que indica que la invocación directa de `codeql` falló porque no había ejecutable en PATH en ese entorno de ejecución.
- La acción fijada `github/codeql-action/init@ad2a4837011b42f6...` expone la ruta del binario a través del output `codeql-path`, por lo que la intención es usar ese output en lugar de invocar `codeql` directamente desde el PATH.
- Revisé los artefactos relevantes de CodeQL (`.github/codeql/custom/qlpack.yml`, `.github/codeql/custom/codeql-config.yml`, el directorio de tests ` .github/codeql/custom/test/ast_no_export_validation/` y `tests/test_codeql_config.py`) y no es necesario ni apropiado cambiar las queries ni sus fixtures para resolver el fallo de invocación.

### Description

- Añadí `id: codeql-init` al paso `Initialize CodeQL` en ` .github/workflows/codeql.yml` para exponer sus outputs.
- Cambié el paso `Test custom CodeQL queries` para invocar el CLI usando el output `steps.codeql-init.outputs.codeql-path`, concretamente `"${{ steps.codeql-init.outputs.codeql-path }}" test run .github/codeql/custom/test/ast_no_export_validation` con formato YAML seguro para evitar errores de parseo.
- El cambio se limita al archivo ` .github/workflows/codeql.yml` y no modifica queries, `.qlref`, `.expected`, fixtures Python, ni los módulos Lexer/Parser del proyecto.

### Testing

- Ejecuté `pytest -q tests/test_codeql_config.py tests/test_workflows_yaml.py` y ambas pruebas pasaron (`27 passed`).
- Validé que ` .github/workflows/codeql.yml` es YAML válido con `yaml.safe_load(...)` y confirmé que `git diff --check` y la verificación de no cambios en Lexer/Parser (`git diff --quiet HEAD -- src/.../lexer.py src/.../parser.py`) son correctos.
- Intenté ejecutar localmente el harness con `codeql test run .github/codeql/custom/test/ast_no_export_validation`, y la invocación directa de `codeql` devolvió `/bin/bash: codeql: command not found` y `HARNESS_EXIT=127`, confirmando la limitación local y justificando la corrección para usar `codeql-path` provisto por la action init.
- Confirmé que la diff resultante se limita a ` .github/workflows/codeql.yml` y que no se realizaron cambios en queries, fixtures ni código del lenguaje.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80392bc6348327a5214182c9e59171)