### PR TITLE
test: migrate temporary sources and verify tests to use .cobra

### DIFF
--- a/tests/integration/test_transpilador_syntax.py
+++ b/tests/integration/test_transpilador_syntax.py
@@ -92,7 +92,7 @@ VALID_SYNTAX_TARGETS = tuple(
 
 @pytest.mark.parametrize("lang", VALID_SYNTAX_TARGETS)
 def test_transpilador_syntax(tmp_path, lang, monkeypatch):
-    archivo = tmp_path / "prog.co"
+    archivo = tmp_path / "prog.cobra"
     archivo.write_text(Path("tests/data/ejemplo.cobra").read_text())
 
     monkeypatch.setattr(module_map_src, "get_toml_map", lambda: {})

--- a/tests/unit/test_verify_cmd.py
+++ b/tests/unit/test_verify_cmd.py
@@ -4,14 +4,14 @@ from unittest.mock import patch
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand, VALID_EXTENSIONS
 
 
-def test_valid_extensions_include_co():
-    """La extensión `.co` debe incluirse en el listado permitido."""
-    assert ".co" in VALID_EXTENSIONS
+def test_valid_extensions_include_cobra():
+    """La extensión `.cobra` debe incluirse en el listado permitido."""
+    assert ".cobra" in VALID_EXTENSIONS
 
 
-def test_verify_command_accepts_co_file(tmp_path):
-    """`VerifyCommand` debe aceptar archivos `.co`."""
-    archivo = tmp_path / "script.co"
+def test_verify_command_accepts_cobra_file(tmp_path):
+    """`VerifyCommand` debe aceptar archivos `.cobra`."""
+    archivo = tmp_path / "script.cobra"
     archivo.write_text("imprimir('hola')\n", encoding="utf-8")
 
     comando = VerifyCommand()


### PR DESCRIPTION
### Motivation
- Align tests with the updated public contract that treats `.cobra` as the canonical editable source extension so temporary files and validation tests do not be treated as packages and fail before execution.

### Description
- Rename the temporary source in `tests/integration/test_transpilador_syntax.py` from `prog.co` to `prog.cobra` to ensure `CompileCommand` treats it as a source file.
- Update `tests/unit/test_verify_cmd.py` to assert that `.cobra` is included in `VALID_EXTENSIONS` and to use `script.cobra` for the `_validate_file` test.
- Verified that Lexer and Parser were not modified as required by repository policy.

### Testing
- Ran `pytest -q tests/integration/test_transpilador_syntax.py` and all tests passed (3 passed).
- Ran `pytest -q tests/unit/test_verify_cmd.py::test_valid_extensions_include_cobra tests/unit/test_verify_cmd.py::test_verify_command_accepts_cobra_file` and both tests passed.
- Ran `pytest -q tests/unit/test_verify_cmd.py` which reported 4 passed and 1 unrelated failure because one test expects `cpp` to be listed in `SUPPORTED_LANGUAGES` and is unrelated to the `.cobra` migration; this failure was not caused by the test changes here.
- Confirmed no changes to Lexer or Parser files after the edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8966caec5883279f7f8dc6525a96ac)