### PR TITLE
docs(audit): enmendar evidencia Runtime y CodeQL de 3482

### DIFF
--- a/docs/auditorias/3482_reparacion_runtime_codeql/README.md
+++ b/docs/auditorias/3482_reparacion_runtime_codeql/README.md
@@ -214,3 +214,124 @@ revalidación quedaron **PENDIENTE** los tests de configuración CodeQL, ambos
 `black --check`. Sus ejecuciones reales anteriores, incluidos el
 `codeql-path` real `/tmp/codeql-bundle-3482/codeql/codeql`, permanecen
 registradas arriba sin presentarlas falsamente como una nueva ejecución.
+
+## Enmienda trazable posterior: tareas A y B (2026-08-16 UTC)
+
+Esta sección es una adenda: conserva el relato anterior como evidencia
+histórica y corrige expresamente sus datos sin reescribirlos.
+
+### Corrección del SHA histórico y límites de la revalidación
+
+El valor `d3b10012633b8ba3e409682671cd69d27759eb64` consignado arriba es un
+**dato histórico erróneo**. El SHA correcto del merge de la PR #3484 es
+`d3b10012fe393633891925e4807df3b70197c8bd`. La enmienda se debe a que el
+valor anterior no identifica ningún commit del historial disponible, mientras
+que `git show -s --format='%H %s' d3b10012fe393633891925e4807df3b70197c8bd`
+resuelve el merge esperado. El dato erróneo no se borra para mantener visible
+la cadena de auditoría.
+
+Para las tareas A y B, el `BASE_SHA` real es
+`6c75e34e69016427348a32870c71d386788e550d` y el `HEAD_SHA` funcional final
+real es `6868e33562d438aafe3de42820d7cd51f08b3607`. La rama de trabajo documental
+es `fix/contrato-extensiones-cobra`. Este `HEAD_SHA` designa el estado final
+de las dos tareas antes del commit que incorpora la presente adenda; no se
+pretende que un commit se autorreferencie.
+
+- **Tarea A:** el commit `2af7edee8760f6d22368540b04e039a34ded6fa4`
+  volvió a exponer `obtener_url_texto` desde el agregador público y añadió
+  comprobaciones contractuales. Es una exportación pública ya existente: la
+  función estaba implementada y el contrato `cobra.web.obtener_url_texto`
+  ya declaraba soporte Python `full`; no se inventó un alias ni sintaxis.
+- **Tarea B:** el commit `9b30ac702fd06aeb4b0eb6a6aeb1ecd74be09d7b`
+  añadió a `missing-codegen-exception.ql` exclusivamente metadata QLDoc
+  (`@kind problem`, severidad e identificador) y una prueba de presencia de
+  `@kind`. El `from`, el `where` y el `select` de la query permanecieron
+  idénticos: **no hubo cambio lógico**.
+
+Los archivos modificados por A y B, y sólo éstos, fueron:
+
+1. `src/pcobra/corelibs/__init__.py`;
+2. `tests/cli/test_runtime_imports_contract.py`;
+3. `tests/unit/test_runtime_api_matrix_contract.py`;
+4. `.github/codeql/custom/missing-codegen-exception.ql`;
+5. `tests/test_codeql_config.py`.
+
+La presente ronda modifica exclusivamente
+`docs/auditorias/3482_reparacion_runtime_codeql/README.md`. No existe una ref
+local `master` ni una ref local de seguimiento `origin/master`; no se ejecutó
+merge ni push y `master` **no fue tocado**. La consulta remota de sólo lectura
+registró `8b1676cdf52f30147ce42584a98ca4c421756369` para `master` antes de crear el
+commit documental.
+
+### Evidencia remota sobre el SHA base
+
+La API pública de GitHub aporta evidencia trazable para
+`6c75e34e69016427348a32870c71d386788e550d` en los runs CodeQL
+[`31898923095`](https://github.com/Alphonsus411/pCobra/actions/runs/31898923095)
+y [`31901256502`](https://github.com/Alphonsus411/pCobra/actions/runs/31901256502):
+
+- `Test custom CodeQL queries` (paso 6) terminó `completed/success`:
+  **PASS**. Por tanto, `ast-no-type-validation` ya no era el blocker.
+- `Perform CodeQL Analysis` (paso 7) terminó `completed/failure`: **FAIL
+  preexistente en el SHA base**.
+- Las anotaciones de los jobs
+  [`95046414355`](https://github.com/Alphonsus411/pCobra/actions/runs/31898923095/job/95046414355)
+  y [`95052284291`](https://github.com/Alphonsus411/pCobra/actions/runs/31901256502/job/95052284291)
+  atribuyen el fallo a que `interpret-results` no pudo procesar
+  `missing-codegen-exception.bqrs`: la query carecía de la propiedad metadata
+  `@kind` (`NO_KIND_SPECIFIED`). Esta es la causa demostrada remotamente, no
+  una inferencia a partir del resultado global del workflow.
+- La primera comprobación Runtime registrada al partir de ese SHA estaba
+  bloqueada por `RuntimeError: Snapshot inválido para python.corelibs:
+  símbolos desconocidos ['obtener_url_texto']`. Es un bloqueo preexistente de
+  A, distinto del fallo de metadata que resolvió B.
+
+### Comandos, códigos de salida y atribución
+
+| Comando exacto | Código | Estado y resultado |
+|---|---:|---|
+| `git show -s --format='%H %s' d3b10012fe393633891925e4807df3b70197c8bd` | 0 | **PASS**; resolvió `d3b10012fe393633891925e4807df3b70197c8bd Merge pull request #3484 ...`. |
+| `python -m pytest -q tests/cli/test_runtime_imports_contract.py tests/unit/test_runtime_api_matrix_contract.py` | 1 | **FAIL preexistente/no atribuible a esta adenda**; `1 failed, 8 passed`: snapshot desactualizado, nuevo símbolo sin mapear `obtener_url_texto`. La prueba de import público sí pasó. |
+| `python scripts/generar_matriz_api_runtime.py` | 1 | **FAIL preexistente/no atribuible a esta adenda**; `Snapshot de API Python desactualizado ... Nuevos símbolos sin mapear: ['obtener_url_texto']`. |
+| `python scripts/validate_runtime_contract.py` | 1 | **FAIL preexistente/no atribuible a esta adenda**; `cobra.system.ejecutar_comando_async.python` está marcado `full` pero no aparece en la matriz global. |
+| `python -m pytest -q tests/test_codeql_config.py` | 0 | **PASS**; `9 passed in 0.06s`, incluida la prueba de metadata de B. |
+| `/tmp/codeql-bundle-3482/codeql/codeql test run .github/codeql/custom/test/ast_no_export_validation .github/codeql/custom/test/ast_no_type_validation` | no ejecutado | **warning / NOT DEMONSTRATED en esta revalidación**; el binario no estaba presente. Se mantiene separada la evidencia remota PASS del SHA base. |
+| `git show-ref --verify refs/heads/master` | 128 | **warning**; la ref local no existe. Confirma que esta ronda no operó sobre una rama local `master`, pero por sí solo no prueba el estado remoto. |
+| `git show-ref --verify refs/remotes/origin/master` | 128 | **warning**; no existe remote-tracking ref porque este checkout no tiene `origin`. |
+| `python - <<'PY' ... urllib.request.urlopen('https://api.github.com/repos/Alphonsus411/pCobra/branches/master') ... PY` | 0 | **PASS**; consulta remota de sólo lectura: `master` = `8b1676cdf52f30147ce42584a98ca4c421756369`. |
+| `git diff --check` | 0 | **PASS**; sin salida. |
+| `git diff --name-only` | 0 | **PASS**; sólo `docs/auditorias/3482_reparacion_runtime_codeql/README.md`. |
+| `for f in src/pcobra/cobra/core/lexer.py src/pcobra/cobra/core/parser.py src/pcobra/core/lexer.py src/pcobra/core/parser.py; do printf '%s  %s\n' "$(git hash-object "$f")" "$f"; done` | 0 | **PASS**; produjo exactamente los cuatro Git blob SHA exigidos. |
+| `git diff --name-only -- src/pcobra/cobra/core/lexer.py src/pcobra/cobra/core/parser.py src/pcobra/core/lexer.py src/pcobra/core/parser.py` | 0 | **PASS**; sin salida, ninguna superficie protegida cambió. |
+
+Los fallos Runtime son deuda funcional del estado recibido y no fueron
+causados por esta modificación exclusivamente documental. La prueba focal
+confirma el import introducido por A, pero A no deja verde el generador: el
+símbolo pasó de «desconocido en los exports» a «nuevo sin mapear». B sí corrige
+la causa remota `NO_KIND_SPECIFIED`; la suite de configuración local pasa,
+pero el análisis CodeQL completo posterior queda **NOT DEMONSTRATED** en esta
+revalidación.
+
+### Integridad de superficies protegidas
+
+Antes de editar esta adenda, `git hash-object` produjo estos Git blob SHA, que
+coinciden exactamente con los valores exigidos:
+
+```text
+50dbd208b1ff09c80462bca4036a8dcc84649be8  src/pcobra/cobra/core/lexer.py
+cdcb0230e5ea4ea47ae710cbaccb38afde5b87d0  src/pcobra/cobra/core/parser.py
+413cd9cdbf3835657cc766e645b1472bee11886c  src/pcobra/core/lexer.py
+aad60be7f3f3e029c452937edf3c2e4656c59459  src/pcobra/core/parser.py
+```
+
+Después de editar y revisar el diff, la misma comprobación produjo exactamente
+los mismos cuatro valores. La comprobación dirigida con `git diff --name-only`
+no produjo rutas: Lexer y Parser no se han modificado.
+
+### Estado de cierre
+
+**No se declara cierre global.** El generador y el validador Runtime no
+finalizan correctamente, y el análisis CodeQL completo posterior a B no está
+demostrado como PASS. El alcance queda documentado como avance incremental:
+export público e import focal de A demostrados, metadata de B demostrada, y
+deuda Runtime/análisis completo todavía abierta.


### PR DESCRIPTION
### Motivation

- Registrar de forma trazable y corregir sin borrar un SHA histórico erróneo en el informe de la auditoría 3482, preservando la cadena de evidencia original. 
- Añadir evidencia remota y local que explique por qué `Test custom CodeQL queries` pasó, por qué `Perform CodeQL Analysis` falló (causa metadata `@kind` ausente), y por qué el generador Runtime quedó bloqueado por `obtener_url_texto`. 
- Aclarar el alcance de las tareas A y B (qué commits y archivos modificaron) y dejar constancia de que esta edición es exclusivamente documental y no modifica `master` ni los archivos protegidos. 

### Description

- Se modificó únicamente `docs/auditorias/3482_reparacion_runtime_codeql/README.md` para añadir una adenda titulada "Enmienda trazable posterior: tareas A y B (2026-08-16 UTC)" y explicar la corrección del SHA histórico. 
- Se mantuvo el SHA incorrecto como dato histórico y se añadió la corrección explícita al SHA correcto `d3b10012fe393633891925e4807df3b70197c8bd`. 
- Se documentaron el `BASE_SHA` real `6c75e34e69016427348a32870c71d386788e550d`, el `HEAD_SHA` funcional final `6868e33562d438aafe3de42820d7cd51f08b3607`, la rama `fix/contrato-extensiones-cobra`, los commits de las tareas A y B (`2af7edee...` y `9b30ac70...`) y la lista exacta de archivos que A y B modificaron. 
- Se dejó constancia contractual y técnica de que `obtener_url_texto` es una exportación pública existente y que la corrección de B añade sólo metadata QLDoc (`@kind problem`, severidad e id) sin alterar la lógica de la query. 
- Se verificó y registró que los cuatro archivos protegidos de Lexer/Parser mantienen exactamente los Git blob SHA exigidos y que no se tocaron en esta ronda. 

### Testing

- `git show -s --format='%H %s' d3b10012fe393633891925e4807df3b70197c8bd` — PASS (exit 0) y resolvió el merge esperado para el SHA correcto. 
- `python -m pytest -q tests/cli/test_runtime_imports_contract.py tests/unit/test_runtime_api_matrix_contract.py` — FAIL (exit 1); resultado `1 failed, 8 passed` con fallo preexistente por snapshot desactualizado que reportó `Nuevos símbolos sin mapear: ['obtener_url_texto']`. 
- `python scripts/generar_matriz_api_runtime.py` — FAIL (exit 1); `RuntimeError: Snapshot inválido para python.corelibs: símbolos desconocidos ['obtener_url_texto']`. 
- `python scripts/validate_runtime_contract.py` — FAIL (exit 1); `ContractValidationError` relativo a `cobra.system.ejecutar_comando_async.python` ausente en la matriz global (deuda/fallo preexistente). 
- `python -m pytest -q tests/test_codeql_config.py` — PASS (exit 0); `9 passed in 0.06s`, incluida la verificación que exige `@kind` en las queries (corrección B). 
- Remoto GitHub Actions: para el SHA `6c75e34e...` los runs CodeQL muestran que el paso `Test custom CodeQL queries` completó `completed/success` (PASS) mientras que `Perform CodeQL Analysis` completó `completed/failure` (FAIL) y las anotaciones de job indican que `interpret-results` no pudo procesar `missing-codegen-exception.bqrs` por ausencia de `@kind` (`NO_KIND_SPECIFIED`). 
- `codeql test run .github/codeql/custom/test/ast_no_export_validation` y `codeql test run .github/codeql/custom/test/ast_no_type_validation` se demostraron PASS sobre el SHA base en ejecuciones remotas anteriores, pero en la revalidación local el binario temporal de CodeQL no estaba presente, por lo que la ejecución completa del análisis CodeQL posterior a B queda como NOT DEMONSTRATED en esta revalidación local. 
- `git diff --check` — PASS (exit 0) y `git diff --name-only` — PASS (exit 0) confirmaron que la única ruta modificada localmente antes del commit fue `docs/auditorias/3482_reparacion_runtime_codeql/README.md`. 
- Verificación de integridad de archivos protegidos con `git hash-object` sobre los cuatro ficheros de Lexer/Parser — PASS (exit 0) y los cuatro Git blob SHA exigidos coincidieron exactamente con los valores requeridos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a814da130a483278e48f3220009957a)