### PR TITLE
Traducir y suprimir errores internos en holobit.graficar

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -247,9 +247,7 @@ def graficar(hb: dict[str, Any]) -> dict[str, str]:
     try:
         _AdaptadorInternoHolobit.graficar(_desde_estructura_cobra(hb))
     except Exception as exc:  # pragma: no cover - defensivo frente al SDK
-        raise _error_dominio(
-            "No se pudo graficar el holobit en el runtime de Cobra", causa=exc
-        ) from None
+        raise _traducir_error_interno("graficar", exc) from None
     resultado = {"estado": "ok"}
     _garantizar_json_estable(resultado)
     return resultado

--- a/tests/unit/test_holobit_corelib_domain_errors.py
+++ b/tests/unit/test_holobit_corelib_domain_errors.py
@@ -37,6 +37,34 @@ def test_adaptador_traduce_error_runtime_sdk_a_error_dominio(
         holobit_module.serializar_holobit({"tipo": "holobit", "valores": [1, 2, 3]})
 
 
+@pytest.mark.parametrize("fase", ["adaptacion", "proyeccion"])
+def test_graficar_oculta_errores_internos_en_toda_la_operacion(
+    monkeypatch: pytest.MonkeyPatch, holobit_module, fase: str
+) -> None:
+    class _FalloSdkSecreto(Exception):
+        pass
+
+    def fallar(*_args, **_kwargs):
+        raise _FalloSdkSecreto("mensaje privado de holobit_sdk")
+
+    if fase == "adaptacion":
+        monkeypatch.setattr(holobit_module, "_SDKHolobit", fallar)
+    else:
+        monkeypatch.setattr(holobit_module, "_runtime_graficar", fallar)
+
+    with pytest.raises(holobit_module.ErrorHolobit) as captura:
+        holobit_module.graficar({"tipo": "holobit", "valores": [1, 2, 3]})
+
+    error = captura.value
+    assert str(error) == (
+        "No se pudo ejecutar la operación 'graficar' de holobit en runtime Cobra"
+    )
+    assert error.__cause__ is None
+    assert error.__suppress_context__ is True
+    assert "ErrorHolobit" not in holobit_module.PUBLIC_API_HOLOBIT
+    assert "ErrorHolobit" not in holobit_module.__all__
+
+
 @pytest.mark.parametrize(
     "entrada",
     [


### PR DESCRIPTION
### Motivation

- Evitar la fuga de detalles internos del SDK al usuario cuando `graficar` falla, unificando la traducción de excepciones al error de dominio de Holobit. 
- Mantener la única frontera `try/except` que engloba adaptación y llamada al runtime para preservar comportamiento defensivo sin exponer internals. 
- Garantizar mensajes públicos expresados únicamente en términos de Holobit y runtime Cobra y suprimir la cadena de excepciones.

### Description

- Reemplaza la creación directa de `ErrorHolobit` en `graficar` por la llamada a `_traducir_error_interno("graficar", exc)` y mantiene `raise ... from None` en `src/pcobra/corelibs/holobit.py`.
- Añade una prueba parametrizada que fuerza fallos durante la adaptación (`_SDKHolobit`) y durante la proyección/ejecución (`_runtime_graficar`) para asegurar que la excepción pública es la traducida y que el contexto está suprimido en `tests/unit/test_holobit_corelib_domain_errors.py`.
- No se modificó la superficie pública `PUBLIC_API_HOLOBIT` ni `__all__`, por lo que `ErrorHolobit` continúa sin exportarse públicamente.
- No se tocó el Lexer ni el Parser conforme a las reglas del repositorio.

### Testing

- `pytest -q tests/unit/test_holobit_corelib_domain_errors.py` pasó con éxito (18 passed). 
- `pytest -q tests/integration/test_runtime_python.py tests/integration/test_usar_runtime_contract.py` pasó con éxito (24 passed) y sólo mostró advertencias deprecatorias preexistentes. 
- `ruff check src/pcobra/corelibs/holobit.py tests/unit/test_holobit_corelib_domain_errors.py` pasó sin errores. 
- Una ejecución combinada amplia que incluía `tests/unit/test_usar_loader_public_api_contract.py` mostró 5 fallos preexistentes no relacionados con este cambio; los fallos provienen de expectativas sobre la política de símbolos prohibidos en otra suite y no se deben a las modificaciones de Holobit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c7bf2aec8327ab0d7ae105f9f4ce)