### PR TITLE
Corrige asignaciones iniciales y aislamiento de imports en hilos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1812,11 +1812,8 @@ class InterpretadorCobra:
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
-                    if self._call_depth == 0:
-                        raise NameError(f"Variable no declarada: {nombre}")
-                    # Una asignación simple dentro de una función introduce un
-                    # nombre local cuando no existe en su cadena léxica. Este
-                    # contexto permanece activo durante todo el cuerpo.
+                    # La asignación Cobra ``nombre = valor`` también declara
+                    # el nombre cuando todavía no existe en la cadena léxica.
                     indice_contexto = len(self.mem_contextos) - 1
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
@@ -2837,6 +2834,12 @@ class InterpretadorCobra:
         interprete_hilo._eval_stack = set()
         interprete_hilo._call_depth = 0
         interprete_hilo._with_return_depth = 0
+        # Estas pilas son estado transitorio de una ejecución. ``copy.copy``
+        # conservaría las mismas listas y permitiría que imports simultáneos
+        # alterasen la resolución relativa o la detección de ciclos del otro.
+        interprete_hilo._current_module_stack = list(self._current_module_stack)
+        interprete_hilo._import_execution_stack = list(self._import_execution_stack)
+        interprete_hilo._usar_loading_stack = list(self._usar_loading_stack)
 
         def destino():
             interprete_hilo.ejecutar_llamada_funcion(nodo.llamada)

--- a/tests/unit/test_interpreter_concurrency.py
+++ b/tests/unit/test_interpreter_concurrency.py
@@ -1,5 +1,7 @@
-import pytest
 import threading
+from pathlib import Path
+
+import pytest
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.ast_nodes import (
     NodoAsignacion,
@@ -56,3 +58,42 @@ def test_hilos_cobra_pueden_sincronizarse_sin_serializarse():
     assert all(not hilo.is_alive() for hilo in hilos)
     assert barrera.n_waiting == 0
     assert not barrera.broken
+
+
+@pytest.mark.timeout(5)
+def test_hilos_tienen_pilas_de_import_independientes(monkeypatch):
+    interp = InterpretadorCobra()
+    interp._current_module_stack = [Path("/modulo/base.co")]
+    interp._import_execution_stack = [Path("/modulo/base.co")]
+    interp._usar_loading_stack = [Path("/modulo/usado.co")]
+    pilas_workers = []
+    barrera = threading.Barrier(2)
+
+    def capturar_pilas(worker, _llamada):
+        pilas_workers.append(
+            (
+                worker._current_module_stack,
+                worker._import_execution_stack,
+                worker._usar_loading_stack,
+            )
+        )
+        barrera.wait(timeout=2)
+
+    monkeypatch.setattr(InterpretadorCobra, "ejecutar_llamada_funcion", capturar_pilas)
+    hilos = [
+        interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion("trabajo", [])))
+        for _ in range(2)
+    ]
+    for hilo in hilos:
+        hilo.join(timeout=3)
+
+    assert all(not hilo.is_alive() for hilo in hilos)
+    assert len(pilas_workers) == 2
+    for indice in range(3):
+        assert pilas_workers[0][indice] is not pilas_workers[1][indice]
+        assert pilas_workers[0][indice] is not getattr(
+            interp,
+            ("_current_module_stack", "_import_execution_stack", "_usar_loading_stack")[
+                indice
+            ],
+        )

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -403,9 +403,12 @@ def test_contrato_anticoopia_entorno_cierre_observa_mutaciones_posteriores() -> 
     assert inter.obtener_variable("resultado") == 2
 
 
-def test_asignar_sin_declarar_falla_con_name_error() -> None:
-    with pytest.raises(NameError, match=r"^Variable no declarada: x$"):
-        _ejecutar([NodoAsignacion("x", NodoValor(10))])
+def test_primera_asignacion_simple_declara_variable() -> None:
+    asignacion = NodoAsignacion("x", NodoValor(10))
+
+    assert asignacion.declaracion is False
+    inter = _ejecutar([asignacion])
+    assert inter.obtener_variable("x") == 10
 
 
 def test_declaracion_y_reasignacion_mantienen_contexto_y_memoria_sin_desfase() -> None:


### PR DESCRIPTION
### Motivation

- Corregir la semántica normativa de asignación por defecto para que una asignación inicial como `x = 10` cree el binding en el entorno actual en lugar de provocar `NameError` según lo establecido en `docs/LIBRO_PROGRAMACION_COBRA.md`.
- Evitar condiciones de carrera y contaminación entre hilos cuando múltiples workers realizan `import`/`usar` concurrentes compartiendo pilas transitorias de resolución y detección de ciclos.

### Description

- En `ejecutar_asignacion` se eliminó la rama que lanzaba `NameError` para asignaciones sin declaración previa y ahora la primera asignación simple crea el binding en el contexto actual preservando la semántica de `declaracion`/`inferencia` y la mutación de variables existentes en su scope definido.
- En `ejecutar_hilo` se copia explícitamente `_current_module_stack`, `_import_execution_stack` y `_usar_loading_stack` hacia el intérprete worker (`list(...)`) para que cada worker tenga pilas de imports independientes y no comparta listas con el intérprete padre.
- Se añadieron y actualizaron pruebas: `test_primera_asignacion_simple_declara_variable` verifica que una `NodoAsignacion` inicial crea el binding, y `test_hilos_tienen_pilas_de_import_independientes` comprueba que los workers reciben copias independientes de las tres pilas de import.

### Testing

- Ejecuté `python -m pytest -q tests/unit/test_interpreter_scope_contract.py::test_primera_asignacion_simple_declara_variable tests/unit/test_interpreter_concurrency.py` y obtuvo `4 passed` en la verificación focalizada.
- Durante la iteración se ejecutaron suites relacionadas incluyendo `tests/unit/test_interpreter_scope_contract.py`, `tests/unit/test_interpreter_concurrency.py`, `tests/unit/test_interpreter_cycles.py` y `tests/unit/test_project_root_usar_resolution.py` y se resolvieron fallos detectados hasta obtener paso consistente en las pruebas locales; se usó `git diff --check` para validar el diff.
- Verifiqué que no se modificaron `Lexer` ni `Parser` comparando cambios en `src/pcobra/core` y ejecutando `git diff --name-only -- src/pcobra/core | rg -i '(lexer|parser)'` con resultado vacío antes del commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d48f5e618832787984fc3a457c9e7)