### PR TITLE
Preserve NameError from project modules and distinguish usar symbol-collisions

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -152,6 +152,10 @@ _USAR_COLLISION_POLICIES = frozenset(
 )
 
 
+class _UsarSymbolConflictError(NameError):
+    """Identifica exclusivamente los ``NameError`` por colisiones de ``usar``."""
+
+
 def formatear_error_usar_usuario(
     codigo: str, modulo: str, contexto_minimo: str | None = None
 ) -> str:
@@ -2793,7 +2797,7 @@ class InterpretadorCobra:
                     stacklevel=2,
                 )
 
-            raise NameError(
+            raise _UsarSymbolConflictError(
                 f"No se puede usar '{modulo}': "
                 "hay conflicto de símbolos en el contexto actual. "
                 f"Símbolo conflictivo: {simbolo}. "
@@ -2853,13 +2857,17 @@ class InterpretadorCobra:
                     )
                 )
                 exc_usuario.add_note(str(exc))
-            elif isinstance(exc, NameError):
+            elif isinstance(exc, _UsarSymbolConflictError):
                 exc_usuario = NameError(
                     formatear_error_usar_usuario(
                         "conflicto_simbolo", nombre_modulo_limpio
                     )
                 )
                 exc_usuario.add_note(str(exc))
+            elif isinstance(exc, NameError):
+                # Los errores de resolución al ejecutar el módulo pertenecen a
+                # su runtime y no representan una colisión durante la inyección.
+                raise
             elif isinstance(exc, (ImportError, PermissionError)):
                 mensaje = str(exc)
                 if "usar_error[" in mensaje:
@@ -2948,7 +2956,7 @@ class InterpretadorCobra:
                     "[USAR_COLLISION][ERROR] "
                     f"módulo={modulo} símbolo={nombre} code=symbol_collision_runtime_recheck"
                 )
-                raise NameError(
+                raise _UsarSymbolConflictError(
                     "No se puede usar el módulo "
                     f"'{metadata_actual.get('module')}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -921,6 +921,25 @@ def test_interpretador_usar_proyecto_modulo_inexistente_oculta_ruta(tmp_path):
     assert str(ruta_buscada) not in mensaje
 
 
+def test_interpretador_usar_preserva_nameerror_del_runtime_del_modulo(monkeypatch):
+    error_runtime = NameError("Variable no declarada: faltante")
+
+    def cargar_modulo_con_nombre_no_declarado(*_args, **_kwargs):
+        raise error_runtime
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter._usar_modulo_con_estado_aislado",
+        cargar_modulo_con_nombre_no_declarado,
+    )
+
+    interp = InterpretadorCobra()
+    with pytest.raises(NameError, match=r"^Variable no declarada: faltante$") as excinfo:
+        interp.ejecutar_usar(SimpleNamespace(modulo="modulo_roto"))
+
+    assert excinfo.value is error_runtime
+    assert "usar_error[conflicto_simbolo]" not in str(excinfo.value)
+
+
 def test_resolver_modulo_cobra_proyecto_rechaza_resultado_manipulado_fuera_de_root(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where a runtime `NameError` raised while evaluating a project module was being misclassified as a `usar_error[conflicto_simbolo]`, hiding the original actionable error. 
- Ensure only NameErrors originating from `usar` collision checks are translated into the public collision diagnostic, while preserving non-collision `NameError` instances raised by imported modules.

### Description

- Added an internal subtype ` _UsarSymbolConflictError` to mark `NameError`s that are produced by `usar` symbol-collision checks so they can be distinguished from module runtime `NameError`s in exception translation. (`src/pcobra/core/interpreter.py`).
- Converted the two internal collision-raising sites to raise ` _UsarSymbolConflictError` instead of a plain `NameError` so only those are transformed to the public `usar_error[conflicto_simbolo]` message. (`_inyectar_exports_modulo_proyecto` and `_inyectar_simbolos_usar_en_contexto`).
- Changed `InterpretadorCobra.ejecutar_usar` exception handling so that it maps `_UsarSymbolConflictError` into the sanitized public `NameError` message but re-raises plain `NameError` exceptions coming from module evaluation unchanged. (`src/pcobra/core/interpreter.py`).
- Added a focused regression test `test_interpretador_usar_preserva_nameerror_del_runtime_del_modulo` to ensure a `NameError` raised while loading/evaluating a project module is preserved and not relabeled as a symbol-collision error. (`tests/unit/test_project_root_usar_resolution.py`).

### Testing

- Ran the targeted tests: `pytest -q tests/unit/test_project_root_usar_resolution.py::test_interpretador_usar_preserva_nameerror_del_runtime_del_modulo tests/integration/test_usar_public_contract_regression.py::test_conflicto_no_overwrite_silencioso_reporta_error_estructurado tests/integration/test_usar_public_contract_regression.py::test_conflictos_abortan_inyeccion_sin_overwrite_silencioso` and they all passed (`3 passed`).
- Ran the broader suites `pytest -q tests/unit/test_project_root_usar_resolution.py tests/integration/test_usar_public_contract_regression.py` which completed successfully (`105 passed`).
- Verified module compiles with `python -m compileall -q src/pcobra/core/interpreter.py` and ran `git diff --check` and a targeted diff for lexer/parser to confirm no changes to lexer or parser.
- All automated checks above succeeded and the new regression test verifies the bug is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c30f66154832795d0cbad1d971782)