### PR TITLE
test: reforzar rechazos públicos de usar

### DIFF
--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -127,14 +127,30 @@ def test_usar_modulo_inexistente_falla_con_diagnostico_publico(monkeypatch):
     )
 
     cmd = InteractiveCommand(InterpretadorCobra())
-    estado_pre = dict(cmd.interpretador.contextos[-1].values)
+    contexto_pre = cmd.interpretador.contextos[-1].values
+    estado_pre = dict(contexto_pre)
 
     with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH) as excinfo:
         cmd.ejecutar_codigo('usar "modulo_inexistente"')
 
     mensaje = str(excinfo.value).lower()
-    assert "modulo_fuera_catalogo_publico" in mensaje or "usar_error[" in mensaje
-    assert "traceback" not in mensaje
+    assert (
+        mensaje.split(":", 1)[0]
+        == "usar_error[modulo_fuera_catalogo_publico]"
+    )
+    assert not any(
+        detalle in mensaje
+        for detalle in (
+            "/workspace/",
+            "src/pcobra",
+            "ruta buscada",
+            "project_root",
+            "current_file",
+            "corelibs",
+            "traceback",
+        )
+    )
+    assert cmd.interpretador.contextos[-1].values is contexto_pre
     assert cmd.interpretador.contextos[-1].values == estado_pre
     assert "modulo_inexistente" not in cmd.interpretador.contextos[-1].values
 
@@ -230,17 +246,50 @@ def test_public_backends_inmutable_tipo_tuple():
     assert PUBLIC_BACKENDS == tuple(PUBLIC_BACKENDS)
 
 
-def test_rechaza_usar_ruta_backend_no_canonica_con_error_consistente():
+def test_rechaza_usar_ruta_backend_no_canonica_con_error_consistente(monkeypatch):
+    from pcobra.cobra import usar_loader as cobra_usar_loader
+
     interp = InterpretadorCobra()
+    contexto_pre = interp.contextos[-1].values
+    estado_pre = dict(contexto_pre)
+    nombres_resueltos = []
+
+    def _resolver_espia(nombre):
+        nombres_resueltos.append(nombre)
+        return _modulo_numero_stub()
+
+    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", _resolver_espia)
 
     class _NodoUsar:
         modulo = "pcobra.corelibs.numero"
 
-    with pytest.raises(
-        (PermissionError, FileNotFoundError),
-        match=r"backend_import_directo|Módulo de proyecto no encontrado",
-    ):
+    with pytest.raises(PermissionError) as excinfo:
         interp.ejecutar_usar(_NodoUsar())
+
+    mensaje = str(excinfo.value).lower()
+    assert mensaje.split(":", 1)[0] == "usar_error[backend_import_directo]"
+    assert not isinstance(excinfo.value, ValueError)
+    assert not any(
+        detalle in mensaje
+        for detalle in (
+            "/workspace/",
+            "src/pcobra",
+            "ruta buscada",
+            "project_root",
+            "current_file",
+            "corelibs",
+            "traceback",
+        )
+    )
+    assert interp.contextos[-1].values is contexto_pre
+    assert interp.contextos[-1].values == estado_pre
+    assert nombres_resueltos == []
+
+    _NodoUsar.modulo = "numero"
+    interp.ejecutar_usar(_NodoUsar())
+
+    assert nombres_resueltos == ["numero"]
+    assert "es_finito" in interp.contextos[-1].values
 
 
 def test_usar_rechaza_modulo_fuera_allowlist_aun_si_alias_map_lo_declara():


### PR DESCRIPTION
### Motivation

- Aumentar la precisión de las pruebas del Grupo E para asegurar que los rechazos públicos de `usar` expongan códigos de error públicos canónicos y no filtren rutas o detalles internos.
- Verificar que el intérprete preserve el contexto exacto (identidad y contenido) tras rechazos y que los backends no canónicos sean rechazados antes de invocarlos.

### Description

- Modifica `test_usar_modulo_inexistente_falla_con_diagnostico_publico` para exigir que el prefijo del mensaje sea exactamente `usar_error[modulo_fuera_catalogo_publico]`, comprobar que no contiene rutas ni detalles internos ni `traceback`, y que el contexto del intérprete conserve su identidad y contenido tras el rechazo.
- Modifica `test_rechaza_usar_ruta_backend_no_canonica_con_error_consistente` para exigir `PermissionError` con código público `usar_error[backend_import_directo]`, comprobar que nunca es un `ValueError`, verificar ausencia de rutas/tracebacks en el mensaje y garantizar que el contexto del intérprete permanezca idéntico tras el rechazo.
- Añade un resolvedor-espía (monkeypatch) que confirma que un nombre backend no canónico es rechazado antes de invocar al resolvedor y un control positivo que permite cargar el módulo canónico `numero` y comprobar sus símbolos expuestos.
- No se tocan `Lexer` ni `Parser`, y los cambios se limitan únicamente a los casos del Grupo E en `tests/unit/test_usar_public_contract.py`.

### Testing

- Ejecutadas las pruebas individuales con `pytest -q tests/unit/test_usar_public_contract.py::test_usar_modulo_inexistente_falla_con_diagnostico_publico tests/unit/test_usar_public_contract.py::test_rechaza_usar_ruta_backend_no_canonica_con_error_consistente` y ambas pasaron (2 passed).
- Ejecutada la suite del archivo con `pytest -q tests/unit/test_usar_public_contract.py` y todas las pruebas del archivo pasaron (20 passed).
- Se verificó `git diff --check` y que `src/pcobra/core/lexer.py` y `src/pcobra/core/parser.py` no cambiaron, y el árbol de trabajo está limpio tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a873b98392c8327a7c61c9c97e49e80)