### PR TITLE
test: preserve rejection coverage for English 'with' syntax

### DIFF
--- a/tests/unit/test_parser_del_global.py
+++ b/tests/unit/test_parser_del_global.py
@@ -45,14 +45,10 @@ def test_parser_with():
     assert len(ast[0].cuerpo) == 1 and isinstance(ast[0].cuerpo[0], NodoPasar)
 
 
-def test_parser_con_alias():
-    code = "con recurso como r: pasar fin"
-    ast = Parser(Lexer(code).analizar_token()).parsear()
-    assert isinstance(ast[0], NodoWith)
-    assert isinstance(ast[0].contexto, NodoIdentificador)
-    assert ast[0].contexto.nombre == "recurso"
-    assert ast[0].alias == "r"
-    assert len(ast[0].cuerpo) == 1 and isinstance(ast[0].cuerpo[0], NodoPasar)
+def test_parser_with_en_rechazado():
+    code = "with recurso as r: pasar fin"
+    with pytest.raises(ParserError):
+        Parser(Lexer(code).analizar_token()).parsear()
 
 
 def test_transpilar_del():


### PR DESCRIPTION
### Motivation

- Preserve negative coverage for the unsupported English `with ... as ...` form so a regression that accepts `with recurso as r` will be detected rather than silently duplicating the Spanish positive test.

### Description

- Replace the duplicated `test_parser_con_alias` with `test_parser_with_en_rechazado` which asserts a `ParserError` for the English input `"with recurso as r: pasar fin"`, while keeping the Spanish positive `test_parser_with` intact in `tests/unit/test_parser_del_global.py`.

### Testing

- Ran `pytest -q tests/unit/test_parser_del_global.py` which passed (`12 passed`), ran `git diff --check`, and verified that Lexer and Parser implementation files were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ae0108d2083278b7976ba92d3d8bf)