### PR TITLE
test: canonicalizar imports legacy de cobra y core con meta-path finder

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from importlib import import_module
+from importlib.abc import Loader, MetaPathFinder
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 import sys
 
@@ -12,7 +14,55 @@ if str(SRC_PATH) not in sys.path:
 
 import asyncio
 import inspect
+from types import ModuleType
 from typing import Any
+
+
+class _CanonicalAliasLoader(Loader):
+    """Carga un nombre histórico reutilizando el módulo canónico."""
+
+    def __init__(self, canonical_name: str) -> None:
+        self.canonical_name = canonical_name
+        self._metadata: tuple[object, object, object] | None = None
+
+    def create_module(self, spec: ModuleSpec) -> ModuleType:  # noqa: ARG002
+        module = import_module(self.canonical_name)
+        self._metadata = (module.__spec__, module.__loader__, module.__package__)
+        return module
+
+    def exec_module(self, module: ModuleType) -> None:
+        # El mecanismo de importación escribe los metadatos del alias sobre el
+        # objeto retornado por ``create_module``; se conserva su identidad
+        # canónica para introspección e importaciones relativas posteriores.
+        if self._metadata is not None:
+            module.__spec__, module.__loader__, module.__package__ = self._metadata
+
+
+class _CanonicalAliasFinder(MetaPathFinder):
+    """Redirige submódulos legacy antes de que ``PathFinder`` los duplique."""
+
+    _prefixes = {"cobra.": "pcobra.cobra.", "core.": "pcobra.core."}
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,  # noqa: ARG002
+        target: ModuleType | None = None,  # noqa: ARG002
+    ) -> ModuleSpec | None:
+        for legacy_prefix, canonical_prefix in self._prefixes.items():
+            if fullname.startswith(legacy_prefix):
+                canonical_name = canonical_prefix + fullname[len(legacy_prefix) :]
+                return ModuleSpec(
+                    fullname,
+                    _CanonicalAliasLoader(canonical_name),
+                    is_package=False,
+                )
+        return None
+
+
+_ALIAS_FINDER = _CanonicalAliasFinder()
+if not any(isinstance(finder, _CanonicalAliasFinder) for finder in sys.meta_path):
+    sys.meta_path.insert(0, _ALIAS_FINDER)
 
 
 def _restore_cobra_alias() -> None:

--- a/tests/unit/test_pytest_global_config.py
+++ b/tests/unit/test_pytest_global_config.py
@@ -34,3 +34,34 @@ def test_configuracion_global_no_importa_shim_core() -> None:
         probe.unlink(missing_ok=True)
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_configuracion_global_preserva_identidad_de_submodulos_legacy() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = repo_root / "test_pytest_alias_identity_probe.py"
+    probe.write_text(
+        "import importlib\n\n"
+        "def test_aliases_lazy_reutilizan_modulos_canonicos():\n"
+        "    legacy_plugin = importlib.import_module('cobra.cli.plugin')\n"
+        "    canonical_plugin = importlib.import_module('pcobra.cobra.cli.plugin')\n"
+        "    legacy_interpreter = importlib.import_module('core.interpreter')\n"
+        "    canonical_interpreter = importlib.import_module('pcobra.core.interpreter')\n"
+        "    assert legacy_plugin is canonical_plugin\n"
+        "    assert legacy_plugin.PluginCommand is canonical_plugin.PluginCommand\n"
+        "    assert legacy_interpreter is canonical_interpreter\n"
+        "    assert legacy_interpreter.InterpretadorCobra is canonical_interpreter.InterpretadorCobra\n",
+        encoding="utf-8",
+    )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", str(probe)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        probe.unlink(missing_ok=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- Evitar que importaciones en tiempo de colecta creen un segundo árbol de módulos bajo `cobra.*` o `core.*` y rompieran la identidad de clases y objetivos de `monkeypatch` cuando `src/pcobra` está en `sys.path`.
- Mantener la política de no carga eager del shim legacy `core` mientras se provee compatibilidad para tests que usan los nombres históricos.
- Hacer un cambio mínimo y localizado en la configuración de Pytest sin tocar Lexer ni Parser.

### Description
- Se añadió un `MetaPathFinder` y `Loader` en `conftest.py` que interceptan importaciones legacy `cobra.*` y `core.*` y redirigen cada submódulo al objeto de módulo canónico correspondiente `pcobra.cobra.*` o `pcobra.core.*` reusando la instancia y preservando metadatos.
- Se preservó la preparación temprana existente (`_restore_cobra_alias()` y `_prepare_core_submodule_aliases()`) para evitar exponer el shim `core` globalmente y se insertó el alias finder en `sys.meta_path` antes de la carga de tests.
- Se añadió un test de regresión subprocessal en `tests/unit/test_pytest_global_config.py` que importa primero los nombres legacy (`cobra.cli.plugin`, `core.interpreter`) y verifica identidad de módulos y clases frente a `pcobra.*`.

### Testing
- Ejecutado `python -m pytest tests/unit/test_pytest_global_config.py tests/unit/test_legacy_import_shims_contract.py -q` y obtuvo `5 passed` con código de salida `0`.
- Ejecutado `python -m pytest tests/unit/test_descubrir_plugins_invalid.py tests/unit/test_ast_contract.py -q` y obtuvo `11 passed` con código de salida `0`.
- Ejecutado `python -m ruff check conftest.py tests/unit/test_pytest_global_config.py`, `git diff --check` y verificado que `src/pcobra/cobra/lexer.py` y `src/pcobra/cobra/parser.py` no cambiaron, todos los chequeos pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d2e4fc4a08327b9456eed050fc1cb)