### PR TITLE
chore: remove legacy AST cache alias and test from this PR (split change)

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -362,12 +362,6 @@ def obtener_cache_ast_import_cobra() -> dict[Path, list[Any]]:
     return _IMPORT_COBRA_AST_CACHE
 
 
-def obtener_cache_ast_import_co() -> dict[Path, list[Any]]:
-    """Alias compatible del antiguo accessor de la caché de ASTs."""
-
-    return obtener_cache_ast_import_cobra()
-
-
 def _formatear_ruta_ciclo_modulo(ruta: Path, project_root: Path | None) -> str:
     """Formatea una ruta de ciclo de forma estable y legible."""
 

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -6,7 +6,6 @@ import pytest
 from pcobra.cobra.cli.execution_pipeline import PipelineInput, ejecutar_pipeline_explicito
 from pcobra.cobra.usar_loader import (
     descubrir_raiz_proyecto,
-    obtener_cache_ast_import_co,
     obtener_cache_ast_import_cobra,
     formatear_ciclo_modulos_cobra_proyecto,
     obtener_cache_modulos_cobra_proyecto,
@@ -24,10 +23,6 @@ from pcobra.core.ast_nodes import (
     NodoUsar,
     NodoValor,
 )
-
-
-def test_accessor_legacy_comparte_cache_ast_import_cobra():
-    assert obtener_cache_ast_import_co() is obtener_cache_ast_import_cobra()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Motivation
- A reviewer flagged that the legacy AST cache compatibility alias is unrelated to the extension-policy docs and regenerated CLI snapshot, and repository policy requires resolving audit findings incrementally and keeping unrelated fixes separate.

### Description
- Removed the legacy accessor `obtener_cache_ast_import_co()` from `src/pcobra/cobra/usar_loader.py` so this PR only contains the extension-policy/docs and CLI snapshot changes.
- Removed the regression test `test_accessor_legacy_comparte_cache_ast_import_cobra` and its import from `tests/unit/test_project_root_usar_resolution.py` so tests continue to rely on the canonical accessor.
- Kept all uses of the canonical accessor `obtener_cache_ast_import_cobra()` unchanged and preserved the `.cobra`/`.co` documentation and generated CLI snapshot changes included in the original PR.
- Ensured changes are minimal and did not touch `Lexer` or `Parser` sources as required by repository policy.

### Testing
- Ran `pytest -q tests/unit/test_project_root_usar_resolution.py` and the suite passed (`77 passed, 1 warning`).
- Ran the targeted docs/GUI tests (`test_ejemplos_cli_generados_derivan_de_target_policies` and the two GUI runtime tests) and they passed. 
- Verified no `Lexer`/`Parser` sources were modified and there were no diff-check warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c5e20d6188327a4e3e376c052f82b)