### PR TITLE
test: restaurar alias canónico `cobra` y evitar carga global del shim `core`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from pathlib import Path
 import sys
 
@@ -14,12 +15,53 @@ import inspect
 from typing import Any
 
 
+def _restore_cobra_alias() -> None:
+    """Mantiene ``cobra`` enlazado al paquete canónico durante las pruebas."""
+
+    module_name = "pcobra.cobra"
+    alias = "cobra"
+    module = import_module(module_name)
+    sys.modules[alias] = module
+    prefix = f"{module_name}."
+    alias_prefix = f"{alias}."
+    for name, loaded_module in list(sys.modules.items()):
+        if name.startswith(prefix):
+            sys.modules[alias_prefix + name[len(prefix) :]] = loaded_module
+
+
+def _prepare_core_submodule_aliases() -> None:
+    """Evita duplicar submódulos de ``pcobra.core`` sin cargar el shim ``core``."""
+
+    module_name = "pcobra.core"
+    alias = "core"
+    import_module(module_name)
+    sys.modules.pop(alias, None)
+    prefix = f"{module_name}."
+    alias_prefix = f"{alias}."
+    for name, loaded_module in list(sys.modules.items()):
+        if name.startswith(prefix):
+            sys.modules[alias_prefix + name[len(prefix) :]] = loaded_module
+
+
+# Se registra antes de que ``tests/conftest.py`` añada ``src/pcobra`` al path;
+# así nunca se crea un segundo árbol de módulos bajo el nombre histórico.
+_restore_cobra_alias()
+_prepare_core_submodule_aliases()
+
+
 def pytest_runtest_setup(item):  # noqa: ARG001
     """Aísla los módulos de transpiladores cargados por cada prueba."""
 
     for prefix in ("cobra.transpilers", "pcobra.cobra.transpilers"):
         for name in [mod for mod in sys.modules if mod.startswith(prefix)]:
             sys.modules.pop(name, None)
+    _restore_cobra_alias()
+
+
+def pytest_collectstart(collector):  # noqa: ARG001
+    """Restaura el alias canónico antes de importar cada módulo de pruebas."""
+
+    _restore_cobra_alias()
 
 
 def _ejecutar_corutina(funcion, **kwargs: Any) -> None:


### PR DESCRIPTION
### Motivation
- Evitar que la recolección de pruebas cree un segundo árbol de módulos bajo `cobra.*` y rompa la identidad de clases y los objetivos de `monkeypatch` al ejecutarse con `src/pcobra` en `sys.path`.
- Mantener la política de no carga eager del shim legacy `core` mientras se preserva la compatibilidad para pruebas que opten por usar el shim explícitamente.
- Hacer un cambio mínimo y localizado en la configuración de Pytest sin tocar Lexer ni Parser.

### Description
- Modificado `conftest.py` para añadir `from importlib import import_module` y las funciones `
  _restore_cobra_alias()` y `_prepare_core_submodule_aliases()` que sincronizan los alias canónicos con `pcobra.*` sin forzar la importación global del shim `core`.
- Registrado el alias `cobra` a tiempo de carga del archivo de configuración y re-sincronizado desde `pytest_collectstart` y `pytest_runtest_setup` para evitar árboles de módulos duplicados y preservar aislamiento de módulos de transpilers.
- `
  _prepare_core_submodule_aliases()` enlaza submódulos `pcobra.core.*` bajo `core.*` sin dejar el paquete shim `core` cargado globalmente, preservando la intención de carga no eager.
- No se realizaron cambios en `src/pcobra/cobra/lexer.py` ni en `src/pcobra/cobra/parser.py` y no se tocó Lexer ni Parser según las reglas de alcance.

### Testing
- Ejecutado `python -m pytest tests/unit/test_ast_contract.py -q` y obtuvo `8 passed` (no regresiones en el contrato AST).
- Ejecutado `python -m pytest tests/unit/test_pytest_global_config.py tests/unit/test_legacy_import_shims_contract.py -q` y obtuvo `4 passed` (verifica que `core` no se importe globalmente y que el shim produce `DeprecationWarning` cuando se importa explícitamente).
- Ejecutado `python -m ruff check conftest.py tests/unit/test_legacy_import_shims_contract.py tests/unit/test_pytest_global_config.py` sin incidencias de estilo.
- Verificado que `src/pcobra/cobra/lexer.py` y `src/pcobra/cobra/parser.py` no cambiaron y que las pruebas relacionadas pasan con las nuevas protecciones de alias canónico.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8a9b2a378083279233ebff2a264609)