### PR TITLE
test: reejecutar módulo canónico al reimportar alias legacy

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from importlib import import_module
+from importlib import import_module, reload
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -21,12 +21,22 @@ from typing import Any
 class _CanonicalAliasLoader(Loader):
     """Carga un nombre histórico reutilizando el módulo canónico."""
 
-    def __init__(self, canonical_name: str) -> None:
+    def __init__(self, legacy_name: str, canonical_name: str) -> None:
+        self.legacy_name = legacy_name
         self.canonical_name = canonical_name
         self._metadata: tuple[object, object, object] | None = None
 
     def create_module(self, spec: ModuleSpec) -> ModuleType:  # noqa: ARG002
+        should_reload = (
+            self.legacy_name in _CanonicalAliasFinder._loaded_aliases
+            and self.canonical_name in sys.modules
+        )
         module = import_module(self.canonical_name)
+        if should_reload:
+            # Si sólo se eliminó el nombre legacy, su siguiente importación
+            # debe conservar la identidad del módulo y repetir a la vez la
+            # inicialización que antes provocaba esa eliminación.
+            reload(module)
         self._metadata = (module.__spec__, module.__loader__, module.__package__)
         return module
 
@@ -36,12 +46,14 @@ class _CanonicalAliasLoader(Loader):
         # canónica para introspección e importaciones relativas posteriores.
         if self._metadata is not None:
             module.__spec__, module.__loader__, module.__package__ = self._metadata
+        _CanonicalAliasFinder._loaded_aliases.add(self.legacy_name)
 
 
 class _CanonicalAliasFinder(MetaPathFinder):
     """Redirige submódulos legacy antes de que ``PathFinder`` los duplique."""
 
     _prefixes = {"cobra.": "pcobra.cobra.", "core.": "pcobra.core."}
+    _loaded_aliases: set[str] = set()
 
     def find_spec(
         self,
@@ -54,7 +66,7 @@ class _CanonicalAliasFinder(MetaPathFinder):
                 canonical_name = canonical_prefix + fullname[len(legacy_prefix) :]
                 return ModuleSpec(
                     fullname,
-                    _CanonicalAliasLoader(canonical_name),
+                    _CanonicalAliasLoader(fullname, canonical_name),
                     is_package=False,
                 )
         return None

--- a/tests/unit/test_pytest_global_config.py
+++ b/tests/unit/test_pytest_global_config.py
@@ -65,3 +65,34 @@ def test_configuracion_global_preserva_identidad_de_submodulos_legacy() -> None:
         probe.unlink(missing_ok=True)
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_configuracion_global_reinicializa_alias_legacy_eliminado() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = repo_root / "test_pytest_alias_reload_probe.py"
+    probe.write_text(
+        "import importlib\n"
+        "import sys\n\n"
+        "def test_alias_eliminado_reejecuta_modulo_canonico():\n"
+        "    legacy = importlib.import_module('cobra.cli.plugin')\n"
+        "    previous_class = legacy.PluginCommand\n"
+        "    sys.modules.pop('cobra.cli.plugin')\n"
+        "    reloaded = importlib.import_module('cobra.cli.plugin')\n"
+        "    assert reloaded is legacy\n"
+        "    assert reloaded is sys.modules['pcobra.cobra.cli.plugin']\n"
+        "    assert reloaded.PluginCommand is not previous_class\n",
+        encoding="utf-8",
+    )
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", str(probe)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        probe.unlink(missing_ok=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- Corregir un fallo donde reimportar un nombre legacy (por ejemplo `core.ast_cache`) devolvía el objeto ya cacheado bajo `pcobra.*` sin volver a ejecutar el cuerpo del módulo, lo que rompía la re-inicialización (p. ej. apertura de la DB) y provocaba fallos en las pruebas.

### Description
- El `Loader` de alias acepta ahora el nombre legacy y el canónico y detecta cuando un alias legacy ya había sido cargado antes para forzar un `reload()` del módulo canónico al reimportarlo. 
- Se añadió un registro `_loaded_aliases` en el `MetaPathFinder` y se pasa el nombre legacy al `Loader` para mantener sincronizadas la expulsión del alias y la posible reejecución del módulo canónico. 
- Se preserva la identidad del objeto de módulo al reusar la instancia canónica y se restauran los metadatos (`__spec__`, `__loader__`, `__package__`) para compatibilidad con importaciones relativas. 
- Se añadió un test subprocessal de regresión que comprueba que borrar y reimportar el alias legacy reejecuta el módulo canónico, preserva la identidad de módulo y hace que las clases definidas en el módulo se re-creeen. 

### Testing
- `python -m pytest tests/unit/test_pytest_global_config.py tests/unit/test_legacy_import_shims_contract.py tests/unit/test_descubrir_plugins_invalid.py tests/unit/test_ast_contract.py tests/unit/test_ast_cache.py tests/unit/test_token_cache.py tests/unit/test_ast_cache_security.py -q` — 28 passed, 2 warnings. 
- `python -m ruff check conftest.py tests/unit/test_pytest_global_config.py` — pasó sin errores. 
- Verificada que `src/pcobra/cobra/lexer.py` y `src/pcobra/cobra/parser.py` no fueron modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d4e0e46348327b7619b12a337ac9c)