### PR TITLE
Propagar `--memory-limit` del entrypoint REPL v2 al delegado InteractiveCommand

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -15,7 +15,7 @@ from pcobra.cobra.cli.utils.parser_error_classifier import (
     _extraer_token_desde_error as extraer_token_desde_error_parser,
     es_parser_error_de_bloque_incompleto,
 )
-from pcobra.cobra.cli.utils.messages import mostrar_info
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError
@@ -154,6 +154,15 @@ class ReplCommandV2(BaseCommand):
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
 
     def run(self, args: Any) -> int:
+        memory_limit = getattr(args, "memory_limit", self._delegate.MEMORY_LIMIT_MB)
+        if memory_limit <= 0:
+            mostrar_error(_("El límite de memoria debe ser positivo"))
+            return 1
+        # Este entrypoint no llama a InteractiveCommand.run(), por lo que debe
+        # propagar explícitamente la opción pública al delegado que crea el
+        # proceso sandbox.
+        self._delegate._memory_limit_mb = memory_limit
+
         buffer: list[str] = []
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
         self._seguro_repl = bool(getattr(args, "seguro", True))

--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -117,6 +117,30 @@ def test_repl_v2_sandbox_docker_no_usa_camino_normal(monkeypatch):
     assert normal_calls == []
 
 
+def test_repl_v2_propaga_memory_limit_al_delegate_sandbox(monkeypatch):
+    command = repl_module.ReplCommandV2()
+    entradas = iter(["imprimir(1)", "exit"])
+    limites_observados: list[int] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(
+        repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [object()]
+    )
+    monkeypatch.setattr(
+        command._delegate,
+        "_ejecutar_en_sandbox",
+        lambda _codigo: limites_observados.append(
+            command._delegate._memory_limit_mb
+        ),
+    )
+
+    args = _args_repl()
+    args.sandbox = True
+
+    assert command.run(args) == 0
+    assert limites_observados == [128]
+
+
 def test_repl_v2_persistencia_estado_var_x_e_imprimir_x(monkeypatch, capsys):
     command = repl_module.ReplCommandV2()
     command._interpretador_persistente = {}


### PR DESCRIPTION
### Motivation
- Evitar que la ruta pública `ReplCommandV2` ignore la opción `--memory-limit` y ejecute sandboxes con el valor por defecto del delegado en lugar del solicitado por el usuario.

### Description
- Valida `args.memory_limit` en `ReplCommandV2.run()` y copia el valor en `self._delegate._memory_limit_mb` para que la ejecución sandbox use el límite configurado (archivo modificado: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`).
- Añade un test de regresión que verifica que el camino público de REPL en modo `--sandbox` pasa el límite de memoria al delegado (archivo añadido/actualizado: `tests/unit/cli/commands_v2/test_repl_cmd_v2.py::test_repl_v2_propaga_memory_limit_al_delegate_sandbox`).

### Testing
- Ejecutado `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y la suite relevante reportó `15 passed, 1 warning`.
- Ejecutado `python -m ruff check src/pcobra/cobra/cli/commands_v2/repl_cmd.py tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y no se reportaron errores de estilo.
- Ejecutado `git diff --check` y `git status` localmente; el árbol quedó limpio tras el commit que incluye estas modificaciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c6cf933508327a78d10018f56acf7)