### PR TITLE
test: parametrizar y endurecer pruebas de símbolos prohibidos en usar

### DIFF
--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -1,5 +1,7 @@
 from types import ModuleType
 
+import pytest
+
 from pcobra.core.usar_symbol_policy import (
     CANONICAL_USAR_METADATA_SCHEMA,
     PoliticaSaneamientoUsar,
@@ -11,37 +13,47 @@ from pcobra.core.usar_symbol_policy import (
 )
 
 
-def test_rechaza_nombres_prohibidos_explicitos():
-    for nombre in ("self", "append", "map", "filter", "unwrap", "expect"):
-        resultado = sanear_simbolo_para_usar(nombre, lambda: None)
-        assert resultado.rechazado is True
-        assert resultado.codigo in {
-            "explicit_forbidden_name",
-            "cobra_public_equivalent",
-        }
-        assert "Usa el nombre Cobra canónico" in (resultado.mensaje or "")
+@pytest.mark.parametrize(
+    ("nombre", "equivalente_cobra"),
+    [
+        ("append", "agregar"),
+        ("expect", "obtener_o_error"),
+        ("filter", "filtrar"),
+        ("map", "mapear"),
+        ("unwrap", "obtener_o_error"),
+    ],
+)
+def test_nombres_bloqueados_con_equivalencia_declaran_codigo_y_canonico(
+    nombre, equivalente_cobra
+):
+    resultado = sanear_simbolo_para_usar(nombre, lambda: None)
+
+    assert resultado.rechazado is True
+    assert resultado.codigo == "cobra_public_equivalent"
+    assert resultado.nombre == nombre
+    assert equivalente_cobra in (resultado.mensaje or "")
+
+    permitidos, rechazos, _ = sanear_exportables_para_usar(
+        [(nombre, lambda: None)]
+    )
+    assert nombre not in {nombre_exportado for nombre_exportado, _ in permitidos}
+    assert [rechazo.nombre for rechazo in rechazos.rechazos_duros] == [nombre]
 
 
-def test_nombres_bloqueados_con_equivalencia_declaran_codigo_y_canonico():
-    equivalencias = {
-        "append": "agregar",
-        "expect": "obtener_o_error",
-        "filter": "filtrar",
-        "map": "mapear",
-        "unwrap": "obtener_o_error",
-    }
+def test_nombre_bloqueado_sin_equivalencia_conserva_rechazo_explicito():
+    resultado = sanear_simbolo_para_usar("__self__", lambda: None)
 
-    for nombre, canonico in equivalencias.items():
-        resultado = sanear_simbolo_para_usar(nombre, lambda: None)
-        assert resultado.nombre == nombre
-        assert resultado.rechazado is True
-        assert resultado.codigo == "cobra_public_equivalent"
-        assert canonico in (resultado.mensaje or "")
+    assert resultado.nombre == "__self__"
+    assert resultado.rechazado is True
+    assert resultado.codigo == "explicit_forbidden_name"
 
-    sin_equivalencia = sanear_simbolo_para_usar("__self__", lambda: None)
-    assert sin_equivalencia.nombre == "__self__"
-    assert sin_equivalencia.rechazado is True
-    assert sin_equivalencia.codigo == "explicit_forbidden_name"
+
+def test_rechaza_self_con_su_equivalente_canonico():
+    resultado = sanear_simbolo_para_usar("self", lambda: None)
+
+    assert resultado.rechazado is True
+    assert resultado.codigo == "cobra_public_equivalent"
+    assert "instancia" in (resultado.mensaje or "")
 
 
 def test_rechaza_doble_guion_bajo_y_modulo_backend():
@@ -75,10 +87,7 @@ def test_reglas_de_saneamiento_por_caso_especifico():
 
     r_backend_ingles = sanear_simbolo_para_usar("append", lambda: None)
     assert r_backend_ingles.rechazado is True
-    assert r_backend_ingles.codigo in {
-        "explicit_forbidden_name",
-        "cobra_public_equivalent",
-    }
+    assert r_backend_ingles.codigo == "cobra_public_equivalent"
 
 
 def test_saneamiento_centralizado_aplica_todas_las_reglas():


### PR DESCRIPTION
### Motivation

- Aumentar la precisión de las pruebas que verifican la política de nombres prohibidos en `usar` para casos con equivalentes en Cobra y asegurar que el rechazo persiste al pasar por el saneamiento de exportables. 

### Description

- Añade `pytest` e introduce una prueba parametrizada para `append`, `expect`, `filter`, `map` y `unwrap` que verifica rechazo, `codigo == "cobra_public_equivalent"`, conservación del `nombre`, y presencia del equivalente Cobra esperado en el `mensaje` en `tests/unit/test_usar_symbol_policy.py`.
- Comprueba además que el símbolo no aparece entre los permitidos tras `sanear_exportables_para_usar` y que figura en los rechazos duros.
- Se separa el caso `__self__` en una prueba independiente que confirma que sigue rechazado con `explicit_forbidden_name` y se añade una prueba para `self` que verifica su equivalencia a `instancia` y el código `cobra_public_equivalent`.
- Sustituye la aserción permisiva previa relacionada con `append` por una comprobación exacta del código contractual `cobra_public_equivalent` y no modifica Lexer/Parser ni reglas de sintaxis.

### Testing

- `pytest -q tests/unit/test_usar_symbol_policy.py` — la suite dirigida pasó con `31 passed`.
- `git diff --check` — sin errores detectados en el diff.
- Verificación de que no se modificaron Lexer ni Parser — comprobación satisfecha.
- `pytest -q tests/unit` — la ejecución completa presentó numerosos fallos preexistentes en áreas no relacionadas (AST/caché SQLite/CLI) y se interrumpió, por lo que solo se consideró como contexto y no como bloqueo para este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a872381e5b483278b12226681ebe5cb)