### PR TITLE
Skip unsupported sandbox resource limits on Windows

### DIFF
--- a/src/pcobra/core/sandbox.py
+++ b/src/pcobra/core/sandbox.py
@@ -605,7 +605,7 @@ def _worker(
 ) -> None:
     """Ejecuta ``code_bytes`` en un proceso aislado y comunica el resultado."""
     try:
-        if memoria_mb is not None or cpu_segundos is not None:
+        if (memoria_mb is not None or cpu_segundos is not None) and os.name != "nt":
             _aplicar_limites_proceso_hijo(
                 memoria_mb=memoria_mb, cpu_segundos=cpu_segundos
             )

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,6 +1,9 @@
+import marshal
 import os
 
 import pytest
+
+import core.sandbox as sandbox
 from core.sandbox import _run_in_subprocess, ejecutar_en_sandbox
 
 
@@ -71,3 +74,28 @@ def test_run_in_subprocess_memory_limit():
     codigo = "datos = bytearray(200 * 1024 * 1024)"
     with pytest.raises(MemoryError):
         _run_in_subprocess(codigo, memoria_mb=64)
+
+
+def test_worker_omite_limites_no_soportados_en_windows(monkeypatch):
+    resultados = []
+
+    class QueueStub:
+        def put(self, resultado):
+            resultados.append(resultado)
+
+    def limites_no_soportados(**_kwargs):
+        raise AssertionError("Windows no debe intentar aplicar límites POSIX")
+
+    monkeypatch.setattr(sandbox.os, "name", "nt")
+    monkeypatch.setattr(
+        sandbox, "_aplicar_limites_proceso_hijo", limites_no_soportados
+    )
+
+    sandbox._worker(
+        marshal.dumps(compile("print('ok')", "<test>", "exec")),
+        QueueStub(),
+        memoria_mb=64,
+        cpu_segundos=5,
+    )
+
+    assert resultados == ["ok\n"]


### PR DESCRIPTION
### Motivation

- Prevent sandboxed Cobra executions from failing on Windows when resource limits are supplied by ensuring POSIX-only limit application is not attempted on Windows.

### Description

- Add a guard in `_worker` so `_aplicar_limites_proceso_hijo` is only invoked when `(memoria_mb is not None or cpu_segundos is not None) and os.name != "nt"`, and add a regression test `test_worker_omite_limites_no_soportados_en_windows` to verify the worker runs without attempting POSIX limit application on Windows.

### Testing

- Ran `pytest -q tests/unit/test_sandbox.py -k "worker_omite_limites_no_soportados_en_windows"` and broader checks `pytest -q tests/unit/test_sandbox.py tests/unit/test_resource_limits.py tests/unit/test_resource_limits_run_service.py`, and the executed tests passed (tests completed successfully with the expected warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89ec176ec08327bc580bc10d9af7e7)