### PR TITLE
Preserva el payload de colisiones estructuradas en `usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2861,12 +2861,32 @@ class InterpretadorCobra:
                 )
                 exc_usuario.add_note(str(exc))
             elif isinstance(exc, NameError):
-                exc_usuario = NameError(
-                    formatear_error_usar_usuario(
-                        "conflicto_simbolo", nombre_modulo_limpio
+                mensaje = str(exc)
+                marcador_colision = "colisión estructurada="
+                colision_estructurada = False
+                if marcador_colision in mensaje:
+                    payload = mensaje.split(marcador_colision, 1)[1].strip()
+                    try:
+                        detalle_colision = ast.literal_eval(payload)
+                    except (ValueError, SyntaxError):
+                        detalle_colision = None
+                    colision_estructurada = isinstance(
+                        detalle_colision, dict
+                    ) and detalle_colision.get("code") in {
+                        "symbol_collision",
+                        "symbol_collision_runtime_recheck",
+                    }
+
+                if colision_estructurada:
+                    # El mensaje ya pertenece al contrato público de `usar`:
+                    # conservar literalmente el payload para sus consumidores.
+                    exc_usuario = NameError(mensaje)
+                else:
+                    exc_usuario = NameError(
+                        formatear_error_usar_usuario(
+                            "conflicto_simbolo", nombre_modulo_limpio
+                        )
                     )
-                )
-                exc_usuario.add_note(str(exc))
             elif isinstance(exc, (ImportError, PermissionError)):
                 mensaje = str(exc)
                 if "usar_error[" in mensaje:


### PR DESCRIPTION
### Motivation

- Corrige el manejo de `NameError` en `InterpretadorCobra.ejecutar_usar` para no clasificar indiscriminadamente cualquier `NameError` como una colisión de `usar`.
- Asegurar que las colisiones que ya vienen en el formato público (payload estructurado) se propaguen intactas para que los consumidores puedan extraer `code`, `message`, `symbol`, `module` y `phase`.
- Mantener el comportamiento y contrato de la comprobación de reevaluación en runtime (`symbol_collision_runtime_recheck`) y la política de símbolos existente.

### Description

- Se modificó exclusivamente el tratamiento de `NameError` en `src/pcobra/core/interpreter.py` dentro de `InterpretadorCobra.ejecutar_usar` para detectar explícitamente el marcador `colisión estructurada=` en el mensaje y parsear su payload con `ast.literal_eval` antes de considerarlo una colisión.
- Solo se consideran colisiones estructuradas los payloads dict con el campo `code` igual a `symbol_collision` o `symbol_collision_runtime_recheck`, y en ese caso se propaga literalmente el `NameError` original (manteniendo el mensaje y payload para los consumidores).
- Para `NameError` no estructurados se mantiene un fallback público saneado usando `formatear_error_usar_usuario` y ya no se añade como nota el mensaje interno original, evitando filtrar rutas o detalles internos.
- Se comprobó que la rama de reevaluación runtime (`symbol_collision_runtime_recheck`) sigue provocado rechazo atómico sin inyección parcial y que no se tocaron Lexer ni Parser.

### Testing

- Ejecutado `pytest -q tests/integration/test_usar_core_contract_full.py::test_09_colision_reporta_error_estructurado tests/integration/test_repl_usar_entrypoints_contract.py::test_repl_contract_seguridad_usar_atomico_holobit_y_datos_sin_overwrite` y ambas pruebas focales pasaron (2 passed).
- Ejecutado un chequeo manual mediante un pequeño script en `python` que validó que `symbol_collision_runtime_recheck` sigue rechazando de forma atómica y que el fallback saneado no expone rutas internas, y la comprobación pasó.
- Ejecutado `black --check src/pcobra/core/interpreter.py` y `ruff check src/pcobra/core/interpreter.py`, ambos verificadores reportaron OK.
- Se ejecutó `pytest -q tests/integration/test_usar_core_contract_full.py tests/integration/test_repl_usar_entrypoints_contract.py` para evaluación amplia; el cambio no introdujo regresiones en los nodos solicitados, pero la ejecución completa mostró otras fallas preexistentes en la suite con `14 failed, 93 passed` que son independientes de este ajuste de `NameError` (las pruebas focales relacionadas con colisiones estructuradas pasan).
- Verificado que no hay cambios en Lexer/Parser mediante `git diff --name-only -- 'src/**/lexer*' 'src/**/parser*'` como exige la política de agentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8831a141048327988847098a626ef7)