### PR TITLE
Handle push events in CI protected-file guard and reconcile workflow branch-filter tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,22 @@ jobs:
 
       - name: Guard protected lexer/parser files unchanged in `usar` fix scope (blocking)
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          git diff --name-only origin/${{ github.base_ref }}...HEAD | tee /tmp/changed_files.txt
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            comparison_args=("origin/${BASE_REF}...HEAD")
+          elif [[ "$EVENT_NAME" == "push" ]] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            comparison_args=("${BEFORE_SHA}...HEAD")
+          elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            comparison_args=("HEAD^...HEAD")
+          else
+            comparison_args=("$(git hash-object -t tree /dev/null)" HEAD)
+          fi
+
+          git diff --name-only "${comparison_args[@]}" | tee /tmp/changed_files.txt
           protected_files=(
             "src/pcobra/core/lexer.py"
             "src/pcobra/core/parser.py"

--- a/tests/test_workflows_yaml.py
+++ b/tests/test_workflows_yaml.py
@@ -69,3 +69,15 @@ def test_workflow_branch_triggers_target_default_branch(workflow_filename: str) 
     assert "branches: [ main, work ]" in content or (
         "      - main" in content and "      - work" in content
     )
+
+
+def test_ci_protected_file_guard_uses_event_appropriate_comparison() -> None:
+    """Evita construir una referencia vacía con ``base_ref`` en eventos push."""
+    content = (WORKFLOWS_DIR / "ci.yml").read_text(encoding="utf-8")
+
+    assert 'EVENT_NAME: ${{ github.event_name }}' in content
+    assert 'BEFORE_SHA: ${{ github.event.before }}' in content
+    assert '[[ "$EVENT_NAME" == "pull_request" ]]' in content
+    assert '[[ "$EVENT_NAME" == "push" ]]' in content
+    assert 'comparison_args=("${BEFORE_SHA}...HEAD")' in content
+    assert 'comparison_args=("HEAD^...HEAD")' in content

--- a/tests/unit/test_workflow_branch_filters.py
+++ b/tests/unit/test_workflow_branch_filters.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-ACTIVE_BRANCH = "work"
+ACTIVE_BRANCHES = ("main", "work")
 WORKFLOWS_WITH_BRANCH_FILTERS = (
     ".github/workflows/ci.yml",
     ".github/workflows/runtime-stabilization-contract.yml",
@@ -11,10 +11,11 @@ WORKFLOWS_WITH_BRANCH_FILTERS = (
 )
 
 
-def test_workflows_with_branch_filters_target_active_branch_only():
+def test_workflows_with_branch_filters_target_active_branches():
     for workflow in WORKFLOWS_WITH_BRANCH_FILTERS:
         contenido = (ROOT / workflow).read_text(encoding="utf-8")
 
         assert "branches:" in contenido, workflow
-        assert "main" not in contenido, workflow
-        assert ACTIVE_BRANCH in contenido, workflow
+        assert "master" not in contenido, workflow
+        for branch in ACTIVE_BRANCHES:
+            assert branch in contenido, workflow


### PR DESCRIPTION
### Motivation

- Prevent push CI failures caused by constructing an invalid `origin/...HEAD` comparison when `github.base_ref` is empty for non-PR events. 
- Ensure the repository-wide workflow branch-filter contract matches the actual branches used (`main` and `work`) and continues to reject `master`.

### Description

- Update `.github/workflows/ci.yml` to select a comparison range appropriate to the event by exporting `EVENT_NAME`, `BASE_REF`, and `BEFORE_SHA` and building `comparison_args` for `pull_request`, `push`, `HEAD^` fallback, and an empty-tree fallback, then run `git diff --name-only` with those args. 
- Change `tests/unit/test_workflow_branch_filters.py` to require both `main` and `work` in the configured workflows and assert `master` is not present. 
- Add a regression assertion in `tests/test_workflows_yaml.py` that the CI guard contains the event-aware comparison logic strings (checks for `EVENT_NAME`, `BEFORE_SHA`, `push`/`pull_request` conditions, and the `comparison_args` forms). 
- Preserve scope constraints and avoid touching protected lexer/parser logic. 

### Testing

- Ran `pytest -q tests/test_workflows_yaml.py tests/unit/test_workflow_branch_filters.py`, which succeeded (24 passed, 1 warning). 
- Ran `python scripts/ci/validate_workflow_target_matrix.py`, which reported allowed targets OK. 
- Ran `git diff --check`, which reported no issues, and verified that protected Lexer/Parser files were unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d4b6b89448327b77c0766a71a62f9)