### PR TITLE
Corrige contrato de error para usar fuera del catálogo

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -157,7 +157,6 @@ def formatear_error_usar_usuario(
 ) -> str:
     """Devuelve errores cortos y legibles para la salida de usuario en `usar`."""
     codigos = {
-        "modulo_fuera_catalogo": USAR_NON_PUBLIC_MODULE_ERROR,
         "conflicto_simbolo": USAR_SYMBOL_CONFLICT_ERROR,
         "export_invalido": USAR_INVALID_EXPORT_ERROR,
         "modulo_no_encontrado": USAR_MODULE_NOT_FOUND_ERROR,
@@ -171,8 +170,9 @@ def formatear_error_usar_usuario(
         "carga_modulo_error": f"No se puede usar '{modulo}': error al cargar el módulo.",
     }
     base = mensajes.get(codigo, f"No se puede usar '{modulo}'.")
-    codigo_publico = codigos.get(codigo, USAR_MODULE_LOAD_ERROR).split(":", 1)[0]
-    base = f"{codigo_publico}: {base}"
+    if codigo in codigos:
+        codigo_publico = codigos[codigo].split(":", 1)[0]
+        base = f"{codigo_publico}: {base}"
     if contexto_minimo:
         return f"{base} {contexto_minimo}"
     return base
@@ -207,13 +207,20 @@ def _error_usuario_modulo_fuera_catalogo(
     repl_estricto: bool,
     incluir_detalle: bool,
 ) -> PermissionError:
-    """Crea un PermissionError corto y conserva el detalle técnico como nota."""
+    """Crea el error público según el contrato directo o del REPL."""
 
-    del repl_estricto, incluir_detalle
-    mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", modulo)
-    error = PermissionError(mensaje)
-    error.add_note(str(detalle))
-    return error
+    if repl_estricto:
+        mensaje = (
+            f"Importación no permitida en 'usar': '{modulo}'. Es un módulo "
+            "backend/no canónico y no forma parte de la API pública. "
+            f"Módulos permitidos: {_resumir_modulos_permitidos_usar()}."
+        )
+    else:
+        mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", modulo)
+
+    if incluir_detalle:
+        mensaje = f"{mensaje} {USAR_NON_PUBLIC_MODULE_ERROR}. {detalle}"
+    return PermissionError(mensaje)
 
 
 def _runtime_debug_enabled() -> bool:


### PR DESCRIPTION
### Motivation

- Restaurar el contrato de errores para `usar` cuando un módulo está fuera del catálogo público, diferenciando la salida canónica en modo normal y la salida específica del REPL estricto. 
- Asegurar que `_error_usuario_modulo_fuera_catalogo` respete los parámetros `repl_estricto` e `incluir_detalle` y no deje símbolos parciales en el intérprete tras rechazos repetidos.

### Description

- Ajusta `formatear_error_usar_usuario` para no anteponer el código público en el caso `modulo_fuera_catalogo` mientras mantiene el prefijo `usar_error[...]` para los demás códigos mediante un mapeo controlado. 
- Reescribe `_error_usuario_modulo_fuera_catalogo` para que, si `repl_estricto` es verdadero, devuelva el mensaje REPL explícito con la lista resumida de módulos públicos por `_resumir_modulos_permitidos_usar()`, y si es falso devuelva el mensaje canónico corto; el diagnóstico técnico solo se añade cuando `incluir_detalle` está habilitado. 
- Conserva la política de debug (`PCOBRA_DEBUG_RUNTIME` / `InterpretadorCobra._debug_trazas_habilitadas()`), no antepone `usar_error[...]` en modo normal, no adjunta tracebacks en modo normal y evita exponer `USAR_COBRA_PUBLIC_MODULES` en mensajes normales. 
- No se modificaron `Lexer` ni `Parser`, ni la lista pública de módulos; los cambios quedaron registrados en el commit `d048c513`.

### Testing

- Ejecutado `pytest -q tests/unit/test_usar_numpy_error_contract.py` y todos los tests relevantes pasaron (`3 passed`).
- Ejecutado el subconjunto de integración con `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'seguridad_usar_numpy_error_corto_sin_traceback_modo_normal or repl_seguridad_numpy_rechazado_mensaje_corto_sin_traceback or repl_rechazo_numpy_es_persistente or repl_usar_numpy_error_explicito_corto_sin_traceback_en_modo_normal'` y todos los nodos correspondientes pasaron (`6 passed`), cubriendo el contrato REPL y los casos solicitados. 
- Verificada la atomicidad mediante ejecución programática de dos rechazos consecutivos en `InteractiveCommand` y `ReplCommandV2`, confirmando que `numpy` no aparece en `interp.variables` ni en `interp.contextos[-1].values` y que el contexto quedó intacto. 
- Se ejecutó `git diff --check` y se comprobó que `Lexer`/`Parser` no fueron modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8810e4a0e48327a3e55ed90b0edbb2)