### PR TITLE
Gate protected-file diff to pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: python scripts/validate_targets_policy.py
 
       - name: Guard protected lexer/parser files unchanged in `usar` fix scope (blocking)
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           git diff --name-only origin/${{ github.base_ref }}...HEAD | tee /tmp/changed_files.txt

--- a/tests/test_workflows_yaml.py
+++ b/tests/test_workflows_yaml.py
@@ -68,3 +68,17 @@ def test_workflow_branch_triggers_target_default_branch(workflow_filename: str) 
     assert "branches: [ work ]" not in content
     assert "      - work" not in content
     assert "branches: [ master ]" in content or "      - master" in content
+
+
+def test_protected_file_guard_only_runs_for_pull_requests() -> None:
+    """Evita construir un rango git con ``base_ref`` vacío durante un push."""
+    workflow_path = WORKFLOWS_DIR / "ci.yml"
+    content = workflow_path.read_text(encoding="utf-8")
+    guard_name = (
+        "      - name: Guard protected lexer/parser files unchanged in `usar` "
+        "fix scope (blocking)\n"
+    )
+    guard_start = content.index(guard_name) + len(guard_name)
+    guard_header = content[guard_start : content.index("        run:", guard_start)]
+
+    assert "        if: github.event_name == 'pull_request'\n" in guard_header


### PR DESCRIPTION
### Motivation
- Prevent master push runs from failing when the protected-file guard builds a git range using an empty `github.base_ref` (this guard should only run for PRs). 
- Add a regression check so the PR-only condition on the protected-file guard remains present and cannot regress.

### Description
- Added `if: github.event_name == 'pull_request'` to the protected lexer/parser guard step in `.github/workflows/ci.yml` so the `git diff origin/${{ github.base_ref }}...HEAD` range is only constructed for PR events. 
- Added `test_protected_file_guard_only_runs_for_pull_requests` to `tests/test_workflows_yaml.py` to assert the guard step contains the PR-only condition. 
- Did not modify any protected Lexer/Parser source files.

### Testing
- Ran `pytest -q tests/test_workflows_yaml.py` and the suite passed: `23 passed, 1 warning`.
- Ran `git diff --check` and confirmed there are no diff/whitespace issues.
- Verified no protected Lexer/Parser files were changed by checking `git diff --name-only` for those paths (no modifications found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ad147f7448327b71ff76185719337)