### PR TITLE
test: reforzar rechazo de holobit_sdk en usar

### DIFF
--- a/tests/integration/test_usar_core_contract_full.py
+++ b/tests/integration/test_usar_core_contract_full.py
@@ -127,6 +127,7 @@ def test_04_rechaza_numpy_y_no_inyecta(monkeypatch):
 
 def test_05_rechaza_holobit_sdk(monkeypatch):
     mod_holobit = _modulo_holobit_publico_stub()
+    assert "holobit_sdk" not in REPL_COBRA_MODULE_MAP
     monkeypatch.setattr(
         core_usar_loader,
         "obtener_modulo_cobra_oficial",
@@ -140,10 +141,16 @@ def test_05_rechaza_holobit_sdk(monkeypatch):
     cmd.interpretador.configurar_restriccion_usar_repl(
         {**REPL_COBRA_MODULE_MAP, "holobit": "holobit"}
     )
+    estado_pre = dict(cmd.interpretador.contextos[-1].values)
     with pytest.raises(
         PermissionError, match=r"módulo externo no permitido en REPL estricto"
     ):
         cmd.ejecutar_codigo('usar "holobit_sdk"')
+
+    simbolos = cmd.interpretador.contextos[-1].values
+    assert simbolos == estado_pre
+    assert "holobit_sdk" not in simbolos
+    assert all(nombre not in simbolos for nombre in mod_holobit.__all__)
 
 
 def test_06_saneamiento_excluye_nombres_prohibidos_y_doble_guion_bajo():


### PR DESCRIPTION
### Motivation
- Asegurar que `holobit_sdk` permanece fuera del catálogo público y que `usar "holobit_sdk"` se rechaza sin mutar el contexto del intérprete ni inyectar símbolos públicos de Holobit.

### Description
- Se reforzó la prueba en `tests/integration/test_usar_core_contract_full.py::test_05_rechaza_holobit_sdk` añadiendo una aserción de que `holobit_sdk` no está en `REPL_COBRA_MODULE_MAP`, comprobación de atomicidad del contexto tras el rechazo y verificación de que no se inyectan los nombres públicos del stub de Holobit.

### Testing
- Se ejecutaron las pruebas dirigidas y relacionadas con Holobit con `pytest` (el caso `test_05_rechaza_holobit_sdk`, los tests filtrados por `-k 'holobit or holobit_sdk'` y la suite de integración completa) y las ejecuciones automáticas confirmaron que las pruebas focales relacionadas con `holobit`/`holobit_sdk` pasan; existen fallos preexistentes no relacionados en otras partes de la suite global.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86deba1e308327b80695def3d22fc9)