### PR TITLE
Fix grammar coverage to scan .cobra fixtures

### DIFF
--- a/scripts/grammar_coverage.py
+++ b/scripts/grammar_coverage.py
@@ -2,7 +2,7 @@
 """Calculate grammar rule coverage for sample files.
 
 This script loads ``docs/gramatica.ebnf`` using ``lark.Lark`` and parses
-all ``.co`` files found in the ``examples/`` and ``tests/``
+all ``.cobra`` files found in the ``examples/`` and ``tests/``
 directories. It records which grammar rules are used when parsing and
 computes the percentage of rules that were exercised. If the coverage is
 below a configurable threshold the script exits with a non-zero status.
@@ -45,7 +45,7 @@ def iter_sample_files(dirs: Iterable[Path]) -> Iterable[Path]:
     for base in dirs:
         if not base.exists():
             continue
-        for path in base.rglob("*.co"):
+        for path in base.rglob("*.cobra"):
             if path.is_file():
                 yield path
 


### PR DESCRIPTION
### Motivation
- The repository moved example/fixture source files from `.co` to the canonical `.cobra` extension, so the grammar coverage script must scan `*.cobra` samples to compute meaningful coverage and avoid failing the default `make test` threshold.

### Description
- Updated `scripts/grammar_coverage.py` to document and discover sample files with the `*.cobra` pattern instead of `*.co` by changing the docstring and the `iter_sample_files` rglob from `"*.co"` to `"*.cobra"`.

### Testing
- Ran `python scripts/grammar_coverage.py --threshold=30` which completed with exit code 0 and reported `33.33% (14/42)` coverage, satisfying the threshold. 
- Ran `python -m pytest -q tests/test_cobra_extension_contract.py` which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8972f97ac88327a3b117069514ab88)