### PR TITLE
Propagar límites configurados a los hijos del sandbox

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -294,6 +294,7 @@ class InteractiveCommand(BaseCommand):
         if callable(asegurar_estado_runtime):
             asegurar_estado_runtime()
         self._allow_insecure_fallback = False
+        self._memory_limit_mb = self.MEMORY_LIMIT_MB
         # Contrato de logging: no agregar handlers por comando; la emisión se
         # centraliza en root configurado desde ``pcobra.cli.configure_logging``.
         self.logger = logging.getLogger(__name__)
@@ -894,6 +895,8 @@ class InteractiveCommand(BaseCommand):
                 mostrar_error(_("El límite de memoria debe ser positivo"))
                 return 1
 
+            self._memory_limit_mb = memory_limit
+
             # El límite de memoria se valida aquí, pero no se aplica al proceso
             # anfitrión del REPL. Los límites efectivos deben configurarse sólo
             # dentro de procesos hijos aislados (sandbox/subprocesos).
@@ -1326,8 +1329,14 @@ class InteractiveCommand(BaseCommand):
             imprimir_resultado=True,
         )
 
+        cpu_segundos = getattr(self.interpretador, "limite_cpu_segundos", None)
+        if not isinstance(cpu_segundos, int) or isinstance(cpu_segundos, bool):
+            cpu_segundos = None
+
         salida = ejecutar_en_sandbox(
             script,
+            memoria_mb=self._memory_limit_mb,
+            cpu_segundos=cpu_segundos,
             allow_insecure_fallback=self._allow_insecure_fallback,
         )
         if salida:

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -97,7 +97,7 @@ class RunService:
 
         def ejecutar() -> int:
             if sandbox:
-                return sandbox_module.ejecutar_en_sandbox(
+                return self.ejecutar_en_sandbox(
                     codigo,
                     seguro,
                     extra_validators,
@@ -179,7 +179,8 @@ class RunService:
             salida = sandbox_module.ejecutar_en_sandbox(
                 script,
                 timeout=self.execution_timeout,
-                cpu_segundos=self.execution_timeout,
+                memoria_mb=getattr(setup.interpretador, "limite_memoria_mb", None),
+                cpu_segundos=getattr(setup.interpretador, "limite_cpu_segundos", None),
                 allow_insecure_fallback=allow_insecure_fallback,
             )
             if salida:

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -70,7 +70,7 @@ from .semantic_validators import (
     PrimitivaPeligrosaError,
 )
 from .semantico import AnalizadorSemantico
-from .cobra_config import limite_nodos
+from .cobra_config import limite_cpu_segundos, limite_memoria_mb, limite_nodos
 from .import_utils import (
     MODULES_PATH as _DEFAULT_MODULES_PATH,
     IMPORT_WHITELIST,
@@ -497,6 +497,11 @@ class InterpretadorCobra:
             extra = self._cargar_validadores(extra)
 
         self.safe_mode = safe_mode
+        # Keep the configured limits as execution metadata.  They are consumed
+        # by sandbox callers, which apply them in the isolated child instead of
+        # mutating the process that hosts the interpreter.
+        self.limite_memoria_mb = limite_memoria_mb()
+        self.limite_cpu_segundos = limite_cpu_segundos()
         # Regla de fases: analysis = sin efectos, execution = con efectos.
         # Por defecto iniciamos en ejecución para preservar compatibilidad fuera del REPL.
         self.mode = "execution"

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -636,6 +636,8 @@ def test_ejecutar_en_sandbox_invoca_pipeline_explicito_solo_para_setup():
     )
     mock_sandbox.assert_called_once_with(
         "SCRIPT",
+        memoria_mb=cmd.MEMORY_LIMIT_MB,
+        cpu_segundos=None,
         allow_insecure_fallback=False,
     )
     assert cmd.interpretador is setup.interpretador
@@ -692,6 +694,8 @@ def test_ejecutar_en_sandbox_usa_estado_repl_y_contrato_de_run_service():
     )
     mock_ejecutar.assert_called_once_with(
         "SCRIPT",
+        memoria_mb=cmd.MEMORY_LIMIT_MB,
+        cpu_segundos=None,
         allow_insecure_fallback=False,
     )
 

--- a/tests/unit/test_resource_limits.py
+++ b/tests/unit/test_resource_limits.py
@@ -4,6 +4,7 @@ import pytest
 resource = pytest.importorskip("resource")
 
 from pcobra.cobra.cli.execution_pipeline import construir_script_sandbox_canonico
+from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.sandbox import _run_in_subprocess, ejecutar_en_sandbox
 
 
@@ -50,3 +51,17 @@ def test_programa_cobra_con_limites_no_contamina_proceso_anfitrion():
 def test_limite_cpu_invalido_rechaza_antes_de_crear_subproceso():
     with pytest.raises(ValueError, match="cpu_segundos"):
         _run_in_subprocess("print('no debe ejecutarse')", cpu_segundos=0)
+
+
+def test_interprete_conserva_limites_configurados_para_el_sandbox(monkeypatch):
+    monkeypatch.setitem(
+        InterpretadorCobra.__init__.__globals__, "limite_memoria_mb", lambda: 96
+    )
+    monkeypatch.setitem(
+        InterpretadorCobra.__init__.__globals__, "limite_cpu_segundos", lambda: 7
+    )
+
+    interpretador = InterpretadorCobra()
+
+    assert interpretador.limite_memoria_mb == 96
+    assert interpretador.limite_cpu_segundos == 7


### PR DESCRIPTION
### Motivation
- Evitar que los límites de memoria/CPU configurados en `cobra.toml` se apliquen al proceso anfitrión y, en su lugar, asegurarse de que se preserven y apliquen únicamente en los procesos hijos del sandbox. 
- Mantener la UX del REPL (`--memory-limit`) y la compatibilidad con tests/plugins que esperan los accesores públicos de configuración.

### Description
- Guarda los valores de `limite_memoria_mb` y `limite_cpu_segundos` como metadata en `InterpretadorCobra` sin invocar `setrlimit()` en el proceso anfitrión (`src/pcobra/core/interpreter.py`).
- Enruta la ejecución sandbox de `RunService` por el pipeline canónico y transmite `memoria_mb` y `cpu_segundos` al sandbox hijo (`src/pcobra/cobra/cli/services/run_service.py`).
- Conserva y valida el `--memory-limit` del REPL en `InteractiveCommand`, lo almacena en `self._memory_limit_mb` y lo pasa junto con el límite de CPU configurado al llamar a `ejecutar_en_sandbox` (`src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- Actualiza pruebas y expectativas: añade/verifica regresiones en `tests/unit/test_resource_limits.py` y ajusta mocks/expectativas en `tests/unit/test_cli_interactive_cmd.py` para incluir los argumentos `memoria_mb`/`cpu_segundos` enviados al sandbox.

### Testing
- Ejecutadas pruebas unitarias relacionadas con límites y sandbox: `tests/unit/test_resource_limits.py`, `tests/unit/test_sandbox.py`, `tests/unit/test_restricted_exec.py`, `tests/unit/test_sandbox_allowlist.py`, y `tests/unit/test_cli_interactive_cmd.py` (ajustadas); resultado: todas las pruebas pasaron tras las correcciones (ej. `39 passed, 1 warning`).
- Ejecutadas pruebas de integración/REPL relevantes: `tests/integration/test_run_repl_equivalence.py::test_sandbox_normaliza_safe_mode_y_validadores_igual_en_run_y_repl` y `tests/test_interactive_cmd_no_console.py`; resultado: pasaron.
- Durante la iteración aparecieron fallos en un subconjunto de tests CLI que se diagnosticaron y arreglaron mediante ajustes en la propagación de límites y en los mocks, tras lo cual los tests automatizados quedaron verdes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89e4b53c7c8327adf728debc0e98b2)