### PR TITLE
fix(holobit): rechazar valores no finitos

### DIFF
--- a/docs/auditoria_holobit_contract_fix.md
+++ b/docs/auditoria_holobit_contract_fix.md
@@ -1,86 +1,80 @@
-# Auditoría de la corrección del contrato público de Holobit
+# Auditoría de valores finitos en el contrato público de Holobit
 
 ## Problema encontrado
 
-La función pública `graficar` de la corelib declaraba y validaba una salida de
-tipo `str`. Esa expectativa era incompatible con el runtime interno: la
-operación de graficado se ejecuta por efecto lateral y su retorno normal es
-`None`. Como consecuencia, una ejecución interna correcta podía terminar en un
-`TypeError` al atravesar la corelib, únicamente porque `None` no satisfacía el
-contrato público de texto.
+La frontera pública de Holobit aceptaba `NaN`, `Infinity` y `-Infinity` porque
+`_normalizar_valores` comprobaba que cada elemento fuera numérico, pero lo
+incorporaba a la salida inmediatamente después de convertirlo a `float`. Estos
+valores podían entrar mediante `crear_holobit` o un payload JSON y propagarse a
+serialización, proyección, transformación, combinación y medición.
 
 ## Solución aplicada
 
-La frontera pública deja de propagar o interpretar el valor devuelto por la
-implementación interna. Después de que el adaptador complete la operación sin
-excepciones, `graficar` construye y retorna exactamente:
+Después de conservar la validación `_es_numero(item)`, cada elemento se
+convierte exactamente una vez con `valor_normalizado = float(item)`. Antes de
+añadirlo a `salida`, `_normalizar_valores` ejecuta exactamente
+`math.isfinite(valor_normalizado)`. Si el resultado es falso, lanza `ValueError`
+con el mensaje público de dominio `Todos los valores del holobit deben ser
+finitos`.
 
-```json
-{"estado": "ok"}
-```
-
-Antes de entregarlo, el resultado pasa por la validación JSON-safe de la
-corelib. El retorno interno se descarta deliberadamente: tanto el `None`
-esperado como cualquier otro objeto que pudiera devolver el SDK permanecen
-detrás del adaptador y no alteran ni contaminan la respuesta pública.
+El rechazo mediante `TypeError` de booleanos, texto, bytes y elementos no
+numéricos permanece intacto. Los enteros y `float` finitos continúan
+normalizándose a `float`. La validación centralizada protege también las rutas
+de deserialización, validación, serialización, proyección, transformación,
+combinación y medición sin duplicar lógica productiva.
 
 ## Archivos modificados
 
-El cambio mínimo realizado en esta tarea de documentación modifica únicamente:
-
-- `docs/auditoria_holobit_contract_fix.md` (este informe).
-
-No se realizaron cambios adicionales al runtime, a pruebas ni a otros
-documentos durante esta tarea.
+- `src/pcobra/corelibs/holobit.py`: comprobación de finitud en
+  `_normalizar_valores`.
+- `tests/unit/test_corelibs_holobit_adapter.py`: casos parametrizados de valores
+  no finitos, payloads JSON, validación booleana, operaciones protegidas y
+  roundtrip positivo con enteros, cero, negativos y floats finitos.
+- `docs/auditoria_holobit_contract_fix.md`: este informe de auditoría.
 
 ## Verificaciones ejecutadas
 
-Los comandos se ejecutaron desde la raíz del repositorio, en el orden solicitado:
+Los comandos se ejecutaron desde la raíz del repositorio, en el orden
+solicitado:
 
-1. Prueba dirigida del retorno público de `graficar`:
+1. Pruebas dirigidas del nuevo contrato:
 
    ```console
-   $ pytest -q tests/unit/test_holobit_graficar_contract.py
-   3 passed in 2.57s
+   $ pytest -q tests/unit/test_corelibs_holobit_adapter.py -k 'no_finitos or valores_no_finitos or public_contract_roundtrip'
+   15 passed, 17 deselected in 2.02s
    ```
 
-   Resultado: **correcto** (código de salida 0). Cubre el retorno fijo JSON-safe,
-   el descarte del objeto interno del SDK y el saneamiento de sus excepciones.
+2. Archivo unitario completo del adaptador Holobit:
 
-2. Suites de Holobit y contratos relacionados de `usar`:
+   ```console
+   $ pytest -q tests/unit/test_corelibs_holobit_adapter.py
+   32 passed in 1.67s
+   ```
+
+3. Suite ampliada documentada:
 
    ```console
    $ pytest -q tests/integration/test_holobit_tiers.py tests/integration/transpilers/test_holobit_hooks_golden.py tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_holobit_backend_contract_matrix.py tests/unit/test_holobit_corelib_domain_errors.py tests/unit/test_holobit_generation.py tests/unit/test_holobit_graficar_contract.py tests/unit/test_holobit_no_fuga_exports.py tests/unit/test_holobit_runtime_backends.py tests/unit/test_holobit_sdk_compatibility_report.py tests/unit/test_holobit_sdk_fallback_contract.py tests/unit/test_holobit_sdk_integration.py tests/unit/test_holobit_transformacion_extra.py tests/unit/test_parser_holobit.py tests/unit/test_to_js_holobit_runtime_snapshot.py tests/integration/test_repl_usar_entrypoints_contract.py tests/integration/test_usar_canonical_surface_contract.py tests/integration/test_usar_core_contract_full.py tests/integration/test_usar_export_sanitation.py tests/integration/test_usar_public_contract_regression.py tests/integration/test_usar_runtime_contract.py tests/unit/test_usar_loader_public_api_contract.py tests/unit/test_usar_loader_validation.py tests/unit/test_usar_numpy_error_contract.py tests/unit/test_usar_policy_contract.py tests/unit/test_usar_public_contract.py
-   15 failed, 492 passed, 5 skipped, 2 warnings in 14.22s
+   15 failed, 506 passed, 5 skipped, 2 warnings in 12.46s
    ```
 
-   Resultado: **con fallos preexistentes fuera del hallazgo dirigido** (código de
-   salida 1). Los 15 fallos corresponden a contratos históricos inconsistentes
-   en exportaciones de `pcobra.core.holobits`, la matriz de compatibilidad de
-   backends y validaciones generales de `usar`. No se modificaron runtime,
-   pruebas, lexer, parser, AST ni transpiladores para ocultarlos o mezclarlos con
-   la estabilización ya implementada de `graficar`.
-
-3. Comprobaciones del parche final:
-
-   - `git diff --check`: sin errores.
-   - `git diff --name-only`: únicamente
-     `docs/auditoria_holobit_contract_fix.md`; no aparecen rutas de lexer,
-     parser, AST ni transpiladores.
-   - Revisión de `git diff`: no amplía `PUBLIC_API_HOLOBIT` ni `__all__`.
+   El resultado conserva **exactamente el baseline de 15 fallos históricos**.
+   Los fallos siguen perteneciendo a exportaciones históricas de
+   `pcobra.core.holobits`, la matriz de compatibilidad de backends y contratos
+   generales de `usar`; ninguno corresponde a la nueva validación de finitud.
+   No se modificaron sus pruebas ni los subsistemas afectados para ocultarlos.
 
 ## Riesgos pendientes
 
-- La proyección y las operaciones completas de Holobit en el runtime Python
-  siguen dependiendo de `holobit_sdk`.
-- Los objetos, las excepciones y los módulos de `holobit_sdk` permanecen detrás
-  del adaptador interno: no forman parte del retorno público de `graficar` ni se
-  exponen a través de él.
-- Una indisponibilidad o un fallo del SDK todavía puede impedir la operación;
-  la frontera pública debe continuar traduciendo ese fallo sin filtrar detalles
-  internos.
+- Los 15 fallos históricos de la suite ampliada permanecen pendientes y fuera
+  del alcance incremental de este hallazgo.
+- La protección depende de que toda estructura pública continúe atravesando
+  `_normalizar_valores`; las operaciones públicas actuales sí comparten esa
+  frontera y quedan cubiertas por las pruebas.
+- Una indisponibilidad o un fallo del runtime interno todavía puede impedir una
+  operación; este cambio no modifica la traducción existente de esos errores.
 
 ## Confirmación de alcance
 
-Se confirma expresamente que en esta tarea **no fueron modificados** el lexer,
-el parser, el AST, los transpiladores, `PUBLIC_API_HOLOBIT` ni `__all__`.
+El cambio no modifica lexer, parser, AST, transpiladores, adaptadores de
+imports, `PUBLIC_API_HOLOBIT`, `__all__` ni el contrato de `graficar`.

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -93,7 +93,10 @@ def _normalizar_valores(valores: Iterable[Any]) -> list[float]:
     for item in valores:
         if not _es_numero(item):
             raise TypeError("Todos los valores del holobit deben ser numéricos")
-        salida.append(float(item))
+        valor_normalizado = float(item)
+        if not math.isfinite(valor_normalizado):
+            raise ValueError("Todos los valores del holobit deben ser finitos")
+        salida.append(valor_normalizado)
     return salida
 
 

--- a/tests/unit/test_corelibs_holobit_adapter.py
+++ b/tests/unit/test_corelibs_holobit_adapter.py
@@ -25,9 +25,10 @@ EXPECTED_PUBLIC_API = {
 
 
 def test_holobit_adapter_public_contract_roundtrip():
-    hb = holobit.crear_holobit([1, 2, 3])
+    hb = holobit.crear_holobit([1, 0, -2, 3.5])
     assert set(holobit.__all__) == EXPECTED_PUBLIC_API
-    assert hb == {"tipo": "holobit", "valores": [1.0, 2.0, 3.0]}
+    assert hb == {"tipo": "holobit", "valores": [1.0, 0.0, -2.0, 3.5]}
+    assert all(isinstance(valor, float) for valor in hb["valores"])
     assert holobit.validar_holobit(hb) is True
 
     payload = holobit.serializar_holobit(hb)
@@ -90,6 +91,50 @@ def test_graficar_devuelve_estado_json_e_ignora_retorno_interno(monkeypatch):
 def test_crear_holobit_rechaza_booleanos(valor_invalido):
     with pytest.raises(TypeError):
         holobit.crear_holobit([valor_invalido, 1])
+
+
+@pytest.mark.parametrize("valor_no_finito", [float("nan"), float("inf"), float("-inf")])
+def test_crear_holobit_rechaza_valores_no_finitos(valor_no_finito):
+    with pytest.raises(ValueError, match="valores del holobit deben ser finitos"):
+        holobit.crear_holobit([valor_no_finito])
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"tipo":"holobit","valores":[NaN]}',
+        '{"tipo":"holobit","valores":[Infinity]}',
+        '{"tipo":"holobit","valores":[-Infinity]}',
+    ],
+)
+def test_deserializar_holobit_rechaza_valores_no_finitos(payload):
+    with pytest.raises(ValueError):
+        holobit.deserializar_holobit(payload)
+
+
+@pytest.mark.parametrize("valor_no_finito", [float("nan"), float("inf"), float("-inf")])
+def test_validar_holobit_devuelve_false_para_valores_no_finitos(valor_no_finito):
+    assert (
+        holobit.validar_holobit({"tipo": "holobit", "valores": [valor_no_finito]})
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("operacion", "argumentos"),
+    [
+        (holobit.serializar_holobit, ()),
+        (holobit.proyectar, ("2d",)),
+        (holobit.transformar, ("rotar", "z", 90)),
+        (holobit.combinar, ({"tipo": "holobit", "valores": [1]},)),
+        (holobit.medir, ()),
+    ],
+)
+def test_operaciones_rechazan_estructuras_con_valores_no_finitos(operacion, argumentos):
+    estructura = {"tipo": "holobit", "valores": [float("inf")]}
+
+    with pytest.raises(ValueError):
+        operacion(estructura, *argumentos)
 
 
 def test_policy_rechaza_holobit_sdk_en_usar():


### PR DESCRIPTION
### Motivation
- Evitar que `NaN`, `Infinity` y `-Infinity` entren en la API pública de Holobit y puedan propagarse a serialización, proyección, transformación, combinación y medición.
- Mantener la validación centralizada en el adaptador sin cambiar lexer, parser, AST, transpiladores ni la superficie pública existente.

### Description
- En `src/pcobra/corelibs/holobit.py` `_normalizar_valores` ahora convierte cada elemento una sola vez con `valor_normalizado = float(item)` y rechaza no finitos con `if not math.isfinite(valor_normalizado): raise ValueError("Todos los valores del holobit deben ser finitos")`, preservando los `TypeError` existentes para tipos no numéricos.
- Se añadieron casos de prueba en `tests/unit/test_corelibs_holobit_adapter.py` que comprueban `crear_holobit([NaN|Inf|-Inf])` falla con `ValueError`, verifican payloads JSON con `NaN/Infinity/-Infinity` rechazados por `deserializar_holobit`, que `validar_holobit` devuelve `False` para valores no finitos y que `serializar_holobit`, `proyectar`, `transformar`, `combinar` y `medir` rechazan estructuras con valores no finitos; también se amplió el roundtrip positivo para cubrir enteros, cero, negativos y floats finitos.
- Se actualizó `docs/auditoria_holobit_contract_fix.md` con la auditoría que explica la incorporación exacta de `math.isfinite()`, archivos modificados, comandos ejecutados, resultados y riesgos remanentes, sin modificar `PUBLIC_API_HOLOBIT`, `__all__` ni `graficar`.

### Testing
- `pytest -q tests/unit/test_corelibs_holobit_adapter.py -k 'no_finitos or valores_no_finitos or public_contract_roundtrip'` — 15 passed, 17 deselected.
- `pytest -q tests/unit/test_corelibs_holobit_adapter.py` — 32 passed.
- Suite ampliada (tal como documentada en la auditoría) — resultado preserva exactamente el baseline histórico: `15 failed, 506 passed, 5 skipped, 2 warnings`, sin aparición de fallos adicionales atribuibles al cambio.
- Formateo y checks: `black --check` y `git diff --check` pasaron, y las comprobaciones muestran que no se modificaron lexer, parser, AST, transpiladores, `PUBLIC_API_HOLOBIT`, `__all__` ni el contrato de `graficar`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86f41be1e88327847216466a0bd37d)