### PR TITLE
Harden CI protected-file guard for push rewrites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             comparison_args=("origin/${BASE_REF}...HEAD")
           elif [[ "$EVENT_NAME" == "push" ]] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
-            comparison_args=("${BEFORE_SHA}...HEAD")
+            comparison_args=("${BEFORE_SHA}" HEAD)
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            echo "❌ No se puede resolver el commit previo del push; se bloquea por seguridad." >&2
+            exit 1
           elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
             comparison_args=("HEAD^...HEAD")
           else

--- a/tests/test_workflows_yaml.py
+++ b/tests/test_workflows_yaml.py
@@ -79,5 +79,7 @@ def test_ci_protected_file_guard_uses_event_appropriate_comparison() -> None:
     assert 'BEFORE_SHA: ${{ github.event.before }}' in content
     assert '[[ "$EVENT_NAME" == "pull_request" ]]' in content
     assert '[[ "$EVENT_NAME" == "push" ]]' in content
-    assert 'comparison_args=("${BEFORE_SHA}...HEAD")' in content
+    assert 'comparison_args=("${BEFORE_SHA}" HEAD)' in content
+    assert 'elif [[ "$EVENT_NAME" == "push" ]]; then' in content
+    assert "se bloquea por seguridad" in content
     assert 'comparison_args=("HEAD^...HEAD")' in content


### PR DESCRIPTION
### Motivation

- Prevent incorrect `git diff` semantics on non-fast-forward `push` events where `...` compares to a merge base instead of the prior tip.  
- Prevent unresolved/created-branch pushes from being reduced to only the tip commit, which could let earlier protected-file changes slip through.  

### Description

- Replace the merge-base-style range (`"${BEFORE_SHA}...HEAD"`) with a direct two-endpoint comparison (`"${BEFORE_SHA}" HEAD`) for resolved push events in `.github/workflows/ci.yml`.  
- When `BEFORE_SHA` cannot be resolved on a `push` (e.g. new branch creation), fail closed by exiting with an error and a diagnostic message instead of falling back to inspecting just `HEAD`.  
- Update `tests/test_workflows_yaml.py` to assert the new comparison form and the presence of the fail-closed `push` branch message.  
- Preserve scope constraints and did not modify any protected lexer/parser source files.  

### Testing

- Ran `pytest -q tests/test_workflows_yaml.py tests/unit/test_workflow_branch_filters.py` and observed `24 passed, 1 warning`.  
- Ran `python scripts/ci/validate_workflow_target_matrix.py` which reported allowed targets OK.  
- Ran `git diff --check` and verified the protected lexer/parser files are unchanged via `git diff --name-only` (no issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d60a89cac8327aacd2241e123b1dc)