### PR TITLE
fix(usar): clasificar nombres bloqueados según equivalencias canónicas

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -186,10 +186,15 @@ def sanear_simbolo_para_usar(
         )
 
     if nombre in NOMBRES_BLOQUEADOS_USAR:
+        codigo = (
+            "cobra_public_equivalent"
+            if nombre in EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS
+            else "explicit_forbidden_name"
+        )
         return _rechazar(
             nombre,
             simbolo,
-            "explicit_forbidden_name",
+            codigo,
             _mensaje_nombre_prohibido(nombre),
             metadata,
         )

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -22,6 +22,28 @@ def test_rechaza_nombres_prohibidos_explicitos():
         assert "Usa el nombre Cobra canónico" in (resultado.mensaje or "")
 
 
+def test_nombres_bloqueados_con_equivalencia_declaran_codigo_y_canonico():
+    equivalencias = {
+        "append": "agregar",
+        "expect": "obtener_o_error",
+        "filter": "filtrar",
+        "map": "mapear",
+        "unwrap": "obtener_o_error",
+    }
+
+    for nombre, canonico in equivalencias.items():
+        resultado = sanear_simbolo_para_usar(nombre, lambda: None)
+        assert resultado.nombre == nombre
+        assert resultado.rechazado is True
+        assert resultado.codigo == "cobra_public_equivalent"
+        assert canonico in (resultado.mensaje or "")
+
+    sin_equivalencia = sanear_simbolo_para_usar("__self__", lambda: None)
+    assert sin_equivalencia.nombre == "__self__"
+    assert sin_equivalencia.rechazado is True
+    assert sin_equivalencia.codigo == "explicit_forbidden_name"
+
+
 def test_rechaza_doble_guion_bajo_y_modulo_backend():
     r_privado = sanear_simbolo_para_usar("__danger__", lambda: None)
     assert r_privado.rechazado is True


### PR DESCRIPTION
### Motivation

- Asegurar que cuando un nombre esté en `NOMBRES_BLOQUEADOS_USAR` se determine el código de rechazo en función de si existe una equivalencia canónica en `EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS`, y que el mensaje incluya el equivalente canónico cuando corresponda. 
- Verificar explícitamente las correspondencias solicitadas: `append → agregar`, `expect → obtener_o_error`, `filter → filtrar`, `map → mapear`, `unwrap → obtener_o_error`.

### Description

- Ajuste en `sanear_simbolo_para_usar` para calcular `codigo` como `"cobra_public_equivalent"` si `nombre` está en `EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS` y `"explicit_forbidden_name"` en caso contrario, y pasar `codigo` a `_rechazar` en la rama de `NOMBRES_BLOQUEADOS_USAR`.
- Se preservan llamadas a `_rechazar`, `rechazado=True`, `ResultadoSaneamientoSimboloUsar.nombre` con el símbolo original y el uso de `_mensaje_nombre_prohibido(nombre)` para que el mensaje contenga la equivalencia canónica cuando exista.
- Se añadió una prueba unitaria que valida las cinco correspondencias requeridas y comprueba también un caso bloqueado sin equivalencia (`__self__`) que debe devolver `explicit_forbidden_name`.
- No se modificaron `EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS`, listas de bloqueo, Lexer, Parser, AST, transpiladores, runtime, corelibs, resolver ni CLI.

### Testing

- Ejecutado `python -m pytest tests/unit/test_usar_symbol_policy.py -q` y obtuvo `26 passed` (todas las pruebas del archivo pasaron).
- Ejecutado `python -m pytest tests/integration/test_usar_runtime_contract.py -q` y obtuvo `21 passed` (suite de integración relevante pasó).
- Al ejecutar conjuntamente `tests/unit/test_usar_loader_public_api_contract.py` junto con la integración se produjo un error de recopilación no relacionado con este cambio: `ImportError: attempted relative import beyond top-level package` durante la colección de `test_usar_loader_public_api_contract.py` (la integración y las pruebas unitarias relevantes fueron ejecutadas por separado y pasaron).
- Verificación de estado del árbol y diffs: `git diff --check` y comprobación de que no se tocaron componentes excluidos completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87147061fc832796e5716475a8172a)