### PR TITLE
Exportar obtener_url_texto desde corelibs

### DIFF
--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -185,6 +185,7 @@ from .coleccion import (
 from .seguridad import hash_sha256, generar_uuid
 from .red import (
     obtener_url,
+    obtener_url_texto,
     obtener_url_async,
     enviar_post,
     enviar_post_async,
@@ -407,6 +408,7 @@ __all__ = [
     "hash_sha256",
     "generar_uuid",
     "obtener_url",
+    "obtener_url_texto",
     "obtener_url_async",
     "enviar_post",
     "enviar_post_async",

--- a/tests/cli/test_runtime_imports_contract.py
+++ b/tests/cli/test_runtime_imports_contract.py
@@ -30,3 +30,11 @@ def test_politica_publica_targets_falla_si_hay_targets_extra():
         "assert tuple(PUBLIC_BACKENDS + ('go',)) != ('python','javascript','rust')"
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_obtener_url_texto_se_puede_importar_desde_corelibs():
+    result = _run_python_isolated(
+        "from pcobra.corelibs import obtener_url_texto; "
+        "assert callable(obtener_url_texto)"
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_runtime_api_matrix_contract.py
+++ b/tests/unit/test_runtime_api_matrix_contract.py
@@ -58,6 +58,14 @@ def test_python_global_api_includes_ejecutar_comando_async() -> None:
     )
 
 
+def test_python_runtime_includes_obtener_url_texto() -> None:
+    matrix = build_runtime_api_matrix()
+
+    python_api = matrix["available_api_by_backend"]["python"]
+    assert "obtener_url_texto" in python_api["global"]
+    assert "obtener_url_texto" in python_api["corelibs"]
+
+
 def test_python_runtime_preserves_public_extension_exports() -> None:
     matrix = build_runtime_api_matrix()
 


### PR DESCRIPTION
### Motivation

- Exponer `obtener_url_texto` desde `pcobra.corelibs` para que forme parte de la API pública de runtime y permita su importación directa con el mismo patrón que otras funciones de red. 
- Alinear los exports públicos con las comprobaciones automatizadas de la matriz Runtime sin tocar la implementación de `red.py`, snapshots ni artefactos generados.

### Description

- Se añadió la importación de `obtener_url_texto` en `src/pcobra/corelibs/__init__.py` siguiendo el patrón existente de `pcobra.corelibs.red`.
- Se incluyó `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80ada70a708327aa1084faa9726f74)