### PR TITLE
Pruebas: contrato público de `graficar` y refuerzo de comprobaciones de exportaciones

### DIFF
--- a/tests/unit/test_holobit_graficar_contract.py
+++ b/tests/unit/test_holobit_graficar_contract.py
@@ -1,0 +1,89 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def holobit_module():
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_graficar_contract", ruta)
+    modulo = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+def test_graficar_retorna_solo_estado_publico_json_safe(
+    monkeypatch: pytest.MonkeyPatch, holobit_module
+) -> None:
+    monkeypatch.setattr(
+        holobit_module._AdaptadorInternoHolobit,
+        "graficar",
+        lambda _holobit: None,
+    )
+
+    resultado = holobit_module.graficar(
+        {"tipo": "holobit", "valores": [1, 2, 3]}
+    )
+
+    assert resultado == {"estado": "ok"}
+    assert json.dumps(resultado) == '{"estado": "ok"}'
+    assert all(isinstance(clave, str) for clave in resultado)
+    assert all(
+        valor is None or isinstance(valor, (str, int, float, bool))
+        for valor in resultado.values()
+    )
+
+
+def test_graficar_ignora_resultado_interno_del_sdk(
+    monkeypatch: pytest.MonkeyPatch, holobit_module
+) -> None:
+    class CentinelaSdk:
+        pass
+
+    CentinelaSdk.__module__ = "holobit_sdk.core.holobit"
+    centinela = CentinelaSdk()
+    monkeypatch.setattr(
+        holobit_module._AdaptadorInternoHolobit,
+        "graficar",
+        lambda _holobit: centinela,
+    )
+
+    resultado = holobit_module.graficar(
+        {"tipo": "holobit", "valores": [1, 2, 3]}
+    )
+
+    assert resultado == {"estado": "ok"}
+    assert centinela not in resultado.values()
+    json.dumps(resultado)
+
+
+def test_graficar_sanea_excepcion_interna_del_sdk(
+    monkeypatch: pytest.MonkeyPatch, holobit_module
+) -> None:
+    class FalloInternoHolobitSdk(Exception):
+        pass
+
+    FalloInternoHolobitSdk.__module__ = "holobit_sdk.core.holobit"
+    mensaje_original = "holobit_sdk fallo secreto de FalloInternoHolobitSdk"
+
+    def fallar(_holobit):
+        raise FalloInternoHolobitSdk(mensaje_original)
+
+    monkeypatch.setattr(
+        holobit_module._AdaptadorInternoHolobit, "graficar", fallar
+    )
+
+    with pytest.raises(holobit_module.ErrorHolobit) as captura:
+        holobit_module.graficar(
+            {"tipo": "holobit", "valores": [1, 2, 3]}
+        )
+
+    mensaje_publico = str(captura.value)
+    assert "Cobra" in mensaje_publico
+    assert "graficar" in mensaje_publico
+    assert "holobit_sdk" not in mensaje_publico
+    assert "FalloInternoHolobitSdk" not in mensaje_publico
+    assert mensaje_original not in mensaje_publico

--- a/tests/unit/test_holobit_no_fuga_exports.py
+++ b/tests/unit/test_holobit_no_fuga_exports.py
@@ -64,5 +64,23 @@ def test_no_fuga_en_corelibs_por_getattr():
 
 def test_corelibs_no_exporta_clases_internas_de_adaptador():
     mod = _load_corelib_module()
-    for symbol in ("_AdaptadorInternoHolobit", "_SDKHolobit", "ErrorHolobit"):
-        assert symbol not in set(mod.__all__)
+    assert mod.__all__ == list(mod.PUBLIC_API_HOLOBIT)
+    assert mod.__all__ == [
+        "crear_holobit",
+        "validar_holobit",
+        "serializar_holobit",
+        "deserializar_holobit",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    ]
+    for symbol in (
+        "ErrorHolobit",
+        "Holobit",
+        "_SDKHolobit",
+        "_AdaptadorInternoHolobit",
+        "holobit_sdk",
+    ):
+        assert symbol not in mod.__all__


### PR DESCRIPTION
### Motivation

- Añadir pruebas dirigidas que verifiquen la frontera pública de `src/pcobra/corelibs/holobit.py` para garantizar que la operación `graficar` no filtre datos internos del SDK ni excepciones privadas. 
- Asegurar que la API pública expuesta por el módulo corelibs no contiene símbolos internos ni fugas del SDK.

### Description

- Añadí `tests/unit/test_holobit_graficar_contract.py` que carga el módulo con una fixture que importa directamente `src/pcobra/corelibs/holobit.py` y usa `monkeypatch` para sustituir `_AdaptadorInternoHolobit.graficar` en las pruebas. 
- Implementé pruebas que verifican que una proyección exitosa retorna exactamente `{"estado": "ok"}`, que `json.dumps(resultado)` funciona y que solo aparecen claves/valores JSON-safe. 
- Añadí una prueba que crea un objeto centinela cuya clase tiene `__module__ = "holobit_sdk.core.holobit"` y comprueba que dicho objeto devuelto por el adaptador se ignora y la respuesta sigue siendo `{"estado": "ok"}`. 
- Añadí una prueba que provoca una excepción interna con módulo `holobit_sdk` y verifica que la API eleva `ErrorHolobit` con un mensaje orientado a terminología Cobra y sin revelar `holobit_sdk`, nombres de clases internas ni el mensaje original. 
- Modifiqué `tests/unit/test_holobit_no_fuga_exports.py` para afirmar explícita y ordenadamente que `__all__` coincide exactamente con `PUBLIC_API_HOLOBIT` y para comprobar que no incluye símbolos internos como `ErrorHolobit`, `Holobit`, `_SDKHolobit`, `_AdaptadorInternoHolobit` ni `holobit_sdk`.
- No se realizaron cambios en Lexer ni Parser y las modificaciones son limitadas a nuevas pruebas y ajustes de comprobaciones de exportaciones.

### Testing

- Ejecuté `pytest -q tests/unit/test_holobit_graficar_contract.py tests/unit/test_holobit_corelib_domain_errors.py tests/unit/test_holobit_no_fuga_exports.py` y la ejecución informó `28 passed, 2 failed` (las fallas provienen de comprobaciones de superficies externas relacionadas con `pcobra.core.holobits`).
- Ejecuté pruebas focalizadas con `pytest -q tests/unit/test_holobit_graficar_contract.py tests/unit/test_holobit_no_fuga_exports.py::test_corelibs_holobit_solo_exporta_api_canonica tests/unit/test_holobit_no_fuga_exports.py::test_corelibs_no_exporta_clases_internas_de_adaptador` y obtuve `5 passed` (las nuevas pruebas y las comprobaciones de corelibs relacionadas pasaron).
- Ejecuté `python -m ruff check tests/unit/test_holobit_graficar_contract.py tests/unit/test_holobit_no_fuga_exports.py` y `git diff --check`, ambos sin problemas reportados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86d6fb6d8c83278db0c2f142f854ac)