### PR TITLE
Corregir descubrimiento/generación de muestras para la extensión `.cobra`

### DIFF
--- a/scripts/benchmarks/compare_backends.py
+++ b/scripts/benchmarks/compare_backends.py
@@ -137,8 +137,8 @@ def main() -> None:
 
     results = []
     with tempfile.TemporaryDirectory() as tmpdir:
-        co_file = Path(tmpdir) / "program.co"
-        co_file.write_text(CODE)
+        cobra_file = Path(tmpdir) / "program.cobra"
+        cobra_file.write_text(CODE)
 
         # Ejecutar directamente con el intérprete Cobra
         cobra_cmd = [
@@ -146,7 +146,7 @@ def main() -> None:
             "-m",
             "cobra.cli.cli",
             "ejecutar",
-            str(co_file),
+            str(cobra_file),
         ]
         elapsed, mem = run_and_measure(cobra_cmd, env)
         results.append({"backend": "cobra", "time": round(elapsed, 4), "memory_kb": mem})
@@ -163,7 +163,7 @@ def main() -> None:
                 "-m",
                 "cobra.cli.cli",
                 "compilar",
-                str(co_file),
+                str(cobra_file),
                 "--tipo",
                 backend,
             ]

--- a/scripts/benchmarks/run_benchmarks.py
+++ b/scripts/benchmarks/run_benchmarks.py
@@ -134,8 +134,8 @@ def main() -> None:
 
     results = []
     with tempfile.TemporaryDirectory() as tmpdir:
-        co_file = Path(tmpdir) / "program.co"
-        co_file.write_text(CODE)
+        cobra_file = Path(tmpdir) / "program.cobra"
+        cobra_file.write_text(CODE)
         selected_backends = list(
             executable_benchmark_backends(
                 BACKEND_METADATA,
@@ -154,7 +154,7 @@ def main() -> None:
                 "-m",
                 "cobra.cli.cli",
                 "compilar",
-                str(co_file),
+                str(cobra_file),
                 "--tipo",
                 backend,
             ]

--- a/scripts/ci/audit_feature_rollout.py
+++ b/scripts/ci/audit_feature_rollout.py
@@ -148,7 +148,7 @@ def audit_feature_id(feature_id: str) -> dict[str, list[str]]:
     matrix_hits = [p for p in MATRIX_HINTS if (ROOT / p).exists() and feature in (ROOT / p).read_text(encoding="utf-8", errors="ignore").lower()]
     test_hits = _files_containing_token((ROOT / "tests",), feature)
     docs_hits = _files_containing_token((ROOT / "docs", ROOT / "CONTRIBUTING.md"), feature)
-    example_path = EXAMPLES_FEATURES_DIR / feature / "minimal.co"
+    example_path = EXAMPLES_FEATURES_DIR / feature / "minimal.cobra"
     example_hits = [example_path.relative_to(ROOT).as_posix()] if example_path.exists() else []
 
     return {

--- a/scripts/grammar_coverage.py
+++ b/scripts/grammar_coverage.py
@@ -2,7 +2,7 @@
 """Calculate grammar rule coverage for sample files.
 
 This script loads ``docs/gramatica.ebnf`` using ``lark.Lark`` and parses
-all ``.co`` files found in the ``examples/`` and ``tests/``
+all ``.cobra`` files found in the ``examples/`` and ``tests/``
 directories. It records which grammar rules are used when parsing and
 computes the percentage of rules that were exercised. If the coverage is
 below a configurable threshold the script exits with a non-zero status.
@@ -45,7 +45,7 @@ def iter_sample_files(dirs: Iterable[Path]) -> Iterable[Path]:
     for base in dirs:
         if not base.exists():
             continue
-        for path in base.rglob("*.co"):
+        for path in base.rglob("*.cobra"):
             if path.is_file():
                 yield path
 


### PR DESCRIPTION
### Motivation
- Finalizar la migración a la extensión canónica de fuentes `.cobra` para que herramientas, benchmarks y auditorías de features consuman las muestras renombradas. 
- Evitar que validaciones prematuras sobre `.co` rechacen entradas legítimas y que scripts sigan produciendo artefactos con la extensión antigua. 
- Mantener intactos el Lexer y Parser según las reglas de auditoría del repositorio. 

### Description
- Actualiza `scripts/benchmarks/run_benchmarks.py` para crear `program.cobra` y pasar ese archivo a los comandos de `compilar`/`ejecutar` en lugar de `program.co`.
- Actualiza `scripts/benchmarks/compare_backends.py` para crear `program.cobra` y usarlo en las invocaciones a Cobra en lugar de `program.co`.
- Ajusta `scripts/ci/audit_feature_rollout.py` para buscar la fixture `minimal.cobra` en `examples/features/<feature>/minimal.cobra` en lugar de `minimal.co`.
- Cambia `scripts/grammar_coverage.py` para documentar y escanear `*.cobra` (y actualiza el globs/documentación interna de muestra) en vez de `*.co`.
- Verifiqué explícitamente que no se modificaron archivos de Lexer o Parser durante estos cambios. 

### Testing
- Ejecuté `pytest -q tests/unit/test_ci_audit_feature_rollout.py tests/unit/test_syntax_validation_feature_fixtures.py`, ambos tests unitarios pasaron (4 passed).
- Ejecuté `python scripts/grammar_coverage.py --threshold 1`, el script descubrió las muestras `*.cobra` y completó con cobertura reportada (`33.33%`) y exit code 0.
- Verifiqué la compilación sintáctica de los scripts modificados con `python -m py_compile scripts/benchmarks/run_benchmarks.py scripts/benchmarks/compare_backends.py scripts/ci/audit_feature_rollout.py scripts/grammar_coverage.py` y no se reportaron errores.
- Ejecuté `python scripts/benchmarks/run_benchmarks.py`, el script finalizó sin crash pero produjo una lista vacía debido a errores preexistentes de registro/importación de comandos en este checkout que impiden registrar `compilar` (esto es un problema independiente a la migración de extensiones).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8975bba18083279f705bdecee547a1)