### PR TITLE
Fix canonical .cobra migration regressions (grammar coverage, feature audit, AST cache alias)

### DIFF
--- a/scripts/ci/audit_feature_rollout.py
+++ b/scripts/ci/audit_feature_rollout.py
@@ -148,7 +148,7 @@ def audit_feature_id(feature_id: str) -> dict[str, list[str]]:
     matrix_hits = [p for p in MATRIX_HINTS if (ROOT / p).exists() and feature in (ROOT / p).read_text(encoding="utf-8", errors="ignore").lower()]
     test_hits = _files_containing_token((ROOT / "tests",), feature)
     docs_hits = _files_containing_token((ROOT / "docs", ROOT / "CONTRIBUTING.md"), feature)
-    example_path = EXAMPLES_FEATURES_DIR / feature / "minimal.co"
+    example_path = EXAMPLES_FEATURES_DIR / feature / "minimal.cobra"
     example_hits = [example_path.relative_to(ROOT).as_posix()] if example_path.exists() else []
 
     return {

--- a/scripts/grammar_coverage.py
+++ b/scripts/grammar_coverage.py
@@ -2,7 +2,7 @@
 """Calculate grammar rule coverage for sample files.
 
 This script loads ``docs/gramatica.ebnf`` using ``lark.Lark`` and parses
-all ``.co`` files found in the ``examples/`` and ``tests/``
+all ``.cobra`` files found in the ``examples/`` and ``tests/``
 directories. It records which grammar rules are used when parsing and
 computes the percentage of rules that were exercised. If the coverage is
 below a configurable threshold the script exits with a non-zero status.
@@ -45,7 +45,7 @@ def iter_sample_files(dirs: Iterable[Path]) -> Iterable[Path]:
     for base in dirs:
         if not base.exists():
             continue
-        for path in base.rglob("*.co"):
+        for path in base.rglob("*.cobra"):
             if path.is_file():
                 yield path
 

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -357,9 +357,14 @@ def obtener_pila_carga_modulos_cobra_proyecto() -> list[Path]:
     return _USAR_PROJECT_LOADING_STACK
 
 
-def obtener_cache_ast_import_co() -> dict[Path, list[Any]]:
+def obtener_cache_ast_import_cobra() -> dict[Path, list[Any]]:
     """Expone la caché compartida de ASTs de fuentes .cobra para el transpilador."""
     return _IMPORT_COBRA_AST_CACHE
+
+
+def obtener_cache_ast_import_co() -> dict[Path, list[Any]]:
+    """Alias obsoleto de :func:`obtener_cache_ast_import_cobra`."""
+    return obtener_cache_ast_import_cobra()
 
 
 def _formatear_ruta_ciclo_modulo(ruta: Path, project_root: Path | None) -> str:


### PR DESCRIPTION
### Motivation
- The migration to use `.cobra` as the canonical source extension left several downstream scanners and audits still looking for `.co` files, breaking CI and feature-audit evidence collection.  
- A public module-level accessor was renamed during the migration causing an import-time break for downstream callers.  
- Fixes must be minimal, incremental, and avoid touching Lexer/Parser per repository agent rules.

### Description
- Update `scripts/grammar_coverage.py` to document and discover sample files with the `.cobra` extension by changing the docstring and `iter_sample_files` pattern from `*.co` to `*.cobra`.  
- Update `scripts/ci/audit_feature_rollout.py` to look for `examples/features/<id>/minimal.cobra` instead of `minimal.co`.  
- In `src/pcobra/cobra/usar_loader.py` introduce the canonical `obtener_cache_ast_import_cobra()` accessor and preserve `obtener_cache_ast_import_co()` as a deprecated alias delegating to the canonical function to maintain backward compatibility.  
- All changes are small, focused edits addressing the three review findings without modifying Lexer/Parser files.

### Testing
- Executed `python scripts/grammar_coverage.py --threshold 30`, which reported grammar parsing diagnostics for some samples but produced `Cobertura de gramática: 33.33%` and met the 30% threshold.  
- Ran `pytest -q tests/unit/test_ci_audit_feature_rollout.py` which passed (3 tests).  
- Ran `pytest -q tests/integration/test_usar_project_modules.py tests/unit/test_project_root_usar_resolution.py` and then a combined run of the updated suites, with the final combined result showing `99 passed, 1 warning`.  
- Verified that `obtener_cache_ast_import_co()` and `obtener_cache_ast_import_cobra()` return the identical cache object via a short Python assertion.  
- Performed `git diff --check` and repository checks to confirm no Lexer or Parser files were changed and the working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89707c6a5c8327b5ec7216b0b790fc)