### PR TITLE
fix(codeql): identify isinstance calls by callee

### DIFF
--- a/.github/codeql/custom/ast-no-type-validation.ql
+++ b/.github/codeql/custom/ast-no-type-validation.ql
@@ -18,9 +18,10 @@ where
     m.getName() = "__post_init__" and
     (
       // Búsqueda de llamada a builtin isinstance
-      exists(Call call |
+      exists(Call call, Name callee |
         call.getScope() = m and
-        call.getFunc().(Name).getId() = "isinstance"
+        call.getFunc() = callee and
+        callee.getId() = "isinstance"
       ) or
       // Búsqueda de sentencia assert
       exists(Assert ast |


### PR DESCRIPTION
### Motivation
- Corregir la detección de validaciones de tipo en nodos AST para reconocer llamadas a `isinstance` sin suponer la existencia de un tipo `FunctionCall` no definido en el paquete estándar de CodeQL.

### Description
- Modifica únicamente `.github/codeql/custom/ast-no-type-validation.ql` para modelar el callee de cada `Call` como un `Name` y detectar `isinstance` comprobando `callee.getId() = "isinstance"`.
- Mantiene la restricción de ámbito a `__post_init__` usando `call.getScope() = m` y conserva la detección de `Assert` con `ast.getScope() = m`.
- Conserva el filtro de clases cuyo nombre coincide con `^Nodo.*` y solo reporta cuando no existe un `__post_init__` que realice esas validaciones.
- No se tocan Lexer, Parser, gramática, AST, `interpreter.py`, `constant_folder` ni otros archivos fuera del objetivo especificado.

### Testing
- Se confirmó el CLI de CodeQL `2.26.3` y el qlpack `codeql/python-all@7.2.3` para verificar tipos y predicados disponibles; la inspección mostró que existen `Function`, `Call`, `Name` y `Assert` y no existe `FunctionCall` (comando: `codeql version` y `codeql resolve packs`).
- Se ejecutó `"/tmp/codeql-bundle-2.26.3/codeql/codeql" test run .github/codeql/custom/test/ast_no_type_validation` y ambos tests (fixtures `insecure` y `safe`) pasaron; resultado: "All 2 tests passed.".
- Se ejecutaron comprobaciones de repositorio (`git diff --check`, `git status --short`) y búsqueda de rutas prohibidas, confirmando que no se modificaron archivos no permitidos y que el árbol de trabajo quedó limpio tras el commit.
- El cambio fue registrado en el commit `4156f6cc` con el mensaje `fix(codeql): identify isinstance calls by callee`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a808cbf129c83279b277593786108c1)