### PR TITLE
Añadir metadatos QLDoc a queries CodeQL personalizadas

### DIFF
--- a/.github/codeql/custom/missing-codegen-exception.ql
+++ b/.github/codeql/custom/missing-codegen-exception.ql
@@ -1,6 +1,8 @@
 /**
  * Reporta métodos "generate_code" en los transpiladores que no contienen
  * sentencias try/except para manejar excepciones durante la generación de código.
+ * @name Falta manejo de excepciones en generación de código
+ * @description Detecta métodos generate_code sin sentencias try/except.
  * @kind problem
  * @problem.severity warning
  * @id py/missing-codegen-exception

--- a/.github/codeql/custom/unsafe-eval-exec.ql
+++ b/.github/codeql/custom/unsafe-eval-exec.ql
@@ -1,3 +1,11 @@
+/**
+ * @name Uso inseguro de eval o exec
+ * @description Detecta llamadas a eval o exec fuera del sandbox.
+ * @kind problem
+ * @problem.severity error
+ * @id py/unsafe-eval-exec
+ */
+
 import python
 
 /**


### PR DESCRIPTION
### Motivation
- Añadir metadatos QLDoc descriptivos a dos consultas CodeQL para proporcionar `@name`, `@description`, `@kind`, `@problem.severity` y `@id` según lo requerido, sin alterar la lógica ejecutable de las queries.

### Description
- Se agregó un bloque QLDoc completo antes de `import python` en `.github/codeql/custom/unsafe-eval-exec.ql` con `@name`, `@description`, `@kind problem`, `@problem.severity error` y `@id py/unsafe-eval-exec`, y se añadieron únicamente `@name` y `@description` al QLDoc existente en `.github/codeql/custom/missing-codegen-exception.ql`, preservando exactamente el bloque `from/where/select` y sin modificar Lexer/Parser ni otras partes del repositorio.

### Testing
- Se ejecutó `git diff --check` y un script Python que comparó los tokens ejecutables (eliminando comentarios) contra `HEAD` para confirmar que solo cambiaron comentarios y espacios en blanco, se verificó con `git diff --name-only` que solo se modificaron las dos queries solicitadas y se comprobó que no hubo cambios en Lexer/Parser; estas comprobaciones automatizadas pasaron, y la única limitación es que la CLI de CodeQL no está disponible en el entorno para compilar las queries localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8165569a5483278fb4df541a2b6a89)