### PR TITLE
Exponer ejecutar_comando_async en corelibs y documentar bloqueo de contrato runtime

### DIFF
--- a/docs/auditorias/3477_runtime_contract_ejecutar_comando_async/README.md
+++ b/docs/auditorias/3477_runtime_contract_ejecutar_comando_async/README.md
@@ -1,0 +1,123 @@
+# Auditoría 3477: contrato runtime de `ejecutar_comando_async`
+
+## Estado final
+
+**PENDIENTE**.
+
+La corrección focal está presente en la exportación agregada y en el snapshot Python, pero el generador se detiene por un bloqueo independiente formado por los otros trece símbolos indicados abajo. Conforme al alcance de esta auditoría, no se amplió el snapshot para esos símbolos y no se declara resuelto el contrato ni se actualizaron manualmente los artefactos generados.
+
+## Base exacta y alcance
+
+- Base exacta auditada: `0eb83da2310266c55de66ef839c0c32f9475dfae`.
+- Rama de trabajo: `fix/contrato-extensiones-cobra`.
+- Causa raíz demostrada: `ejecutar_comando_async` estaba omitido tanto del import agregado desde `sistema` como de `__all__` en `src/pcobra/corelibs/__init__.py`; a continuación, esa misma omisión quedó reflejada en las listas `global` y `corelibs` del snapshot Python `src/pcobra/cobra/transpilers/runtime_api_parity_snapshot.json`.
+- Remediación focal revisada: importar y publicar `ejecutar_comando_async`, incorporarlo en las dos listas Python del snapshot y añadir una aserción focal para la API global.
+
+## Bloqueo independiente literal
+
+La ejecución del generador posterior a la actualización terminó con código `1` y el siguiente error literal:
+
+```text
+RuntimeError: Snapshot de API Python desactualizado para matriz de paridad. Nuevos símbolos sin mapear: ['contiene', 'ejecutar_proceso', 'falso', 'igual', 'info_registro', 'lanza_error', 'leer_configuracion', 'leer_ini', 'leer_json_serializacion', 'leer_toml', 'toml_disponible', 'unir_ruta', 'verdadero']. Símbolos removidos en Python: [].
+```
+
+Estos trece símbolos constituyen un hallazgo independiente. La remediación se detuvo: no se añadieron al snapshot, no se consideran resueltos y deben tratarse en otra auditoría.
+
+## Artefactos derivados
+
+`python scripts/generar_matriz_api_runtime.py` no llegó a escribir artefactos porque valida el snapshot antes de generarlos. Por tanto, el generador modificó **cero** archivos y, en particular, no modificó ningún artefacto derivado distinto de los dos permitidos:
+
+- `docs/_generated/runtime_api_matrix.json`
+- `docs/_generated/runtime_api_matrix.md`
+
+El JSON derivado conservado no contiene todavía `ejecutar_comando_async` ni en `available_api_by_backend.python.global` ni en `available_api_by_backend.python.corelibs`; ambas consultas `jq -e` devolvieron `false` y código `1`. No se alteró el JSON a mano para ocultar el bloqueo.
+
+## Archivos modificados contra la base
+
+1. `src/pcobra/corelibs/__init__.py`: import y `__all__` agregados.
+2. `src/pcobra/cobra/transpilers/runtime_api_parity_snapshot.json`: entradas Python `global` y `corelibs`.
+3. `tests/unit/test_runtime_api_matrix_contract.py`: prueba focal, además normalizada con Black.
+4. `docs/auditorias/3477_runtime_contract_ejecutar_comando_async/README.md`: esta evidencia.
+
+No se modificaron Lexer, Parser, AST, gramática, `constant_folder`, `interpreter.py`, componentes de seguridad/runtime ni workflows no relacionados.
+
+## Comandos, códigos de salida y resultados
+
+### Error anterior en la base
+
+Se creó un worktree temporal detached en la base exacta y se ejecutó:
+
+```console
+$ python scripts/generar_matriz_api_runtime.py
+RuntimeError: Snapshot de API Python desactualizado para matriz de paridad. Nuevos símbolos sin mapear: ['contiene', 'ejecutar_proceso', 'falso', 'igual', 'info_registro', 'lanza_error', 'leer_configuracion', 'leer_ini', 'leer_json_serializacion', 'leer_toml', 'toml_disponible', 'unir_ruta', 'verdadero']. Símbolos removidos en Python: [].
+[exit 1]
+```
+
+La omisión focal era coherente entre la exportación y el snapshot en esa base, por lo que esa validación de deriva no podía detectarla; la evidencia del defecto es la ausencia en ambos sitios.
+
+### Resultado posterior y verificaciones en el orden solicitado
+
+```console
+$ python scripts/generar_matriz_api_runtime.py
+RuntimeError: Snapshot de API Python desactualizado para matriz de paridad. Nuevos símbolos sin mapear: ['contiene', 'ejecutar_proceso', 'falso', 'igual', 'info_registro', 'lanza_error', 'leer_configuracion', 'leer_ini', 'leer_json_serializacion', 'leer_toml', 'toml_disponible', 'unir_ruta', 'verdadero']. Símbolos removidos en Python: [].
+[exit 1]
+
+$ python scripts/validate_runtime_contract.py
+pcobra.cobra.stdlib_contract.validator.ContractValidationError: cobra.system.ejecutar_comando_async.python: marcado full pero no aparece en runtime_api_matrix.available_api_by_backend.global
+[exit 1]
+
+$ python -m pytest tests/unit/test_runtime_api_matrix_contract.py
+collected 4 items
+tests/unit/test_runtime_api_matrix_contract.py FF.. [100%]
+FAILED test_runtime_api_snapshot_contract_is_up_to_date: bloqueo literal de los trece símbolos
+FAILED test_runtime_api_matrix_has_all_official_backends_and_python_full: la lista contiene 13 elementos
+2 failed, 2 passed in 0.63s
+[exit 1]
+
+$ python -m pytest tests/unit/test_corelibs_sistema.py tests/unit/test_usar_core_all_exports.py tests/test_usar_public_exports_snapshot.py
+collected 20 items
+19 passed, 1 skipped in 1.15s
+[exit 0]
+
+$ black --check src/pcobra/corelibs/__init__.py tests/unit/test_runtime_api_matrix_contract.py
+would reformat tests/unit/test_runtime_api_matrix_contract.py
+1 file would be reformatted, 1 file would be left unchanged.
+[exit 1]
+
+$ black tests/unit/test_runtime_api_matrix_contract.py
+1 file reformatted.
+[exit 0]
+
+$ git diff --check
+[exit 0]
+
+$ jq -e '.available_api_by_backend.python.global | index("ejecutar_comando_async") != null' docs/_generated/runtime_api_matrix.json
+false
+[exit 1]
+
+$ jq -e '.available_api_by_backend.python.corelibs | index("ejecutar_comando_async") != null' docs/_generated/runtime_api_matrix.json
+false
+[exit 1]
+```
+
+La primera comprobación de Black falló realmente y se corrigió el formato; debe repetirse en la revisión final. Los fallos contractuales permanecen como **FAIL**, no como advertencias.
+
+### Repetición final de formato y control del diff
+
+```console
+$ black --check src/pcobra/corelibs/__init__.py tests/unit/test_runtime_api_matrix_contract.py
+All done! ✨ 🍰 ✨
+2 files would be left unchanged.
+[exit 0]
+
+$ git diff --check
+[exit 0]
+
+$ git diff --name-only 0eb83da2310266c55de66ef839c0c32f9475dfae | rg -i '(^|/)(lexer|parser|ast|grammar|gramatica|constant_folder|interpreter)(\\.|/)|(^|/)\\.github/workflows/|seguridad|security|runtime/'
+[sin salida: no se encontró ninguna ruta prohibida]
+[exit 1 de rg por ausencia de coincidencias; verificación satisfactoria]
+
+$ git status --short -- docs/_generated/runtime_api_matrix.json docs/_generated/runtime_api_matrix.md
+[sin salida: ninguno de los dos artefactos fue modificado]
+[exit 0]
+```

--- a/tests/unit/test_runtime_api_matrix_contract.py
+++ b/tests/unit/test_runtime_api_matrix_contract.py
@@ -33,9 +33,10 @@ def test_runtime_api_matrix_has_all_official_backends_and_python_full() -> None:
 def test_python_global_api_includes_ejecutar_comando_async() -> None:
     matrix = build_runtime_api_matrix()
 
-    assert "ejecutar_comando_async" in matrix["available_api_by_backend"]["python"][
-        "global"
-    ]
+    assert (
+        "ejecutar_comando_async"
+        in matrix["available_api_by_backend"]["python"]["global"]
+    )
 
 
 def test_runtime_public_backend_policy_is_exact() -> None:


### PR DESCRIPTION
### Motivation

- Corregir la omisión de `ejecutar_comando_async` en la exportación pública Python para restaurar la paridad del contrato runtime y documentar la causa raíz sin mezclar hallazgos independientes.
- Registrar la base exacta `0eb83da2310266c55de66ef839c0c32f9475dfae` y mantener la remediación focal limitada al símbolo afectado.

### Description

- Se añadió la importación y publicación de `ejecutar_comando_async` en `src/pcobra/corelibs/__init__.py` para exponer la API desde `corelibs`.
- Se incorporó `ejecutar_comando_async` en las listas Python `global` y `corelibs` del snapshot `src/pcobra/cobra/transpilers/runtime_api_parity_snapshot.json`.
- Se añadió una prueba focal `test_python_global_api_includes_ejecutar_comando_async` en `tests/unit/test_runtime_api_matrix_contract.py` y se aplicó formato con `black` a ese archivo.
- Se creó la evidencia de auditoría en `docs/auditorias/3477_runtime_contract_ejecutar_comando_async/README.md` que documenta la causa raíz, los archivos modificados y la reproducción exacta.

### Testing

- `python scripts/generar_matriz_api_runtime.py` → exit 1; el generador abortó al detectar 13 símbolos independientes sin mapear (bloqueo), por lo que no escribió los artefactos derivados.
- `python scripts/validate_runtime_contract.py` → exit 1; fallo porque `cobra.system.ejecutar_comando_async.python` está marcado `full` pero no aparece en `runtime_api_matrix.available_api_by_backend.global` debido al bloqueo del generador.
- `python -m pytest tests/unit/test_runtime_api_matrix_contract.py` → `2 failed, 2 passed`; los dos fallos corresponden al bloqueo independiente de trece símbolos mientras que la nueva aserción focal sobre `ejecutar_comando_async` pasó.
- `python -m pytest tests/unit/test_corelibs_sistema.py tests/unit/test_usar_core_all_exports.py tests/test_usar_public_exports_snapshot.py` → `19 passed, 1 skipped`.
- `black --check` inicialmente indicó reformat necesario y se aplicó `black`, tras lo cual `black --check` informó que los archivos quedaron sin cambios.
- `git diff --check` → exit 0.
- Nota: Los artefactos derivados `docs/_generated/runtime_api_matrix.json` y `docs/_generated/runtime_api_matrix.md` no fueron modificados porque el generador se detuvo antes de escribirlos; estado final de la remediación: **PENDIENTE**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804a1029a48327aec36541b61f3166)