### PR TITLE
Corregir contrato público de graficar holobit

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -58,8 +58,8 @@ class _AdaptadorInternoHolobit:
         return [float(v) for v in hb.valores]
 
     @staticmethod
-    def graficar(hb: Any) -> str:
-        return _runtime_graficar(hb)
+    def graficar(hb: Any) -> None:
+        _runtime_graficar(hb)
 
 
 def _es_json_primitivo(valor: Any) -> bool:
@@ -243,16 +243,16 @@ def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[st
     raise ValueError(f"Operacion no soportada: {operacion}")
 
 
-def graficar(hb: dict[str, Any]) -> str:
+def graficar(hb: dict[str, Any]) -> dict[str, str]:
     try:
-        vista = _AdaptadorInternoHolobit.graficar(_desde_estructura_cobra(hb))
+        _AdaptadorInternoHolobit.graficar(_desde_estructura_cobra(hb))
     except Exception as exc:  # pragma: no cover - defensivo frente al SDK
         raise _error_dominio(
             "No se pudo graficar el holobit en el runtime de Cobra", causa=exc
         ) from None
-    if not isinstance(vista, str):
-        raise TypeError("La salida de graficar debe ser texto")
-    return vista
+    resultado = {"estado": "ok"}
+    _garantizar_json_estable(resultado)
+    return resultado
 
 
 def combinar(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/tests/integration/test_runtime_python.py
+++ b/tests/integration/test_runtime_python.py
@@ -42,8 +42,8 @@ def test_holobit_operaciones_publicas_semantica_documentada():
     assert holobit.proyectar(hb, "2d")["valores"] == [3.0, 4.0]
     assert holobit.transformar(hb, "rotar", "z", 90)["tipo"] == "holobit"
     try:
-        vista = holobit.graficar(hb)
-        assert isinstance(vista, str)
+        resultado = holobit.graficar(hb)
+        assert resultado == {"estado": "ok"}
     except TypeError:
         # Runtime parcial/fallback: la API puede rechazar graficado sin backend disponible.
         pass

--- a/tests/unit/test_corelibs_holobit_adapter.py
+++ b/tests/unit/test_corelibs_holobit_adapter.py
@@ -67,6 +67,25 @@ def test_holobit_adapter_normaliza_tipos_cobra_facing():
     assert isinstance(metricas["magnitud"], float)
 
 
+def test_graficar_devuelve_estado_json_e_ignora_retorno_interno(monkeypatch):
+    hb = holobit.crear_holobit([1, 2, 3])
+    proyectados = []
+    retorno_sdk = object()
+
+    def proyectar(interno):
+        proyectados.append(interno)
+        return retorno_sdk
+
+    monkeypatch.setattr(holobit, "_runtime_graficar", proyectar)
+
+    resultado = holobit.graficar(hb)
+
+    assert resultado == {"estado": "ok"}
+    assert len(proyectados) == 1
+    assert proyectados[0].valores == [1.0, 2.0, 3.0]
+    holobit._garantizar_json_estable(resultado)
+
+
 @pytest.mark.parametrize("valor_invalido", [True, False])
 def test_crear_holobit_rechaza_booleanos(valor_invalido):
     with pytest.raises(TypeError):


### PR DESCRIPTION
### Motivation
- Alinear la anotación interna de `graficar` con su uso real y evitar inspeccionar o incorporar el valor retornado por el SDK. 
- Cambiar la firma pública de `graficar(hb)` a un tipo JSON-safe y predecible para garantizar interoperabilidad del runtime. 
- Mantener la conversión con `_desde_estructura_cobra(hb)` y ejecutar la proyección sólo por su efecto lateral sin exponer internals. 

### Description
- Cambié `_AdaptadorInternoHolobit.graficar` para declarar retorno `None` y ejecutar `_runtime_graficar(hb)` exclusivamente por su efecto lateral sin devolver ni inspeccionar su valor. 
- Modifiqué la función pública `graficar(hb)` para devolver `dict[str, str]` con exactamente `{"estado": "ok"}` tras ejecutar la proyección interna y validé la estructura con `_garantizar_json_estable`. 
- Conservé la conversión a runtime mediante `_desde_estructura_cobra(hb)` y capturé/ traduje errores SDK a `ErrorHolobit` sin filtrar símbolos internos. 
- Añadí la prueba `test_graficar_devuelve_estado_json_e_ignora_retorno_interno` y actualicé la prueba de integración afectada para reflejar el nuevo contrato público; no se modificó `src/pcobra/core/holobits/graficar.py`, ni `PUBLIC_API_HOLOBIT`, ni `__all__`. 

### Testing
- Ejecuté `pytest -q tests/unit/test_corelibs_holobit_adapter.py` y la nueva prueba pasó junto con las existentes en ese módulo. 
- Ejecuté `pytest -q tests/unit/test_holobit_corelib_domain_errors.py tests/integration/test_runtime_python.py tests/integration/test_usar_public_contract_regression.py tests/integration/test_repl_usar_entrypoints_contract.py` y la batería reportó éxito completo (todas las pruebas automatizadas relevantes pasaron; resumen: 159 passed, 7 warnings). 
- Verifiqué con `git diff --check` y confirmé que `Lexer` y `Parser` no se vieron afectados por los cambios. 
- Intenté generar el pull request automáticamente, pero la herramienta `make_pr` no está disponible en este entorno, por lo que el PR debe crearse manualmente con este título y descripción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c3b5f8a8832799728b6e124245d1)