### PR TITLE
docs: sincronizar índices y tablas autogeneradas de CLI y standard_library

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -123,6 +123,7 @@ altura = 1.68
 - `desde`
 - `eliminar`
 - `elseif`
+- `enum`
 - `enumeracion`
 - `esperar`
 - `estructura`
@@ -157,11 +158,14 @@ altura = 1.68
 - `sino`
 - `sino si`
 - `switch`
+- `throw`
 - `transformar`
+- `try`
 - `usar`
 - `var`
 - `variable`
 - `y`
+- `yield`
 - `{`
 - `||`
 - `}`
@@ -799,6 +803,43 @@ Cobra incluye módulos de soporte para flujos asíncronos y coordinación.
 
 ## 10) CLI de Cobra para desarrollo diario
 
+<!-- BEGIN: AUTO-CLI-TABLE -->
+### Tabla CLI actualizada (autogenerado)
+
+| Comando | Capacidad | Clase | Archivo |
+|---|---|---|---|
+| `agix` | `-` | `AgixCommand` | `src/pcobra/cobra/cli/commands/agix_cmd.py` |
+| `bench` | `-` | `BenchCommand` | `src/pcobra/cobra/cli/commands/bench_cmd.py` |
+| `benchmarks` | `-` | `BenchmarksCommand` | `src/pcobra/cobra/cli/commands/benchmarks_cmd.py` |
+| `benchmarks2` | `-` | `BenchmarksV2Command` | `src/pcobra/cobra/cli/commands/benchmarks2_cmd.py` |
+| `benchthreads` | `-` | `BenchThreadsCommand` | `src/pcobra/cobra/cli/commands/benchthreads_cmd.py` |
+| `benchtranspilers` | `-` | `BenchTranspilersCommand` | `src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py` |
+| `build` | `codegen` | `BuildCommandV2` | `src/pcobra/cobra/cli/commands_v2/build_cmd.py` |
+| `compilar` | `codegen` | `CompileCommand` | `src/pcobra/cobra/cli/commands/compile_cmd.py` |
+| `contenedor` | `-` | `ContainerCommand` | `src/pcobra/cobra/cli/commands/container_cmd.py` |
+| `crear` | `-` | `CrearCommand` | `src/pcobra/cobra/cli/commands/crear_cmd.py` |
+| `dependencias` | `-` | `DependenciasCommand` | `src/pcobra/cobra/cli/commands/dependencias_cmd.py` |
+| `docs` | `-` | `DocsCommand` | `src/pcobra/cobra/cli/commands/docs_cmd.py` |
+| `ejecutar` | `execute` | `ExecuteCommand` | `src/pcobra/cobra/cli/commands/execute_cmd.py` |
+| `empaquetar` | `-` | `EmpaquetarCommand` | `src/pcobra/cobra/cli/commands/empaquetar_cmd.py` |
+| `gui` | `-` | `FletCommand` | `src/pcobra/cobra/cli/commands/flet_cmd.py` |
+| `hub` | `-` | `HubCommand` | `src/pcobra/cobra/cli/commands/hub_cmd.py` |
+| `init` | `-` | `InitCommand` | `src/pcobra/cobra/cli/commands/init_cmd.py` |
+| `installer` | `codegen` | `InstallerCommandV2` | `src/pcobra/cobra/cli/commands_v2/installer_cmd.py` |
+| `interactive` | `-` | `InteractiveCommand` | `src/pcobra/cobra/cli/commands/interactive_cmd.py` |
+| `jupyter` | `-` | `JupyterCommand` | `src/pcobra/cobra/cli/commands/jupyter_cmd.py` |
+| `mod` | `-` | `ModCommandV2` | `src/pcobra/cobra/cli/commands_v2/mod_cmd.py` |
+| `modulos` | `-` | `ModulesCommand` | `src/pcobra/cobra/cli/commands/modules_cmd.py` |
+| `paquete` | `-` | `PaqueteCommand` | `src/pcobra/cobra/cli/commands/package_cmd.py` |
+| `qa-validar` | `codegen` | `QaValidarCommand` | `src/pcobra/cobra/cli/commands/qa_validar_cmd.py` |
+| `qualia` | `-` | `QualiaCommand` | `src/pcobra/cobra/cli/commands/qualia_cmd.py` |
+| `repl` | `execute` | `ReplCommandV2` | `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` |
+| `run` | `execute` | `RunCommandV2` | `src/pcobra/cobra/cli/commands_v2/run_cmd.py` |
+| `test` | `codegen` | `TestCommandV2` | `src/pcobra/cobra/cli/commands_v2/test_cmd.py` |
+| `validar-sintaxis` | `codegen` | `ValidarSintaxisCommand` | `src/pcobra/cobra/cli/commands/validar_sintaxis_cmd.py` |
+| `verificar` | `codegen` | `VerifyCommand` | `src/pcobra/cobra/cli/commands/verify_cmd.py` |
+<!-- END: AUTO-CLI-TABLE -->
+
 La CLI de Cobra es la herramienta principal para interactuar con el lenguaje. Ofrece comandos para ejecutar, construir, probar y gestionar módulos.
 
 Los comandos públicos disponibles son:
@@ -893,26 +934,34 @@ El BackEnd oficial público está compuesto solo por `python`, `javascript` y `r
 <!-- BEGIN: AUTO-STDLIB-INDEX -->
 ### Índice de módulos y funciones de `standard_library` (autogenerado)
 
-- **`archivo`** (4 funciones) → `docs/standard_library/archivo.md`
-  - API: `adjuntar`, `escribir`, `existe`, `leer`
-- **`asincrono`** (5 funciones) → `docs/standard_library/asincrono.md`
-  - API: `ejecutar_en_hilo`, `grupo_tareas`, `limitar_tiempo`, `proteger_tarea`, `reintentar_async`
-- **`datos`** (32 funciones) → `docs/standard_library/datos.md`
-  - API: `a_listas`, `agrupar_y_resumir`, `calcular_percentiles`, `combinar_tablas`, `correlacion_pearson`, `correlacion_spearman`, `de_listas`, `describir`, ...
+- **`archivo`** (7 funciones) → `docs/standard_library/archivo.md`
+  - API: `adjuntar`, `anexar`, `eliminar`, `escribir`, `existe`, `leer`, `leer_lineas`
+- **`asincrono`** (14 funciones) → `docs/standard_library/asincrono.md`
+  - API: `carrera`, `crear_tarea`, `dormir_async`, `ejecutar_en_hilo`, `esperar_timeout`, `grupo_tareas`, `iterar_completadas`, `limitar_tiempo`, ...
+- **`datos`** (39 funciones) → `docs/standard_library/datos.md`
+  - API: `agregar`, `agrupar_y_resumir`, `calcular_percentiles`, `claves`, `combinar_tablas`, `correlacion_pearson`, `correlacion_spearman`, `describir`, ...
 - **`decoradores`** (9 funciones) → `docs/standard_library/decoradores.md`
   - API: `dataclase`, `depreciado`, `despachar_por_tipo`, `memoizar`, `orden_total`, `reintentar`, `reintentar_async`, `sincronizar`, ...
 - **`fecha`** (3 funciones) → `docs/standard_library/fecha.md`
   - API: `formatear`, `hoy`, `sumar_dias`
+- **`holobit`** (9 funciones) → `docs/standard_library/holobit.md`
+  - API: `combinar`, `crear_holobit`, `deserializar_holobit`, `graficar`, `medir`, `proyectar`, `serializar_holobit`, `transformar`, ...
 - **`interfaz`** (18 funciones) → `docs/standard_library/interfaz.md`
   - API: `barra_progreso`, `estado_temporal`, `grupo_consola`, `imprimir_aviso`, `iniciar_gui`, `iniciar_gui_idle`, `limpiar_consola`, `mostrar_arbol`, ...
 - **`lista`** (12 funciones) → `docs/standard_library/lista.md`
   - API: `cabeza`, `chunk`, `cola`, `combinar`, `descartar_mientras`, `longitud`, `mapear_aplanado`, `mapear_seguro`, ...
 - **`logica`** (25 funciones) → `docs/standard_library/logica.md`
-  - API: `alguna`, `coalesce`, `condicional`, `conjuncion`, `conteo_verdaderos`, `diferencia_simetrica`, `disyuncion`, `entonces`, ...
-- **`numero`** (22 funciones) → `docs/standard_library/numero.md`
-  - API: `coeficiente_variacion`, `combinaciones`, `copiar_signo`, `cuartiles`, `distancia_euclidiana`, `envolver_modular`, `es_finito`, `es_infinito`, ...
-- **`texto`** (51 funciones) → `docs/standard_library/texto.md`
-  - API: `a_camel`, `a_snake`, `acortar_texto`, `centrar_texto`, `codificar`, `contar_subcadena`, `decodificar`, `desindentar_texto`, ...
+  - API: `alguna`, `coalescer`, `condicional`, `conjuncion`, `conteo_verdaderos`, `diferencia_simetrica`, `disyuncion`, `entonces`, ...
+- **`numero`** (42 funciones) → `docs/standard_library/numero.md`
+  - API: `absoluto`, `coeficiente_variacion`, `combinaciones`, `copiar_signo`, `cuartiles`, `distancia_euclidiana`, `envolver_modular`, `es_cercano`, ...
+- **`red`** (7 funciones) → `docs/standard_library/red.md`
+  - API: `descargar_archivo`, `enviar_post`, `enviar_post_async`, `obtener_json`, `obtener_url`, `obtener_url_async`, `obtener_url_texto`
+- **`sistema`** (8 funciones) → `docs/standard_library/sistema.md`
+  - API: `directorio_actual`, `ejecutar`, `ejecutar_async`, `ejecutar_comando_async`, `ejecutar_stream`, `listar_dir`, `obtener_env`, `obtener_os`
+- **`texto`** (10 funciones) → `docs/standard_library/texto.md`
+  - API: `a_snake`, `dividir`, `mayusculas`, `minusculas`, `prefijo_comun`, `quitar_acentos`, `recortar`, `reemplazar`, ...
+- **`tiempo`** (5 funciones) → `docs/standard_library/tiempo.md`
+  - API: `ahora`, `desde_epoch`, `dormir`, `epoch`, `formatear`
 - **`util`** (4 funciones) → `docs/standard_library/util.md`
   - API: `es_nulo`, `es_vacio`, `rel`, `repetir`
 <!-- END: AUTO-STDLIB-INDEX -->

--- a/docs/standard_library/archivo.md
+++ b/docs/standard_library/archivo.md
@@ -24,9 +24,12 @@ Documentación sincronizada automáticamente desde `src/pcobra/standard_library/
 | Función |
 |---|
 | `adjuntar` |
+| `anexar` |
+| `eliminar` |
 | `escribir` |
 | `existe` |
 | `leer` |
+| `leer_lineas` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
 
 

--- a/docs/standard_library/asincrono.md
+++ b/docs/standard_library/asincrono.md
@@ -23,10 +23,19 @@ Documentación sincronizada automáticamente desde `src/pcobra/standard_library/
 
 | Función |
 |---|
+| `carrera` |
+| `crear_tarea` |
+| `dormir_async` |
 | `ejecutar_en_hilo` |
+| `esperar_timeout` |
 | `grupo_tareas` |
+| `iterar_completadas` |
 | `limitar_tiempo` |
+| `mapear_concurrencia` |
+| `primero_exitoso` |
 | `proteger_tarea` |
+| `recolectar` |
+| `recolectar_resultados` |
 | `reintentar_async` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
 

--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -152,17 +152,13 @@ En el objetivo JavaScript se ofrece una implementación parcial que mantiene las
 
 | Función |
 |---|
-| `a_listas` |
 | `agregar` |
-| `claves` |
-| `valores` |
-| `longitud` |
 | `agrupar_y_resumir` |
 | `calcular_percentiles` |
+| `claves` |
 | `combinar_tablas` |
 | `correlacion_pearson` |
 | `correlacion_spearman` |
-| `de_listas` |
 | `describir` |
 | `desplegar_tabla` |
 | `elemento` |
@@ -172,25 +168,29 @@ En el objetivo JavaScript se ofrece una implementación parcial que mantiene las
 | `escribir_json` |
 | `escribir_parquet` |
 | `filtrar` |
-| `mapear` |
-| `reducir` |
+| `invertir_tabla` |
 | `leer_csv` |
 | `leer_excel` |
 | `leer_feather` |
 | `leer_json` |
 | `leer_parquet` |
+| `longitud` |
+| `mapear` |
 | `matriz_covarianza` |
 | `mutar_columna` |
 | `ordenar_tabla` |
 | `pivotar_ancho` |
 | `pivotar_largo` |
 | `pivotar_tabla` |
+| `reducir` |
 | `rellenar_nulos` |
 | `resumen_rapido` |
 | `seleccionar_columnas` |
 | `separar_columna` |
 | `tabla_cruzada` |
+| `tomar` |
 | `unir_columnas` |
+| `valores` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
 
 

--- a/docs/standard_library/holobit.md
+++ b/docs/standard_library/holobit.md
@@ -78,3 +78,19 @@ usar "holobit"
 ```
 
 Nombres públicos en español (fuente: `__all__`).
+
+<!-- BEGIN: AUTO-STDLIB-FUNCTIONS -->
+## API pública sincronizada (`standard_library.holobit`)
+
+| Función |
+|---|
+| `combinar` |
+| `crear_holobit` |
+| `deserializar_holobit` |
+| `graficar` |
+| `medir` |
+| `proyectar` |
+| `serializar_holobit` |
+| `transformar` |
+| `validar_holobit` |
+<!-- END: AUTO-STDLIB-FUNCTIONS -->

--- a/docs/standard_library/logica.md
+++ b/docs/standard_library/logica.md
@@ -50,7 +50,7 @@ para facilitar la depuración.
 | Función |
 |---|
 | `alguna` |
-| `coalesce` |
+| `coalescer` |
 | `condicional` |
 | `conjuncion` |
 | `conteo_verdaderos` |

--- a/docs/standard_library/numero.md
+++ b/docs/standard_library/numero.md
@@ -59,26 +59,46 @@ explícitos tanto en Python como en los demás backends soportados.
 
 | Función |
 |---|
+| `absoluto` |
 | `coeficiente_variacion` |
 | `combinaciones` |
 | `copiar_signo` |
 | `cuartiles` |
 | `distancia_euclidiana` |
 | `envolver_modular` |
+| `es_cercano` |
 | `es_finito` |
 | `es_infinito` |
 | `es_nan` |
+| `es_par` |
+| `es_primo` |
+| `factorial` |
 | `hipotenusa` |
 | `interpolar` |
 | `limitar` |
+| `maximo` |
+| `mcd` |
+| `mcm` |
 | `media_armonica` |
 | `media_geometrica` |
+| `mediana` |
+| `minimo` |
+| `moda` |
 | `percentil` |
 | `permutaciones` |
+| `piso` |
+| `potencia` |
+| `producto` |
+| `promedio` |
+| `raiz` |
 | `raiz_entera` |
 | `rango_intercuartil` |
+| `redondear` |
 | `signo` |
 | `suma_precisa` |
+| `sumatoria` |
+| `techo` |
+| `truncar` |
 | `varianza` |
 | `varianza_muestral` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->

--- a/docs/standard_library/red.md
+++ b/docs/standard_library/red.md
@@ -27,3 +27,17 @@ usar "red"
 ```
 
 Nombres públicos en español (fuente: `__all__`).
+
+<!-- BEGIN: AUTO-STDLIB-FUNCTIONS -->
+## API pública sincronizada (`standard_library.red`)
+
+| Función |
+|---|
+| `descargar_archivo` |
+| `enviar_post` |
+| `enviar_post_async` |
+| `obtener_json` |
+| `obtener_url` |
+| `obtener_url_async` |
+| `obtener_url_texto` |
+<!-- END: AUTO-STDLIB-FUNCTIONS -->

--- a/docs/standard_library/sistema.md
+++ b/docs/standard_library/sistema.md
@@ -32,3 +32,18 @@ usar "sistema"
 ```
 
 Nombres públicos en español (fuente: `__all__`).
+
+<!-- BEGIN: AUTO-STDLIB-FUNCTIONS -->
+## API pública sincronizada (`standard_library.sistema`)
+
+| Función |
+|---|
+| `directorio_actual` |
+| `ejecutar` |
+| `ejecutar_async` |
+| `ejecutar_comando_async` |
+| `ejecutar_stream` |
+| `listar_dir` |
+| `obtener_env` |
+| `obtener_os` |
+<!-- END: AUTO-STDLIB-FUNCTIONS -->

--- a/docs/standard_library/texto.md
+++ b/docs/standard_library/texto.md
@@ -120,57 +120,16 @@ Todas estas funciones respetan Unicode y aprovechan los normalizadores base disp
 
 | Función |
 |---|
-| `a_camel` |
 | `a_snake` |
-| `acortar_texto` |
-| `centrar_texto` |
-| `codificar` |
-| `contar_subcadena` |
-| `decodificar` |
-| `desindentar_texto` |
-| `dividir_derecha` |
-| `dividir_lineas` |
-| `encontrar` |
-| `encontrar_derecha` |
-| `envolver_texto` |
-| `es_alfa_numerico` |
-| `es_alfabetico` |
-| `es_anagrama` |
-| `es_ascii` |
-| `es_decimal` |
-| `es_digito` |
-| `es_espacio` |
-| `es_identificador` |
-| `es_imprimible` |
-| `es_mayusculas` |
-| `es_minusculas` |
-| `es_numerico` |
-| `es_palindromo` |
-| `es_titulo` |
-| `expandir_tabulaciones` |
-| `formatear` |
-| `formatear_mapa` |
-| `indentar_texto` |
-| `indice` |
-| `indice_derecha` |
-| `intercambiar_mayusculas` |
-| `minusculas_casefold` |
-| `normalizar_espacios` |
-| `particionar` |
-| `particionar_derecha` |
+| `dividir` |
+| `mayusculas` |
+| `minusculas` |
 | `prefijo_comun` |
 | `quitar_acentos` |
-| `quitar_envoltura` |
-| `quitar_prefijo` |
-| `quitar_sufijo` |
-| `rellenar_ceros` |
-| `subcadena_antes` |
-| `subcadena_antes_ultima` |
-| `subcadena_despues` |
-| `subcadena_despues_ultima` |
+| `recortar` |
+| `reemplazar` |
+| `repetir` |
 | `sufijo_comun` |
-| `tabla_traduccion` |
-| `traducir` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
 
 - `lineas_no_vacias(texto)` devuelve solo líneas con contenido útil tras `strip`.

--- a/docs/standard_library/tiempo.md
+++ b/docs/standard_library/tiempo.md
@@ -31,3 +31,15 @@ usar "tiempo"
 ```
 
 Nombres públicos en español (fuente: `__all__`).
+
+<!-- BEGIN: AUTO-STDLIB-FUNCTIONS -->
+## API pública sincronizada (`standard_library.tiempo`)
+
+| Función |
+|---|
+| `ahora` |
+| `desde_epoch` |
+| `dormir` |
+| `epoch` |
+| `formatear` |
+<!-- END: AUTO-STDLIB-FUNCTIONS -->


### PR DESCRIPTION
### Motivation
- Sincronizar la documentación con el generador oficial para reflejar el contrato público de extensiones y la API expuesta por `standard_library` y la CLI. 
- Incorporar en el índice y las páginas de la biblioteca estándar los módulos `holobit`, `red`, `sistema` y `tiempo` y exponer sus APIs públicas generadas automáticamente.

### Description
- Actualiza `docs/LIBRO_PROGRAMACION_COBRA.md` dentro de los bloques autogenerados `AUTO-CLI-TABLE` y `AUTO-STDLIB-INDEX` para incluir la tabla de comandos CLI y el índice ampliado de `standard_library` respectivamente. 
- Añade bloques `AUTO-STDLIB-FUNCTIONS` en `docs/standard_library/{holobit,red,sistema,tiempo,archivo,asincrono,datos,logica,numero,texto}.md` y actualiza varias tablas de funciones en otros módulos según lo emitido por el generador. 
- Todos los cambios de contenido quedaron limitados a los bloques `AUTO-SYNTAX-INDEX`, `AUTO-CLI-TABLE`, `AUTO-STDLIB-INDEX` y `AUTO-STDLIB-FUNCTIONS`, y el generador solo añadió líneas separadoras fuera de esos bloques cuando fue necesario. 
- No se modificaron `docs/gramatica.ebnf`, `docs/SPEC_COBRA.md`, el Lexer, el Parser, el Runtime ni el código fuente de la biblioteca estándar; sólo se actualizó la documentación generada.

### Testing
- Ejecuté `python scripts/sync_libro_programacion.py --check` y obtuve inicialmente detección de drift (salida con instrucción de sincronizar) con código de salida `1`. 
- Ejecuté `python scripts/sync_libro_programacion.py` que respondió `Secciones documentales sincronizadas.` y generó las actualizaciones observadas en los `AUTO` blocks. 
- Verifiqué programáticamente que fuera de los bloques `AUTO-*` no hay cambios de contenido, que `python scripts/sync_libro_programacion.py --check` final devolvió `Sin drift documental.` con código `0`, y que la segunda ejecución fue idempotente ya que el `git diff` no cambió (SHA256 del diff idéntico antes/después). 
- Ejecuté `git diff --check` y comprobaciones de rutas/archivos críticas y confirmé que Lexer/Parser y archivos prohibidos no se modificaron; todas las comprobaciones automatizadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8176da427083279afa36eb234ff1ee)