### PR TITLE
test(transpiler): update fixture manifest to use factorial_recursivo.cobra

### DIFF
--- a/tests/data/transpiler_outputs.csv
+++ b/tests/data/transpiler_outputs.csv
@@ -1,2 +1,2 @@
 archivo,lenguaje,salida
-factorial_recursivo.co,python,120\\n
+factorial_recursivo.cobra,python,120\\n


### PR DESCRIPTION
### Motivation
- The transpiler fixture manifest still referenced the deleted `factorial_recursivo.co`, causing the `transpiler_case` fixture to resolve a missing path and making cross-backend output tests fail before transpilation.

### Description
- Update `tests/data/transpiler_outputs.csv` to replace `factorial_recursivo.co` with `factorial_recursivo.cobra` so the fixture resolves the actual source file while leaving the expected output unchanged.

### Testing
- Ran the fixture loader via `_cargar_casos()` to confirm the manifest loads and each `archivo` exists as a `.cobra` file, attempted `pytest -q tests/integration/test_cross_backend_output.py` which failed during collection due to an unrelated `ImportError` in `pcobra.cobra.usar_loader` (not caused by this manifest change), and verified that `Lexer` and `Parser` files were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8969b825f483278f3272048c9694b2)