### PR TITLE
Centraliza diagnósticos públicos de `usar` y sanitiza mensajes de error

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -143,6 +143,8 @@ USAR_NON_PUBLIC_MODULE_ERROR = "usar_error[modulo_fuera_catalogo_publico]: el m�
 USAR_NON_FACING_MODULE_ERROR = "usar_error[modulo_no_cobra_facing]: el módulo solicitado no está marcado como Cobra-facing"
 USAR_INVALID_EXPORT_ERROR = "usar_error[export_invalido]"
 USAR_SYMBOL_CONFLICT_ERROR = "usar_error[conflicto_simbolo]"
+USAR_MODULE_NOT_FOUND_ERROR = "usar_error[modulo_no_encontrado]"
+USAR_MODULE_LOAD_ERROR = "usar_error[carga_modulo_error]"
 USAR_COLLISION_STRICT_ERROR = "strict_error"
 USAR_COLLISION_WARN_ALIAS_REQUIRED = "warn_alias_required"
 _USAR_COLLISION_POLICIES = frozenset(
@@ -154,13 +156,23 @@ def formatear_error_usar_usuario(
     codigo: str, modulo: str, contexto_minimo: str | None = None
 ) -> str:
     """Devuelve errores cortos y legibles para la salida de usuario en `usar`."""
+    codigos = {
+        "modulo_fuera_catalogo": USAR_NON_PUBLIC_MODULE_ERROR,
+        "conflicto_simbolo": USAR_SYMBOL_CONFLICT_ERROR,
+        "export_invalido": USAR_INVALID_EXPORT_ERROR,
+        "modulo_no_encontrado": USAR_MODULE_NOT_FOUND_ERROR,
+        "carga_modulo_error": USAR_MODULE_LOAD_ERROR,
+    }
     mensajes = {
         "modulo_fuera_catalogo": f"No se puede usar '{modulo}': módulo fuera del catálogo público.",
         "conflicto_simbolo": f"No se puede usar '{modulo}': hay conflicto de símbolos en el contexto actual.",
         "export_invalido": f"No se puede usar '{modulo}': no hay símbolos exportables válidos.",
+        "modulo_no_encontrado": f"No se puede usar '{modulo}': módulo no encontrado.",
         "carga_modulo_error": f"No se puede usar '{modulo}': error al cargar el módulo.",
     }
     base = mensajes.get(codigo, f"No se puede usar '{modulo}'.")
+    codigo_publico = codigos.get(codigo, USAR_MODULE_LOAD_ERROR).split(":", 1)[0]
+    base = f"{codigo_publico}: {base}"
     if contexto_minimo:
         return f"{base} {contexto_minimo}"
     return base
@@ -197,21 +209,10 @@ def _error_usuario_modulo_fuera_catalogo(
 ) -> PermissionError:
     """Crea un PermissionError corto y conserva el detalle técnico como nota."""
 
-    if repl_estricto:
-        mensaje = (
-            f"Importación no permitida en 'usar': '{modulo}'. "
-            "Es un módulo backend/no canónico y no forma parte de la API pública. "
-            f"Módulos permitidos: {_resumir_modulos_permitidos_usar()}."
-        )
-    else:
-        mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", modulo)
-
-    if incluir_detalle:
-        mensaje = f"{mensaje} {USAR_NON_PUBLIC_MODULE_ERROR}. Detalle: {detalle}"
-
+    del repl_estricto, incluir_detalle
+    mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", modulo)
     error = PermissionError(mensaje)
-    if not incluir_detalle:
-        error.add_note(str(detalle))
+    error.add_note(str(detalle))
     return error
 
 
@@ -2832,7 +2833,7 @@ class InterpretadorCobra:
             self._inyectar_exports_modulo_proyecto(exports)
         except Exception as exc:
             detalle_usar_habilitado = _usar_detalle_habilitado()
-            exc_usuario = exc
+            exc_usuario: Exception
             if isinstance(exc, ModuloFueraCatalogoPublicoError):
                 exc_usuario = _error_usuario_modulo_fuera_catalogo(
                     nombre_modulo_limpio,
@@ -2840,6 +2841,43 @@ class InterpretadorCobra:
                     repl_estricto=self._repl_usar_alias_map is not None,
                     incluir_detalle=detalle_usar_habilitado,
                 )
+            elif isinstance(exc, ValueError):
+                # Los validadores del loader conservan el diagnóstico preciso;
+                # la frontera pública sólo revela el rechazo de política.
+                exc_usuario = PermissionError(USAR_DIRECT_BACKEND_IMPORT_ERROR)
+                exc_usuario.add_note(str(exc))
+            elif isinstance(exc, FileNotFoundError):
+                exc_usuario = FileNotFoundError(
+                    formatear_error_usar_usuario(
+                        "modulo_no_encontrado", nombre_modulo_limpio
+                    )
+                )
+                exc_usuario.add_note(str(exc))
+            elif isinstance(exc, NameError):
+                exc_usuario = NameError(
+                    formatear_error_usar_usuario(
+                        "conflicto_simbolo", nombre_modulo_limpio
+                    )
+                )
+                exc_usuario.add_note(str(exc))
+            elif isinstance(exc, (ImportError, PermissionError)):
+                mensaje = str(exc)
+                if "usar_error[" in mensaje:
+                    exc_usuario = type(exc)(mensaje)
+                else:
+                    exc_usuario = type(exc)(
+                        formatear_error_usar_usuario(
+                            "carga_modulo_error", nombre_modulo_limpio
+                        )
+                    )
+                exc_usuario.add_note(str(exc))
+            else:
+                exc_usuario = ImportError(
+                    formatear_error_usar_usuario(
+                        "carga_modulo_error", nombre_modulo_limpio
+                    )
+                )
+                exc_usuario.add_note(str(exc))
             if detalle_usar_habilitado:
                 logging.exception(
                     "Error al usar el módulo '%s': %s", nodo.modulo, exc_usuario
@@ -2850,22 +2888,7 @@ class InterpretadorCobra:
                     nodo.modulo,
                     exc_usuario,
                 )
-            if isinstance(
-                exc,
-                (
-                    ImportError,
-                    PermissionError,
-                    ValueError,
-                    NameError,
-                    FileNotFoundError,
-                ),
-            ):
-                if exc_usuario is not exc:
-                    raise exc_usuario from exc
-                raise
-            raise ImportError(
-                formatear_error_usar_usuario("carga_modulo_error", nodo.modulo)
-            ) from exc
+            raise exc_usuario from exc
 
     def _detectar_conflictos_usar_en_contexto(
         self,

--- a/tests/data/usar_error_messages_snapshot.json
+++ b/tests/data/usar_error_messages_snapshot.json
@@ -1,8 +1,8 @@
 {
-  "modulo_fuera_catalogo": "No se puede usar 'datos': módulo fuera del catálogo público.",
-  "conflicto_simbolo": "No se puede usar 'datos': hay conflicto de símbolos en el contexto actual.",
-  "export_invalido": "No se puede usar 'datos': no hay símbolos exportables válidos.",
-  "carga_modulo_error": "No se puede usar 'datos': error al cargar el módulo.",
-  "fallback": "No se puede usar 'datos'.",
-  "contexto_minimo": "No se puede usar 'datos': hay conflicto de símbolos en el contexto actual. Requiere alias explícito."
+  "modulo_fuera_catalogo": "usar_error[modulo_fuera_catalogo_publico]: No se puede usar 'datos': módulo fuera del catálogo público.",
+  "conflicto_simbolo": "usar_error[conflicto_simbolo]: No se puede usar 'datos': hay conflicto de símbolos en el contexto actual.",
+  "export_invalido": "usar_error[export_invalido]: No se puede usar 'datos': no hay símbolos exportables válidos.",
+  "carga_modulo_error": "usar_error[carga_modulo_error]: No se puede usar 'datos': error al cargar el módulo.",
+  "fallback": "usar_error[carga_modulo_error]: No se puede usar 'datos'.",
+  "contexto_minimo": "usar_error[conflicto_simbolo]: No se puede usar 'datos': hay conflicto de símbolos en el contexto actual. Requiere alias explícito."
 }

--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -185,8 +185,10 @@ def test_ejecutar_codigo_modulo_inexistente_falla_controladamente(tmp_path):
 
     mensaje = str(excinfo.value)
 
-    assert "Módulo no encontrado: modulo_inexistente" in mensaje
-    assert "modulo_inexistente.cobra" in mensaje
+    assert "usar_error[modulo_no_encontrado]" in mensaje
+    assert "modulo_inexistente" in mensaje
+    assert "Ruta buscada" not in mensaje
+    assert "modulo_inexistente.cobra" not in mensaje
     assert "modulo_fuera_catalogo_publico" not in mensaje
 
 

--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -406,12 +406,13 @@ def test_conflicto_no_overwrite_silencioso_reporta_error_estructurado(monkeypatc
     class _NodoUsar:
         modulo = "datos"
 
-    with pytest.raises(NameError, match=r"colisión estructurada=") as excinfo:
+    with pytest.raises(NameError, match=r"usar_error\[conflicto_simbolo\]") as excinfo:
         interp.ejecutar_usar(_NodoUsar())
 
     mensaje = str(excinfo.value)
-    assert "'code': 'symbol_collision'" in mensaje
-    assert "'symbol': 'filtrar'" in mensaje
+    assert "symbol_collision" not in mensaje
+    assert "'code': 'symbol_collision'" in str(excinfo.value.__cause__)
+    assert "'symbol': 'filtrar'" in str(excinfo.value.__cause__)
     assert interp.contextos[-1].get("filtrar")() == "ocupado"
     assert "mapear" not in interp.contextos[-1].values
     assert "reducir" not in interp.contextos[-1].values
@@ -431,12 +432,13 @@ def test_conflictos_abortan_inyeccion_sin_overwrite_silencioso(monkeypatch):
     class _NodoUsar:
         modulo = "datos"
 
-    with pytest.raises(NameError, match=r"colisión estructurada=") as excinfo:
+    with pytest.raises(NameError, match=r"usar_error\[conflicto_simbolo\]") as excinfo:
         interp.ejecutar_usar(_NodoUsar())
 
     mensaje = str(excinfo.value)
-    assert "'code': 'symbol_collision'" in mensaje
-    assert "'symbol': 'filtrar'" in mensaje
+    assert "symbol_collision" not in mensaje
+    assert "'code': 'symbol_collision'" in str(excinfo.value.__cause__)
+    assert "'symbol': 'filtrar'" in str(excinfo.value.__cause__)
 
     assert interp.contextos[-1].get("filtrar")() == "ocupado"
     assert interp.contextos[-1].get("mapear")() == "ocupado"

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -301,10 +301,8 @@ def test_interpretador_usar_proyecto_detecta_ciclos_con_rutas_canonicas(
     try:
         interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.a"))
     except ImportError as exc:
-        assert str(exc) == (
-            "Ciclo de módulos detectado en usar: "
-            "utilidades/a.cobra -> utilidades/b.cobra -> utilidades/a.cobra"
-        )
+        assert str(exc).startswith("usar_error[carga_modulo_error]")
+        assert "utilidades/a.cobra" not in str(exc)
     else:
         raise AssertionError("Se esperaba un ImportError por ciclo de módulos")
     assert interp._usar_loading_stack == []
@@ -815,13 +813,7 @@ def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_pa
     )
 
     interp = InterpretadorCobra(safe_mode=False, main_file=principal)
-    with pytest.raises(
-        ImportError,
-        match=(
-            r"utilidades/internas/a\.cobra -> utilidades/internas/b\.cobra -> "
-            r"utilidades/internas/c\.cobra -> utilidades/internas/a\.cobra"
-        ),
-    ):
+    with pytest.raises(ImportError, match=r"usar_error\[carga_modulo_error\]"):
         interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.internas.a"))
 
 
@@ -847,9 +839,8 @@ def test_interpretador_usar_proyecto_detecta_ciclo_directo_en_root_con_mensaje_e
     with pytest.raises(ImportError) as excinfo:
         interp.ejecutar_usar(SimpleNamespace(modulo="a"))
 
-    assert (
-        str(excinfo.value) == "Ciclo de módulos detectado en usar: a.cobra -> a.cobra"
-    )
+    assert str(excinfo.value).startswith("usar_error[carga_modulo_error]")
+    assert "a.cobra" not in str(excinfo.value)
     assert obtener_pila_carga_modulos_cobra_proyecto() == []
 
 
@@ -882,9 +873,8 @@ def test_interpretador_usar_proyecto_detecta_ciclo_indirecto_en_root_con_cadena_
     with pytest.raises(ImportError) as excinfo:
         interp.ejecutar_usar(SimpleNamespace(modulo="a"))
 
-    assert str(excinfo.value) == (
-        "Ciclo de módulos detectado en usar: a.cobra -> b.cobra -> c.cobra -> a.cobra"
-    )
+    assert str(excinfo.value).startswith("usar_error[carga_modulo_error]")
+    assert "a.cobra" not in str(excinfo.value)
     assert obtener_pila_carga_modulos_cobra_proyecto() == []
 
 
@@ -911,7 +901,7 @@ def test_usar_proyecto_limpia_pila_si_falla_cargar_ast_modulo(monkeypatch, tmp_p
     assert obtener_pila_carga_modulos_cobra_proyecto() == []
 
 
-def test_interpretador_usar_proyecto_modulo_inexistente_muestra_nombre_y_ruta(tmp_path):
+def test_interpretador_usar_proyecto_modulo_inexistente_oculta_ruta(tmp_path):
     import pytest
 
     proyecto = tmp_path / "app"
@@ -926,8 +916,9 @@ def test_interpretador_usar_proyecto_modulo_inexistente_muestra_nombre_y_ruta(tm
         interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.faltante"))
 
     mensaje = str(excinfo.value)
+    assert "usar_error[modulo_no_encontrado]" in mensaje
     assert "utilidades.faltante" in mensaje
-    assert str(ruta_buscada) in mensaje
+    assert str(ruta_buscada) not in mensaje
 
 
 def test_resolver_modulo_cobra_proyecto_rechaza_resultado_manipulado_fuera_de_root(


### PR DESCRIPTION
### Motivation

- Centralizar la traducción y normalización de errores de `usar` en `InterpretadorCobra.ejecutar_usar` para reutilizar `formatear_error_usar_usuario`, `_error_usuario_modulo_fuera_catalogo` y las constantes `USAR_*_ERROR` existentes.
- Garantizar que todos los mensajes públicos siempre incluyan su código canónico `usar_error[...]` y que los detalles técnicos queden en notas o excepciones encadenadas, no en `str(exc)`.
- Evitar filtrado de rutas o diagnósticos internos exponiendo en su lugar errores públicos contractuales; rechazar validaciones internas de nombres/rutas (`ValueError`) como `PermissionError` con `usar_error[backend_import_directo]` y mapear módulos inexistentes a `usar_error[modulo_no_encontrado]`.

### Description

- Se añadieron las constantes `USAR_MODULE_NOT_FOUND_ERROR` y `USAR_MODULE_LOAD_ERROR` y se actualizó `formatear_error_usar_usuario` para prefijar siempre el mensaje con el código canónico `usar_error[...]`.
- `_error_usuario_modulo_fuera_catalogo` se simplificó para reutilizar el formateador central y conservar el detalle técnico como nota usando `Exception.add_note` en lugar de incrustarlo en el `str` público.
- En `InterpretadorCobra.ejecutar_usar` se centraliza la traducción de excepciones: `ValueError` se convierte en `PermissionError(USAR_DIRECT_BACKEND_IMPORT_ERROR)`, `FileNotFoundError` en un `FileNotFoundError` público con `usar_error[modulo_no_encontrado]`, `NameError` y otros errores de importación se sanitizan a mensajes públicos y el original se preserva con encadenamiento (`raise ... from exc`).
- Se actualizaron mensajes de pruebas y el snapshot de errores públicos en `tests/data/usar_error_messages_snapshot.json` y se ajustaron tests de integración y GUI para validar que el código canónico aparece en el mensaje público y que no se filtran rutas ni detalles internos.

### Testing

- Ejecuté las pruebas dirigidas relacionadas con `usar` usando `pytest` sobre `tests/unit/test_usar_error_messages_snapshot.py`, `tests/unit/test_usar_public_contract.py`, `tests/unit/test_project_root_usar_resolution.py` y suites relacionadas, y corregí los tests afectados por la nueva sanidad de mensajes.
- Ejecuté las suites de integración y GUI relevantes (`tests/integration/test_usar_runtime_contract.py`, `tests/integration/test_usar_public_contract_regression.py`, `tests/gui/test_gui_runtime_execution_scope.py`) y las pruebas relacionadas con `usar`; las pruebas dirigidas y las suites ajustadas pasaron tras los cambios.
- Verifiqué la compilación del archivo modificado con `python -m compileall -q src/pcobra/core/interpreter.py` y ejecuté `git diff --check` y comprobé que `src/pcobra/core/lexer.py` y `src/pcobra/core/parser.py` no se modificaron.
- Resultado final de las ejecuciones de prueba dirigidas: las suites verificadas pasaron y las verificaciones contractuales de `usar` reportaron éxito (selección de pruebas relacionadas: 162 pruebas verdes en la ejecución final dirigida).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8735331f808327a832b9fa26a95ba3)