### PR TITLE
Agregar metadata obligatoria a missing-codegen-exception.ql y validar @kind en tests

### DIFF
--- a/.github/codeql/custom/missing-codegen-exception.ql
+++ b/.github/codeql/custom/missing-codegen-exception.ql
@@ -1,9 +1,13 @@
-import python
-
 /**
  * Reporta métodos "generate_code" en los transpiladores que no contienen
  * sentencias try/except para manejar excepciones durante la generación de código.
+ * @kind problem
+ * @problem.severity warning
+ * @id py/missing-codegen-exception
  */
+
+import python
+
 from Function m, File f
 where
   m.getName() = "generate_code" and

--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -63,6 +64,21 @@ def test_codeql_custom_queries_resolve_from_repository_root() -> None:
     for query_path in query_paths:
         assert f"  - uses: {query_path}" in config
         assert (ROOT / query_path).is_file(), query_path
+
+
+def test_configured_validation_queries_declare_a_non_empty_kind() -> None:
+    """Exige que las tres queries de validación declaren su tipo de resultado."""
+    queries = (
+        AST_NO_EXPORT_VALIDATION_QUERY,
+        AST_NO_TYPE_VALIDATION_QUERY,
+        MISSING_CODEGEN_EXCEPTION_QUERY,
+    )
+
+    for query_path in queries:
+        query = query_path.read_text(encoding="utf-8")
+        header = query.split("*/", maxsplit=1)[0]
+
+        assert re.search(r"^\s*\*\s+@kind\s+\S+\s*$", header, re.MULTILINE), query_path
 
 
 def test_ast_export_query_uses_formal_isolated_fixtures() -> None:


### PR DESCRIPTION
### Motivation

- Asegurar que la consulta `missing-codegen-exception.ql` declare la metadata mínima que exige CodeQL CLI 2.26.3 para consultas de tipo `problem` y así poder compilar y ejecutar el análisis sin errores de metadatos.
- Evitar bloqueos futuros del pipeline provocados por queries de validación que no declaran `@kind` mediante una comprobación automática en las pruebas de configuración.

### Description

- Añadí la QLDoc con `@kind problem` y los campos requeridos por la versión 2.26.3 de CodeQL: `@problem.severity warning` y `@id py/missing-codegen-exception` en `.github/codeql/custom/missing-codegen-exception.ql` sin cambiar el `from/where/select` ni el texto del mensaje de alerta. 
- Reubiqué el `import python` después del bloque QLDoc para mantener la QLDoc inmediatamente anterior a la query como en las otras consultas configuradas. 
- Amplié `tests/test_codeql_config.py` para añadir la prueba `test_configured_validation_queries_declare_a_non_empty_kind` que exige que las tres queries de validación configuradas declaren un `@kind` no vacío en su encabezado QLDoc.

### Testing

- Ejecuté `python -m pytest tests/test_codeql_config.py -q` y las pruebas de configuración pasaron exitosamente con `9 passed`.
- Confirmé la versión del CLI con `/tmp/codeql-bundle-2.26.3/codeql/codeql version` y usé `codeql resolve metadata` para verificar que `missing-codegen-exception.ql` ahora expone `kind`, `problem.severity` e `id` correctamente. 
- Compilé y ejecuté la query con `codeql query compile` y `codeql database analyze` para `missing-codegen-exception.ql` sin errores de metadata, y ejecuté los harnesses de prueba (`codeql test run`) para las queries `ast-no-export-validation` y `ast-no-type-validation`, que pasaron individualmente.
- Durante la ejecución completa del análisis, apareció un nuevo blocker en la query `unsafe-eval-exec.ql` y registré su salida literal sin corregirla en esta ronda: "A fatal error occurred: Could not process query metadata for /tmp/pCobra-db/results/custom-queries/unsafe-eval-exec.bqrs. Error was: Cannot process query metadata for a query without the '@kind' metadata property. To learn more, see https://codeql.github.com/docs/writing-codeql-queries/metadata-for-codeql-queries/ [NO_KIND_SPECIFIED] EXIT:2".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80b1b525008327a12cb258fdf697af)