### PR TITLE
Restaura contratos de asignación y aisla hilos del intérprete

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -614,10 +614,6 @@ class InterpretadorCobra:
         self._eval_stack = set()
         self._call_depth = 0
         self._with_return_depth = 0
-        import threading
-
-        self._thread_execution_lock = threading.RLock()
-        self._thread_isolation_depth = 0
         # Funciones Cobra declaradas en el AST fuente. Se mantiene separada del
         # entorno de variables para que los optimizadores puedan eliminar nodos
         # ``NodoFuncion`` sin impedir que sus nombres sigan siendo resolubles
@@ -1816,8 +1812,11 @@ class InterpretadorCobra:
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
-                    # La primera asignación introduce el nombre en el entorno
-                    # activo; las lecturas siguen exigiendo que ya exista.
+                    if self._call_depth == 0:
+                        raise NameError(f"Variable no declarada: {nombre}")
+                    # Una asignación simple dentro de una función introduce un
+                    # nombre local cuando no existe en su cadena léxica. Este
+                    # contexto permanece activo durante todo el cuerpo.
                     indice_contexto = len(self.mem_contextos) - 1
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
@@ -2267,11 +2266,6 @@ class InterpretadorCobra:
         entorno_capturado = funcion.get(
             "scope_lexico", funcion.get("entorno", self.contextos[-1])
         )
-        if self._thread_isolation_depth:
-            entorno_capturado = Environment(
-                values=dict(entorno_capturado.values),
-                parent=entorno_capturado.parent,
-            )
         self.contextos.append(Environment(parent=entorno_capturado))
         self.mem_contextos.append({})
         try:
@@ -2374,11 +2368,6 @@ class InterpretadorCobra:
                 entorno_capturado = funcion.get(
                     "scope_lexico", funcion.get("entorno", self.contextos[-1])
                 )
-                if self._thread_isolation_depth:
-                    entorno_capturado = Environment(
-                        values=dict(entorno_capturado.values),
-                        parent=entorno_capturado.parent,
-                    )
                 self.contextos.append(Environment(parent=entorno_capturado))
                 self.mem_contextos.append({})
                 for nombre_param, valor in zip(parametros, argumentos_resueltos):
@@ -2811,19 +2800,46 @@ class InterpretadorCobra:
 
     def ejecutar_hilo(self, nodo):
         """Ejecuta una función en un hilo separado."""
+        import copy
         import threading
 
+        # Cada worker recibe sus propias pilas y su propia cadena de entornos.
+        # Los valores ajenos al runtime Cobra (por ejemplo, primitivas Python
+        # que esperan sobre I/O) se conservan por referencia.
+        entornos_clonados = {}
+
+        def clonar_entorno(entorno):
+            if entorno is None:
+                return None
+            clave = id(entorno)
+            if clave in entornos_clonados:
+                return entornos_clonados[clave]
+            clon = Environment(parent=clonar_entorno(entorno.parent))
+            entornos_clonados[clave] = clon
+            clon.values = dict(entorno.values)
+            return clon
+
+        contexto_hilo = clonar_entorno(self.contextos[-1])
+        for clon in list(entornos_clonados.values()):
+            for nombre, valor in tuple(clon.values.items()):
+                if self._es_descriptor_funcion_cobra(valor):
+                    descriptor = dict(valor)
+                    scope = valor.get("scope_lexico", valor.get("entorno"))
+                    descriptor["scope_lexico"] = clonar_entorno(scope)
+                    clon.values[nombre] = descriptor
+
+        interprete_hilo = copy.copy(self)
+        interprete_hilo.contextos = [contexto_hilo]
+        interprete_hilo.mem_contextos = [{}]
+        interprete_hilo.gestor_memoria = GestorMemoriaGenetico()
+        interprete_hilo.estrategia = interprete_hilo.gestor_memoria.poblacion[0]
+        interprete_hilo.op_memoria = 0
+        interprete_hilo._eval_stack = set()
+        interprete_hilo._call_depth = 0
+        interprete_hilo._with_return_depth = 0
+
         def destino():
-            # Las llamadas concurrentes comparten el intérprete, pero cada
-            # hilo ejecuta la función sobre una vista aislada de su entorno
-            # capturado. El bloqueo protege las pilas internas de contextos y
-            # memoria, que son estructuras compartidas y no thread-local.
-            with self._thread_execution_lock:
-                self._thread_isolation_depth += 1
-                try:
-                    self.ejecutar_llamada_funcion(nodo.llamada)
-                finally:
-                    self._thread_isolation_depth -= 1
+            interprete_hilo.ejecutar_llamada_funcion(nodo.llamada)
 
         # El hilo se marca como daemon para evitar que bloquee el cierre del
         # intérprete si queda en ejecución al finalizar el programa.

--- a/tests/unit/test_interpreter_concurrency.py
+++ b/tests/unit/test_interpreter_concurrency.py
@@ -1,4 +1,5 @@
 import pytest
+import threading
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.ast_nodes import (
     NodoAsignacion,
@@ -13,7 +14,9 @@ from pcobra.core.ast_nodes import (
 @pytest.mark.timeout(5)
 def test_hilos_preservan_variables_globales_concurrentes():
     interp = InterpretadorCobra()
-    interp.ejecutar_asignacion(NodoAsignacion('contador', NodoValor(0)))
+    interp.ejecutar_asignacion(
+        NodoAsignacion('contador', NodoValor(0), declaracion=True)
+    )
     funcion = NodoFuncion(
         'trabajo',
         ['n'],
@@ -32,3 +35,24 @@ def test_hilos_preservan_variables_globales_concurrentes():
 
     assert interp.variables['contador'] == 0
     assert len(interp.contextos) == 1
+
+
+@pytest.mark.timeout(5)
+def test_hilos_cobra_pueden_sincronizarse_sin_serializarse():
+    interp = InterpretadorCobra()
+    barrera = threading.Barrier(2)
+    interp.funciones_nativas["esperar"] = lambda: barrera.wait(timeout=2)
+    interp.ejecutar_funcion(
+        NodoFuncion("trabajo", [], [NodoLlamadaFuncion("esperar", [])])
+    )
+
+    hilos = [
+        interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion("trabajo", [])))
+        for _ in range(2)
+    ]
+    for hilo in hilos:
+        hilo.join(timeout=3)
+
+    assert all(not hilo.is_alive() for hilo in hilos)
+    assert barrera.n_waiting == 0
+    assert not barrera.broken

--- a/tests/unit/test_interpreter_cycles.py
+++ b/tests/unit/test_interpreter_cycles.py
@@ -1,7 +1,7 @@
 import pytest
 
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.ast_nodes import (
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import (
     NodoAsignacion,
     NodoBloque,
     NodoCondicional,
@@ -9,7 +9,7 @@ from pcobra.core.ast_nodes import (
     NodoOperacionBinaria,
     NodoValor,
 )
-from pcobra.core.lexer import TipoToken, Token
+from cobra.core import TipoToken, Token
 
 
 def test_referencia_circular_variable():


### PR DESCRIPTION
### Motivation

- Restaurar contratos de runtime y semántica del intérprete detectados por auditoría, en particular la política de `NameError` para asignaciones no declaradas y la detección de autorreferencias/ciclos.  
- Evitar que la primitiva de hilos serialice toda la ejecución del intérprete y permitir verdadero solapamiento entre hilos para operaciones bloqueantes/síncronas.  
- Mantener cambios incrementales y localizados y no tocar `Lexer`/`Parser` según las reglas de repository-wide audit.

### Description

- Restaura el contrato de asignación no declarada en `ejecutar_asignacion` de modo que una asignación a un nombre ausente en el scope top-level vuelve a lanzar `NameError`, mientras que las asignaciones locales dentro de funciones aún crean bindings locales cuando procede (se preservó la semántica previa de `declaracion`/`inferencia`).  
- Conserva la detección de autorreferencia directa en `_asegurar_no_autorreferencia_asignacion` para que `x = x` sin binding previo sea rechazado como ciclo, pero permite patrones válidos como `x = x + 1` cuando existe el binding previo.  
- Sustituye el bloqueo que serializaba la ejecución de cada hilo por un enfoque donde cada hilo obtiene un intérprete-worker con pilas y `Environment` clonados; se clonan entornos léxicos y descriptores de función relevantes y se crea una copia ligera del intérprete (`copy.copy`) con `contextos`, `mem_contextos` y `gestor_memoria` independientes para el worker.  
- Añade una prueba de regresión de concurrencia que usa una `Barrier` de dos participantes para validar que dos hilos Cobra pueden sincronizarse sin que la implementación serialice toda la función, y separa la canonicalización de imports de las pruebas de ciclos para mantener los cambios incrementales.

### Testing

- Ejecuté `python -m pytest -q tests/unit/test_interpreter_concurrency.py` y obtuvo `2 passed` (incluye la nueva prueba de barrera).  
- Ejecuté `python -m pytest -q tests/unit/test_interpreter_cycles.py` y obtuvo `12 passed` tras separar la canonicalización de imports.  
- Ejecuté `python -m pytest -q tests/unit/test_interpreter_scope_contract.py::test_asignar_sin_declarar_falla_con_name_error` y obtuvo `1 passed`, confirmando que `NameError` fue restaurado.  
- Ejecuté `python -m pytest -q tests/unit/test_interpreter_atributo.py` y obtuvo `1 passed`, asegurando que cambios no afectaron la resolución de literales/atributos y que `Lexer`/`Parser` no fueron modificados (comprobado con diff contra la referencia proporcionada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ad3a6bfd88327a4ccb225aae0d408)