### PR TITLE
test(codeql): verify both custom query harnesses and config ignores

### DIFF
--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CODEQL_CONFIG = ROOT / ".github" / "codeql" / "custom" / "codeql-config.yml"
+CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 MISSING_CODEGEN_EXCEPTION_QUERY = (
     ROOT / ".github" / "codeql" / "custom" / "missing-codegen-exception.ql"
 )
@@ -20,6 +21,24 @@ AST_NO_TYPE_VALIDATION_QUERY = (
 
 def _codeql_config_text() -> str:
     return CODEQL_CONFIG.read_text(encoding="utf-8")
+
+
+def test_codeql_workflow_runs_both_custom_query_harnesses() -> None:
+    """Ejecuta ambos harnesses con el binario publicado por CodeQL init."""
+    workflow = CODEQL_WORKFLOW.read_text(encoding="utf-8")
+
+    assert '"${{ steps.codeql-init.outputs.codeql-path }}" test run' in workflow
+    assert ".github/codeql/custom/test/ast_no_export_validation" in workflow
+    assert ".github/codeql/custom/test/ast_no_type_validation" in workflow
+
+
+def test_codeql_production_config_keeps_fixtures_isolated() -> None:
+    """Excluye ambos árboles de fixtures sin retirar la consulta productiva."""
+    config = _codeql_config_text()
+
+    assert "  - '.github/codeql/custom/test/ast_no_export_validation/**'" in config
+    assert "  - '.github/codeql/custom/test/ast_no_type_validation/**'" in config
+    assert "  - uses: ./.github/codeql/custom/ast-no-type-validation.ql" in config
 
 
 def test_codeql_paths_exist_in_repository() -> None:
@@ -71,18 +90,15 @@ def test_ast_export_query_uses_formal_isolated_fixtures() -> None:
 def test_ast_type_query_uses_supported_api_and_isolated_fixtures() -> None:
     """Valida la API de llamadas y aísla los casos inseguros deliberados."""
     config = _codeql_config_text()
-    workflow = (ROOT / ".github" / "workflows" / "codeql.yml").read_text(
-        encoding="utf-8"
-    )
     fixture_dir = (
         ROOT / ".github" / "codeql" / "custom" / "test" / "ast_no_type_validation"
     )
     query = AST_NO_TYPE_VALIDATION_QUERY.read_text(encoding="utf-8")
 
     assert "  - '.github/codeql/custom/test/ast_no_type_validation/**'" in config
-    assert ".github/codeql/custom/test/ast_no_type_validation" in workflow
-    assert "exists(Call call |" in query
-    assert 'call.getFunc().(Name).getId() = "isinstance"' in query
+    assert "exists(Call call, Name callee |" in query
+    assert "call.getFunc() = callee" in query
+    assert 'callee.getId() = "isinstance"' in query
     assert "FunctionCall" not in query
     assert "not exists(Function m |" in query
     assert 'c.getName().regexpMatch("^Nodo.*")' in query


### PR DESCRIPTION
### Motivation

- Asegurar que el workflow de CodeQL ejecuta ambos harnesses de pruebas personalizadas usando el `codeql-path` publicado por `Initialize CodeQL` y que la configuración productiva continúa ignorando los árboles de fixtures destinados a tests.

### Description

- Añadí `CODEQL_WORKFLOW` y el test `test_codeql_workflow_runs_both_custom_query_harnesses` en `tests/test_codeql_config.py` para verificar que el workflow usa `"${{ steps.codeql-init.outputs.codeql-path }}" test run` y lista ambos directorios de harnesses.
- Añadí `test_codeql_production_config_keeps_fixtures_isolated` en `tests/test_codeql_config.py` para comprobar ambos `paths-ignore` y que `ast-no-type-validation.ql` sigue registrada en la configuración productiva (`.github/codeql/custom/codeql-config.yml`).
- Ajusté las aserciones de `test_ast_type_query_uses_supported_api_and_isolated_fixtures` para reflejar la API actual de la consulta (`exists(Call call, Name callee |`, `call.getFunc() = callee`, `callee.getId() = "isinstance"`) sin modificar ninguna consulta productiva ni tocar Lexer/Parser.

### Testing

- `python -m pytest tests/test_codeql_config.py -q` — `8 passed` (todas las pruebas focales pasan).
- Ejecuté `"<codeql-path>" test run .github/codeql/custom/test/ast_no_export_validation` — `PENDIENTE` porque no hay `codeql` disponible en este entorno local (salida y código 127).
- Ejecuté `"<codeql-path>" test run .github/codeql/custom/test/ast_no_type_validation` — `PENDIENTE` por la misma razón (salida y código 127).
- Verificaciones de control de cambios: `git diff --check` y búsqueda de cambios en Lexer/Parser indicaron que no se tocaron archivos de Lexer o Parser; commit resultante `e2a204bd` (`test(codeql): verify both custom query harnesses`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80918d34488327a3b53129a99dffd5)