### PR TITLE
Generalizar validación de metadata QLDoc para queries productivas de CodeQL

### DIFF
--- a/tests/test_codeql_config.py
+++ b/tests/test_codeql_config.py
@@ -67,18 +67,46 @@ def test_codeql_custom_queries_resolve_from_repository_root() -> None:
 
 
 def test_configured_validation_queries_declare_a_non_empty_kind() -> None:
-    """Exige que las tres queries de validación declaren su tipo de resultado."""
-    queries = (
-        AST_NO_EXPORT_VALIDATION_QUERY,
-        AST_NO_TYPE_VALIDATION_QUERY,
-        MISSING_CODEGEN_EXCEPTION_QUERY,
+    """Valida el QLDoc de todas las queries productivas configuradas."""
+    query_paths = re.findall(
+        r"^\s*-\s+uses:\s+['\"]?(\./[^'\"\s]+)['\"]?\s*$",
+        _codeql_config_text(),
+        re.MULTILINE,
     )
+    required_metadata = ("name", "description", "kind", "id")
 
-    for query_path in queries:
+    assert query_paths
+
+    for configured_path in query_paths:
+        query_path = ROOT / configured_path
+        assert query_path.is_file(), configured_path
+
         query = query_path.read_text(encoding="utf-8")
-        header = query.split("*/", maxsplit=1)[0]
+        before_python_import, separator, _ = query.partition("import python")
+        assert separator, query_path
 
-        assert re.search(r"^\s*\*\s+@kind\s+\S+\s*$", header, re.MULTILINE), query_path
+        qldoc_match = re.search(r"/\*\*(.*?)\*/\s*$", before_python_import, re.DOTALL)
+        assert qldoc_match, query_path
+        qldoc = qldoc_match.group(1)
+
+        metadata = {}
+        for field in required_metadata:
+            values = re.findall(
+                rf"^\s*\*\s+@{re.escape(field)}\s+(\S(?:.*\S)?)\s*$",
+                qldoc,
+                re.MULTILINE,
+            )
+            assert len(values) == 1, (query_path, field)
+            metadata[field] = values[0]
+
+        if metadata["kind"] == "problem":
+            severities = re.findall(
+                r"^\s*\*\s+@problem\.severity\s+(\S(?:.*\S)?)\s*$",
+                qldoc,
+                re.MULTILINE,
+            )
+            assert len(severities) == 1, query_path
+            assert severities[0] in {"error", "warning", "recommendation"}, query_path
 
 
 def test_ast_export_query_uses_formal_isolated_fixtures() -> None:


### PR DESCRIPTION
### Motivation
- Sustituir la comprobación hardcodeada por una validación general que cubra todas las entradas locales `uses:` en `.github/codeql/custom/codeql-config.yml` para evitar casos especiales por consulta.

### Description
- Se modificó `tests/test_codeql_config.py` para descubrir automáticamente las rutas `uses:` en el YAML y resolverlas desde `ROOT`.
- Para cada query configurada se comprueba que el archivo exista y se extrae el QLDoc situado antes de `import python` usando `partition` y expresiones regulares.
- Se exige una única declaración no vacía y única para `@name`, `@description`, `@kind` y `@id` en el QLDoc; y además, si `@kind` es `problem`, se exige un `@problem.severity` válido entre `error`, `warning` o `recommendation`.
- Se conservaron intactas las pruebas específicas de lógica y los fixtures aislados; no se redujeron ni eliminaron aserciones existentes.

### Testing
- `python -m pytest -q tests/test_codeql_config.py` — todas las pruebas locales pasaron (`9 passed`).
- `black --check tests/test_codeql_config.py` — verificación de formato superada (archivo sin cambios por `black`).
- `git diff --check` — sin problemas detectados en el diff del cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81681996c8832796e67b5b673be02a)