### PR TITLE
fix(ci): discover canonical .cobra fixtures

### DIFF
--- a/scripts/ci/audit_feature_rollout.py
+++ b/scripts/ci/audit_feature_rollout.py
@@ -128,7 +128,7 @@ def _files_containing_token(search_roots: tuple[Path, ...], token: str) -> list[
         for path in root.rglob("*"):
             if not path.is_file():
                 continue
-            if path.suffix not in {".py", ".md", ".rst", ".txt", ".co", ".csv", ".json", ".yaml", ".yml"}:
+            if path.suffix not in {".py", ".md", ".rst", ".txt", ".cobra", ".csv", ".json", ".yaml", ".yml"}:
                 continue
             content = path.read_text(encoding="utf-8", errors="ignore").lower()
             if lowered in content or lowered in path.as_posix().lower():
@@ -148,7 +148,7 @@ def audit_feature_id(feature_id: str) -> dict[str, list[str]]:
     matrix_hits = [p for p in MATRIX_HINTS if (ROOT / p).exists() and feature in (ROOT / p).read_text(encoding="utf-8", errors="ignore").lower()]
     test_hits = _files_containing_token((ROOT / "tests",), feature)
     docs_hits = _files_containing_token((ROOT / "docs", ROOT / "CONTRIBUTING.md"), feature)
-    example_path = EXAMPLES_FEATURES_DIR / feature / "minimal.co"
+    example_path = EXAMPLES_FEATURES_DIR / feature / "minimal.cobra"
     example_hits = [example_path.relative_to(ROOT).as_posix()] if example_path.exists() else []
 
     return {

--- a/scripts/grammar_coverage.py
+++ b/scripts/grammar_coverage.py
@@ -2,7 +2,7 @@
 """Calculate grammar rule coverage for sample files.
 
 This script loads ``docs/gramatica.ebnf`` using ``lark.Lark`` and parses
-all ``.co`` files found in the ``examples/`` and ``tests/``
+all ``.cobra`` files found in the ``examples/`` and ``tests/``
 directories. It records which grammar rules are used when parsing and
 computes the percentage of rules that were exercised. If the coverage is
 below a configurable threshold the script exits with a non-zero status.
@@ -45,7 +45,7 @@ def iter_sample_files(dirs: Iterable[Path]) -> Iterable[Path]:
     for base in dirs:
         if not base.exists():
             continue
-        for path in base.rglob("*.co"):
+        for path in base.rglob("*.cobra"):
             if path.is_file():
                 yield path
 


### PR DESCRIPTION
### Motivation
- Align CI/audit scripts with the canonical Cobra source extension `.cobra` so fixture discovery and feature-rollout checks find real samples and do not report 0% grammar coverage or missing example fixtures.

### Description
- Update `scripts/grammar_coverage.py` to search for `*.cobra` samples and modify `scripts/ci/audit_feature_rollout.py` to include `.cobra` in the file-suffix whitelist and to reference `minimal.cobra` for feature fixtures, while keeping Lexer/Parser files unchanged per repository rules.

### Testing
- Ran `pytest tests/unit/test_ci_audit_feature_rollout.py` and all tests passed (3 passed); ran `python scripts/grammar_coverage.py --threshold=30` which discovered `.cobra` samples and exited successfully; ran `git diff --check` to verify no accidental lexer/parser changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a896e21806083278e2066c8f858e185)