### PR TITLE
fix(codeql): scope assert validation to post init

### DIFF
--- a/.github/codeql/custom/ast-no-type-validation.ql
+++ b/.github/codeql/custom/ast-no-type-validation.ql
@@ -20,7 +20,7 @@ where
       ) or
       // Búsqueda de sentencia assert
       exists(Assert ast |
-        ast.getEnclosingCallable() = m
+        ast.getScope() = m
       )
     )
   )

--- a/.github/codeql/custom/test/ast_no_type_validation/insecure/ast-no-type-validation.expected
+++ b/.github/codeql/custom/test/ast_no_type_validation/insecure/ast-no-type-validation.expected
@@ -1,0 +1,2 @@
+| insecure_type_validation.py:1:1:3:22 | class NodoSinValidacion: ... | El nodo del AST carece de validación de tipos |
+| insecure_type_validation.py:6:1:11:42 | class NodoAssertAjeno: ... | El nodo del AST carece de validación de tipos |

--- a/.github/codeql/custom/test/ast_no_type_validation/insecure/ast-no-type-validation.qlref
+++ b/.github/codeql/custom/test/ast_no_type_validation/insecure/ast-no-type-validation.qlref
@@ -1,0 +1,1 @@
+ast-no-type-validation.ql

--- a/.github/codeql/custom/test/ast_no_type_validation/insecure/insecure_type_validation.py
+++ b/.github/codeql/custom/test/ast_no_type_validation/insecure/insecure_type_validation.py
@@ -1,0 +1,11 @@
+class NodoSinValidacion:
+    def __post_init__(self):
+        self.valor = 1
+
+
+class NodoAssertAjeno:
+    def __post_init__(self):
+        self.valor = 1
+
+    def validar(self):
+        assert isinstance(self.valor, int)

--- a/.github/codeql/custom/test/ast_no_type_validation/safe/ast-no-type-validation.qlref
+++ b/.github/codeql/custom/test/ast_no_type_validation/safe/ast-no-type-validation.qlref
@@ -1,0 +1,1 @@
+ast-no-type-validation.ql

--- a/.github/codeql/custom/test/ast_no_type_validation/safe/safe_type_validation.py
+++ b/.github/codeql/custom/test/ast_no_type_validation/safe/safe_type_validation.py
@@ -1,0 +1,8 @@
+class NodoValidadoConAssert:
+    def __post_init__(self):
+        assert isinstance(self.valor, int)
+
+
+class NodoValidadoConIsinstance:
+    def __post_init__(self):
+        isinstance(self.valor, int)


### PR DESCRIPTION
### Motivation
- Evitar el error `getEnclosingCallable() cannot be resolved for type Stmts::Assert` usando la navegación de API correcta para sentencias `assert` en la librería Python QL.
- Mantener la intención original de la query para detectar clases `Nodo...` cuyo `__post_init__` no valide tipos mediante `isinstance` o `assert` sin cambiar Lexer/Parser ni otras queries.

### Description
- Cambiado únicamente en `/.github/codeql/custom/ast-no-type-validation.ql` la comprobación de `assert` de `ast.getEnclosingCallable() = m` a `ast.getScope() = m` para reflejar la API expuesta por las librerías QL para `Assert`.
- Añadido un directorio de pruebas `/.github/codeql/custom/test/ast_no_type_validation` con casos `safe` y `insecure` que incluyen fixtures: un caso inseguro sin validación, un caso inseguro con `assert` en otro método, un caso seguro con `assert` en `__post_init__` y un caso seguro con `isinstance` en `__post_init__`, y los archivos `.qlref` y `.expected` correspondientes.
- No se modificó `.github/codeql/custom/ast-no-export-validation.ql`, no se tocó Lexer ni Parser, y los cambios están comprometidos en el repositorio (commit `603596d1`).

### Testing
- Ejecuté comprobaciones de git (`git diff --check`, verificación de cambios en Lexer/Parser) que pasaron sin problemas.
- Intenté `codeql test run .github/codeql/custom/test/ast_no_type_validation` con la CLI disponible inicialmente, pero falló porque el pack `codeql/python-all` no estaba instalado; el mensaje fue que hay que ejecutar `codeql pack install` (fallido por ausencia de lock file/paquete).
- Ejecuté `/tmp/codeql-cli/codeql/codeql test run --search-path=/tmp/codeql-src .github/codeql/custom/test/ast_no_type_validation` usando una copia local de las librerías CodeQL, lo que confirmó que desaparece el error original `getEnclosingCallable() cannot be resolved for type Stmts::Assert` pero la compilación se detuvo con errores independientes: `could not resolve type FunctionCall`, `could not resolve type Method`, y `regexp(string) cannot be resolved for type string`, por lo que los tests de query focal terminaron con fallo de compilación.
- Intentos de instalar packs con `codeql pack install .github/codeql/custom` fallaron por un error del almacén de certificados (`SunCertPathBuilderException`), por lo que la reproducción completa del pipeline fijado por el workflow (`Test custom CodeQL queries` y `Perform CodeQL Analysis`) quedó **NOT DEMONSTRATED** en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8055419b388327b9e0b58aa280cc97)