### PR TITLE
docs(auditoria): reconciliar refs y certificar pre-merge (2026-08-25)

### DIFF
--- a/auditoria_contrato_extensiones_codigo.txt
+++ b/auditoria_contrato_extensiones_codigo.txt
@@ -1,0 +1,8002 @@
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/usar_loader.py
+========================================================================================
+
+import importlib
+import importlib.util
+import logging
+import os
+import re
+import shlex
+from pathlib import Path
+import subprocess
+import sys
+import tomllib as tomli
+from typing import Any
+
+from pcobra.cobra.imports import resolver as imports_resolver
+from pcobra.cobra.imports.resolver import ImportResolutionError
+from pcobra.cobra.usar_policy import (
+    CANONICAL_MODULE_SURFACE_CONTRACTS,
+    REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
+    USAR_BACKEND_BLOCKLIST,
+    USAR_COBRA_PUBLIC_MODULES,
+    USAR_RUNTIME_EXPORT_OVERRIDES,
+)
+from pcobra.core.usar_symbol_policy import (
+    build_and_validate_usar_symbol_metadata,
+    depuracion_saneamiento_usar_habilitada,
+    sanear_exportables_para_usar,
+)
+
+# Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.
+_VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_.]*$")
+
+
+# Segmentos seguros para módulos de proyecto: ruta lógica punteada, no ruta del sistema.
+_VALID_PROJECT_MODULE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROJECT_MODULE_FORBIDDEN_CHARS = frozenset('/\\@$%*?"\'<>|;`!()[]{}=+,')
+_USAR_PROJECT_MODULE_CACHE: dict[Path, dict[str, Any]] = {}
+_USAR_PROJECT_LOADING_STACK: list[Path] = []
+_IMPORT_CO_AST_CACHE: dict[Path, list[Any]] = {} # Nueva caché para ASTs de .co
+CobraImportResolver = imports_resolver.CobraImportResolver
+_DEFAULT_COBRA_IMPORT_RESOLVER = CobraImportResolver
+
+
+def _obtener_resolver_imports_parcheable():
+    """Devuelve el resolver respetando las dos superficies legacy de parcheo."""
+
+    if CobraImportResolver is not _DEFAULT_COBRA_IMPORT_RESOLVER:
+        return CobraImportResolver
+    return imports_resolver.CobraImportResolver
+
+# Compatibilidad con la API histórica de ``usar_loader``.  La política
+# canónica vive en ``usar_policy``, pero algunas integraciones y pruebas siguen
+# extendiendo esta lista blanca para módulos Python externos controlados.
+USAR_WHITELIST: dict[str, str] = {
+    "numpy": "numpy",
+    "agix": "agix",
+    **{modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES},
+}
+
+# Patrones que deben bloquearse explícitamente para evitar imports de backend o rutas internas.
+_INTERNAL_HINTS = (
+    "pcobra",
+    "cobra",
+    "core",
+    "corelibs",
+    "standard_library",
+    "backend",
+    "sdk",
+    "holobit_sdk",
+    "bindings",
+    "runtime",
+    "transpilers",
+    "transpiler",
+)
+
+_BACKEND_PREFIXES = (
+    "backend",
+    "pcobra",
+    "cobra",
+    "core",
+    "corelibs",
+    "runtime",
+)
+
+_BACKEND_EQUIVALENTS = {
+    "nodefetch",
+    "node_fetch",
+    "serde",
+    "holobitsdk",
+    "holobit_sdk",
+}
+
+
+class UsarExports(dict):
+    """Mapa de exports compatible con API directa y metadata estructurada."""
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict) and not {"simbolos", "metadata"} & set(other):
+            return {
+                nombre: self[nombre]
+                for nombre in self
+                if nombre not in {"simbolos", "metadata"}
+            } == other
+        return super().__eq__(other)
+
+
+class ModuloFueraCatalogoPublicoError(PermissionError):
+    """Rechazo inequívoco emitido por la política del catálogo de ``usar``."""
+
+
+def _construir_exports_usar(
+    simbolos: list[tuple[str, Any]],
+    metadata: dict[str, dict[str, Any]],
+) -> UsarExports:
+    exports = UsarExports({"simbolos": simbolos, "metadata": metadata})
+    exports.update(dict(simbolos))
+    return exports
+
+
+def normalizar_nombre_usar(nombre: str) -> str:
+    """Normaliza nombre de módulo para validaciones canónicas de `usar`."""
+
+    return (nombre or "").strip().lower().replace("-", "_")
+
+
+def _rechazar_modulo_no_canonico(nombre: str) -> None:
+    """Rechaza módulos backend/no-canónicos con error explícito para `usar`."""
+
+    nombre_normalizado = normalizar_nombre_usar(nombre)
+    blocklist_normalizada = {normalizar_nombre_usar(item) for item in USAR_BACKEND_BLOCKLIST}
+    equivalentes_normalizados = {normalizar_nombre_usar(item) for item in _BACKEND_EQUIVALENTS}
+
+    partes_mensaje_error_no_canonico = [
+        f"Importación no permitida en 'usar': '{nombre}'.",
+        "Es un módulo backend/no canónico y no forma parte de la API pública.",
+        "usar_error[modulo_fuera_catalogo_publico]: módulo fuera del catálogo público.",
+    ]
+    detalle_repl_estricto = (
+        "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)."
+    )
+    if detalle_repl_estricto:
+        partes_mensaje_error_no_canonico.append(detalle_repl_estricto)
+    if USAR_COBRA_PUBLIC_MODULES:
+        modulos_permitidos = ", ".join(USAR_COBRA_PUBLIC_MODULES)
+        partes_mensaje_error_no_canonico.append(
+            f"Módulos permitidos: {modulos_permitidos}."
+        )
+    mensaje_error_no_canonico = " ".join(partes_mensaje_error_no_canonico)
+
+    if nombre_normalizado in blocklist_normalizada or nombre_normalizado in equivalentes_normalizados:
+        raise ModuloFueraCatalogoPublicoError(mensaje_error_no_canonico)
+
+    if any(
+        nombre_normalizado == prefijo or nombre_normalizado.startswith(f"{prefijo}_")
+        for prefijo in _BACKEND_PREFIXES
+    ):
+        raise ModuloFueraCatalogoPublicoError(mensaje_error_no_canonico)
+
+def validar_nombre_modulo_usar(nombre: str, *, require_allowlist: bool = True) -> str:
+    """Valida nombre de `usar` y opcionalmente exige contrato canónico exacto."""
+
+    if not isinstance(nombre, str):
+        raise ValueError("Nombre de módulo inválido en 'usar': se esperaba string.")
+
+    nombre_raw = nombre.strip()
+    if not nombre_raw:
+        raise ValueError("Nombre de módulo vacío en 'usar'.")
+
+    if any(sep in nombre_raw for sep in ('/', '\\')) or '..' in nombre_raw:
+        raise ValueError(
+            f"Nombre de módulo inválido en 'usar': '{nombre_raw}' parece ruta/traversal."
+        )
+
+    _rechazar_modulo_no_canonico(nombre_raw)
+    nombre = normalizar_nombre_usar(nombre_raw)
+
+    if not _VALID_NAME_RE.fullmatch(nombre):
+        raise ValueError(
+            "Nombre de módulo inválido en 'usar': solo se permiten "
+            "identificadores simples en minúsculas (ej. usar 'texto')."
+        )
+
+    if any(ch in nombre for ch in ("/", "\\", ".", "-", ":", "@")):
+        raise ValueError(f"Nombre de módulo '{nombre}' no es seguro para 'usar'.")
+
+    for hint in _INTERNAL_HINTS:
+        if hint in nombre:
+            raise ValueError(
+                f"Nombre de módulo '{nombre}' parece una ruta interna o de backend; "
+                "usa únicamente módulos Cobra canónicos."
+            )
+
+    if require_allowlist and nombre not in USAR_COBRA_PUBLIC_MODULES:
+        raise ModuloFueraCatalogoPublicoError(
+            f"usar_error[modulo_fuera_catalogo_publico]: '{nombre}' está fuera del catálogo público."
+        )
+
+    return nombre
+
+
+
+def validar_nombre_modulo_cobra_proyecto(nombre: str) -> tuple[str, ...]:
+    """Valida una ruta lógica punteada de módulo Cobra de proyecto.
+
+    Esta validación es deliberadamente independiente de
+    :func:`validar_nombre_modulo_usar` para no relajar el contrato público de
+    módulos oficiales/corelibs.
+    """
+
+    if not isinstance(nombre, str):
+        raise ValueError("Nombre de módulo de proyecto inválido: se esperaba string.")
+
+    nombre_raw = nombre.strip()
+    if not nombre_raw:
+        raise ValueError("Nombre de módulo de proyecto vacío.")
+
+    # `usar` de proyecto acepta únicamente rutas lógicas punteadas, nunca rutas
+    # del sistema. Bloqueamos separadores POSIX/Windows, traversal, rutas
+    # absolutas y cualquier forma de unidad Windows antes de resolver.
+    if any(sep in nombre_raw for sep in ("/", "\\")):
+        raise ValueError(
+            f"Nombre de módulo de proyecto inválido: '{nombre_raw}' no debe contener separadores de ruta."
+        )
+    if ".." in nombre_raw:
+        raise ValueError(
+            f"Nombre de módulo de proyecto inválido: '{nombre_raw}' contiene traversal."
+        )
+    if os.path.isabs(nombre_raw) or re.match(r"^[A-Za-z]:", nombre_raw):
+        raise ValueError(
+            f"Nombre de módulo de proyecto inválido: '{nombre_raw}' parece una ruta absoluta o unidad Windows."
+        )
+
+    segmentos = nombre_raw.split(".")
+    for segmento in segmentos:
+        if segmento in {"", ".", ".."}:
+            raise ValueError(
+                f"Nombre de módulo de proyecto inválido: '{nombre_raw}' contiene segmentos vacíos/traversal."
+            )
+        if any(caracter in segmento for caracter in _PROJECT_MODULE_FORBIDDEN_CHARS):
+            raise ValueError(
+                f"Nombre de módulo de proyecto inválido: '{nombre_raw}' contiene caracteres no seguros."
+            )
+        if ":" in segmento:
+            raise ValueError(
+                f"Nombre de módulo de proyecto inválido: '{nombre_raw}' parece una unidad Windows."
+            )
+        if not _VALID_PROJECT_MODULE_SEGMENT_RE.fullmatch(segmento):
+            raise ValueError(
+                "Nombre de módulo de proyecto inválido: usa segmentos tipo identificador "
+                "separados por puntos (ej. 'utilidades.fechas')."
+            )
+
+    return tuple(segmentos)
+
+
+def _verificar_path_dentro_de_root(ruta: Path, root: Path) -> None:
+    """Verifica con rutas canónicas que ``ruta`` queda dentro de ``root``."""
+
+    root_canonico = canonicalizar_ruta_usar_proyecto(root)
+    ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta)
+    try:
+        common = os.path.commonpath((str(root_canonico), str(ruta_canonica)))
+    except ValueError as exc:
+        raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.") from exc
+
+    if common != str(root_canonico):
+        raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.")
+
+
+def resolver_modulo_cobra_proyecto(
+    nombre: str,
+    *,
+    project_root: Path,
+    current_file: Path | None = None,
+) -> Path:
+    """Resuelve un módulo Cobra de proyecto a un archivo ``.co`` seguro.
+
+    ``nombre`` es una ruta lógica punteada (por ejemplo
+    ``utilidades.fechas``), que se transforma en
+    ``project_root / "utilidades" / "fechas.co"``. La función sólo devuelve
+    una ruta canónica; no carga ni importa el módulo para evitar introducir un
+    segundo sistema de imports.
+    """
+
+    validar_nombre_modulo_cobra_proyecto(nombre)
+    root_resuelto = canonicalizar_ruta_usar_proyecto(project_root)
+
+    if current_file is not None:
+        current_resuelto = canonicalizar_ruta_usar_proyecto(current_file)
+        _verificar_path_dentro_de_root(current_resuelto, root_resuelto)
+
+    ruta_directa = root_resuelto.joinpath(
+        *validar_nombre_modulo_cobra_proyecto(nombre)
+    ).with_suffix(".co")
+    if ruta_directa.exists():
+        ruta_directa = canonicalizar_ruta_usar_proyecto(ruta_directa)
+        _verificar_path_dentro_de_root(ruta_directa, root_resuelto)
+        return ruta_directa
+
+    # Compatibilidad legacy: el resolver histórico sólo puede actuar como
+    # fallback cuando haya sido sustituido explícitamente por un caller/test.
+    # La ruta principal y estable para `usar utilidades.fechas` es siempre:
+    # `project_root / "utilidades" / "fechas.co"`.
+    resolver_cls = _obtener_resolver_imports_parcheable()
+    if getattr(resolver_cls, "__module__", "") == "pcobra.cobra.imports.resolver":
+        raise FileNotFoundError(f"Módulo no encontrado: {nombre}")
+
+    try:
+        resolution = resolver_cls(
+            project_root=root_resuelto,
+            collision_policy="warn",
+        ).resolve(nombre)
+    except ImportResolutionError as exc:
+        if exc.code == "IMP-PROJECT-PATH-001":
+            raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.") from exc
+        raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
+
+    if resolution.source != "project" or not resolution.file_path:
+        raise FileNotFoundError(f"Módulo no encontrado: {nombre}")
+
+    ruta_resuelta = canonicalizar_ruta_usar_proyecto(resolution.file_path)
+    _verificar_path_dentro_de_root(ruta_resuelta, root_resuelto)
+
+    return ruta_resuelta
+
+
+def canonicalizar_ruta_usar_proyecto(ruta: str | Path) -> Path:
+    """Devuelve la clave canónica de caché para módulos Cobra de proyecto."""
+
+    return Path(ruta).expanduser().resolve(strict=False)
+
+
+def resolver_ruta_canonica_modulo_cobra_proyecto(
+    nombre: str,
+    *,
+    project_root: Path,
+    current_file: Path | None = None,
+) -> Path:
+    """Resuelve un módulo de proyecto y normaliza su ruta como clave de caché."""
+
+    return canonicalizar_ruta_usar_proyecto(
+        resolver_modulo_cobra_proyecto(
+            nombre,
+            project_root=project_root,
+            current_file=current_file,
+        )
+    )
+
+
+def obtener_cache_modulos_cobra_proyecto() -> dict[Path, dict[str, Any]]:
+    """Expone la caché compartida de módulos de proyecto para el intérprete."""
+
+    return _USAR_PROJECT_MODULE_CACHE
+
+
+def obtener_pila_carga_modulos_cobra_proyecto() -> list[Path]:
+    """Expone la pila compartida de carga para detectar ciclos entre entrypoints."""
+
+    return _USAR_PROJECT_LOADING_STACK
+
+
+def obtener_cache_ast_import_co() -> dict[Path, list[Any]]:
+    """Expone la caché compartida de ASTs de módulos .co para el transpilador."""
+    return _IMPORT_CO_AST_CACHE
+
+
+def _formatear_ruta_ciclo_modulo(ruta: Path, project_root: Path | None) -> str:
+    """Formatea una ruta de ciclo de forma estable y legible."""
+
+    try:
+        ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta)
+    except (OSError, RuntimeError, ValueError):
+        return ruta.name or str(ruta)
+
+    if project_root is not None:
+        try:
+            raiz_canonica = canonicalizar_ruta_usar_proyecto(project_root)
+            return ruta_canonica.relative_to(raiz_canonica).as_posix()
+        except (OSError, RuntimeError, ValueError):
+            pass
+
+    return str(ruta_canonica) if str(ruta_canonica) else (ruta.name or str(ruta))
+
+
+def formatear_ciclo_modulos_cobra_proyecto(
+    ruta_modulo: Path,
+    *,
+    project_root: Path | None = None,
+    loading_stack: list[Path] | None = None,
+) -> str:
+    """Construye una cadena clara del ciclo usando rutas relativas si es posible."""
+
+    ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta_modulo)
+    pila_origen = loading_stack if loading_stack is not None else _USAR_PROJECT_LOADING_STACK
+    pila: list[Path] = []
+    for ruta in pila_origen:
+        ruta_pila = canonicalizar_ruta_usar_proyecto(ruta)
+        if not pila or pila[-1] != ruta_pila:
+            pila.append(ruta_pila)
+
+    ciclo = [*pila, ruta_canonica]
+    try:
+        inicio = ciclo.index(ruta_canonica)
+    except ValueError:
+        inicio = max(0, len(ciclo) - 1)
+    ciclo_detectado = ciclo[inicio:]
+    if len(ciclo_detectado) > 50:
+        ciclo_detectado = [*ciclo_detectado[:49], ruta_canonica]
+    return " -> ".join(
+        _formatear_ruta_ciclo_modulo(ruta, project_root) for ruta in ciclo_detectado
+    )
+
+
+def _ascender_hasta_cobra_toml(candidato: Path | None) -> Path | None:
+    """Busca ``cobra.toml`` ascendiendo desde un archivo o directorio."""
+
+    if candidato is None:
+        return None
+    ruta = Path(candidato).expanduser().resolve(strict=False)
+    if ruta.suffix or (ruta.exists() and ruta.is_file()):
+        ruta = ruta.parent
+    for directorio in (ruta, *ruta.parents):
+        if (directorio / "cobra.toml").is_file():
+            return directorio.resolve(strict=False)
+    return None
+
+
+def descubrir_raiz_proyecto(start: Path | None, main_file: Path | None = None) -> Path:
+    """Descubre y canonicaliza la raíz efectiva de un proyecto Cobra.
+
+    Prioridad:
+    1. Directorio que contiene un ``cobra.toml`` encontrado ascendiendo desde
+       ``start`` o desde ``main_file``.
+    2. Directorio canonicalizado de ``main_file`` cuando no hay ``cobra.toml``.
+    3. ``Path.cwd().resolve()`` para preservar el comportamiento legacy.
+    """
+
+    for candidato in (start, main_file):
+        raiz_configurada = _ascender_hasta_cobra_toml(candidato)
+        if raiz_configurada is not None:
+            return raiz_configurada
+
+    if main_file is not None:
+        principal = Path(main_file).expanduser().resolve(strict=False)
+        directorio = principal.parent if principal.suffix or principal.is_file() else principal
+        return directorio.resolve(strict=False)
+
+    return Path.cwd().resolve()
+
+
+def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
+    """Carga un módulo Python desde un directorio local dado."""
+
+    mod_path = directorio / f"{nombre}.py"
+    pkg_path = directorio / nombre / "__init__.py"
+    if not (mod_path.exists() or pkg_path.exists()):
+        return None
+
+    ruta = mod_path if mod_path.exists() else pkg_path
+    mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
+    if mod_spec is None or mod_spec.loader is None:
+        raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
+    modulo = importlib.util.module_from_spec(mod_spec)
+    sys.modules[nombre] = modulo
+    mod_spec.loader.exec_module(modulo)
+    return modulo
+
+
+def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
+    """Carga un módulo Python desde una ruta absoluta explícita."""
+
+    modulo_existente = sys.modules.get(nombre)
+    if modulo_existente is not None:
+        modulo_file = getattr(modulo_existente, "__file__", None)
+        if modulo_file and Path(modulo_file).resolve() == ruta:
+            return modulo_existente
+
+    mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
+    if mod_spec is None or mod_spec.loader is None:
+        raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
+    modulo = importlib.util.module_from_spec(mod_spec)
+    sys.modules[nombre] = modulo
+    mod_spec.loader.exec_module(modulo)
+    return modulo
+
+
+def obtener_modulo_cobra_oficial(nombre: str):
+    """Carga módulos oficiales de Cobra desde la ruta interna canónica declarada."""
+
+    nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
+    rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP.get(nombre)
+    if not rel_path:
+        raise ModuleNotFoundError(
+            f"Módulo oficial Cobra '{nombre}' permitido pero sin ruta interna canónica declarada."
+        )
+
+    repo_root = Path(__file__).resolve().parents[3]
+    ruta_modulo = (repo_root / rel_path).resolve()
+    if not ruta_modulo.exists():
+        raise ModuleNotFoundError(
+            "Módulo oficial Cobra permitido no resoluble en runtime: "
+            f"alias='{nombre}' ruta='{rel_path}'."
+        )
+
+    if rel_path.startswith("src/pcobra/corelibs/"):
+        nombre_import = f"pcobra.corelibs.{ruta_modulo.stem}"
+    elif rel_path.startswith("src/pcobra/standard_library/"):
+        nombre_import = f"pcobra.standard_library.{ruta_modulo.stem}"
+    else:
+        nombre_import = ""
+
+    if nombre_import:
+        modulo = importlib.import_module(nombre_import)
+        modulo_file = getattr(modulo, "__file__", None)
+        if modulo_file and Path(modulo_file).resolve() == ruta_modulo:
+            for export_name in getattr(modulo, "__all__", ()):  # Cobra-facing: alias público.
+                export = getattr(modulo, export_name, None)
+                if callable(export) and hasattr(export, "__module__"):
+                    try:
+                        export.__module__ = nombre
+                    except (AttributeError, TypeError):
+                        pass
+            return modulo
+
+    return _cargar_modulo_local_desde_ruta(nombre, ruta_modulo)
+
+
+def _obtener_modulo_cobra_oficial_compat(nombre: str):
+    """Obtiene un módulo oficial respetando wrappers legacy parcheados."""
+
+    nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
+    if nombre not in REPL_COBRA_MODULE_INTERNAL_PATH_MAP:
+        raise ModuleNotFoundError(
+            f"Módulo oficial Cobra '{nombre}' permitido pero sin ruta interna canónica declarada."
+        )
+
+    wrapper = sys.modules.get("pcobra.core.usar_loader") or sys.modules.get("core.usar_loader")
+    wrapper_oficial = getattr(wrapper, "obtener_modulo_cobra_oficial", None)
+    if (
+        wrapper_oficial is not None
+        and getattr(wrapper_oficial, "__module__", "") != "pcobra.core.usar_loader"
+    ):
+        return wrapper_oficial(nombre)
+
+    modulo = obtener_modulo_cobra_oficial(nombre)
+
+    rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP.get(nombre)
+    if rel_path:
+        ruta_oficial = (Path(__file__).resolve().parents[3] / rel_path).resolve()
+        modulo_file = getattr(modulo, "__file__", None)
+        if not modulo_file or Path(modulo_file).resolve() != ruta_oficial:
+            raise PermissionError(
+                "usar_error[modulo_no_permitido]: módulo externo no permitido en REPL estricto "
+                "(solo alias oficiales Cobra)"
+            )
+    return modulo
+
+
+def cargar_modulo_oficial_para_usar(nombre: str):
+    """Punto de sustitución del cargador oficial usado por ``usar``.
+
+    Las pruebas pueden sustituir esta función con un cargador controlado sin
+    ampliar el catálogo público ni habilitar imports Python arbitrarios. La
+    autorización del alias ocurre antes de invocarla y sus resultados siempre
+    pasan por el saneamiento común de exports.
+    """
+
+    return _obtener_modulo_cobra_oficial_compat(nombre)
+
+
+def _repo_root_desde_loader() -> Path:
+    """Busca la raíz del proyecto/instalación partiendo de este archivo."""
+
+    for candidato in Path(__file__).resolve().parents:
+        if (candidato / "cobra.toml").exists() or (candidato / "pyproject.toml").exists():
+            return candidato
+    return Path(__file__).resolve().parents[3]
+
+
+def cargar_lista_blanca() -> dict[str, str]:
+    """Carga paquetes permitidos legacy desde ``cobra.toml`` si existe.
+
+    Mantiene los valores hardcoded históricos cuando no hay configuración de
+    proyecto, y añade entradas declaradas como ``[usar].permitidos`` cuando la
+    raíz contiene ``cobra.toml``.
+    """
+
+    USAR_WHITELIST.clear()
+    USAR_WHITELIST.update(
+        {
+            "numpy": "numpy",
+            "agix": "agix",
+            **{modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES},
+        }
+    )
+
+    config = _repo_root_desde_loader() / "cobra.toml"
+    if not config.exists():
+        return USAR_WHITELIST
+
+    datos = tomli.loads(config.read_text(encoding="utf-8"))
+    permitidos = datos.get("usar", {}).get("permitidos", [])
+    for spec in permitidos:
+        if not isinstance(spec, str) or not spec.strip():
+            continue
+        spec_limpio = spec.strip()
+        nombre = re.split(r"[<>=!~\s]", spec_limpio, maxsplit=1)[0]
+        if nombre:
+            USAR_WHITELIST[nombre] = spec_limpio
+    return USAR_WHITELIST
+
+
+def _argumentos_pip_desde_spec(spec: str) -> list[str]:
+    """Convierte una spec permitida en argumentos para ``pip install``."""
+
+    if os.environ.get("COBRA_USAR_INSTALL_UNSAFE_SPECS") == "1":
+        return shlex.split(spec)
+    if re.search(r"\s", spec):
+        raise RuntimeError(
+            "Spec de instalación no segura en 'usar'; habilita "
+            "COBRA_USAR_INSTALL_UNSAFE_SPECS=1 para flags explícitos."
+        )
+    return [spec]
+
+
+def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
+    """Resuelve módulos de `usar` contra Cobra canónico o allowlist legacy."""
+
+    nombre = validar_nombre_modulo_usar(nombre, require_allowlist=False)
+    if nombre in USAR_COBRA_PUBLIC_MODULES:
+        try:
+            return cargar_modulo_oficial_para_usar(nombre)
+        except ModuleNotFoundError as oficial_exc:
+            raise ImportError(
+                f"No se pudo resolver el módulo Cobra permitido '{nombre}' en runtime."
+            ) from oficial_exc
+
+    if nombre not in USAR_WHITELIST:
+        raise PermissionError(f"Paquete no permitido en 'usar': '{nombre}'.")
+
+    resolver_cls = _obtener_resolver_imports_parcheable()
+    resolver_parcheado = getattr(resolver_cls, "__module__", "") != "pcobra.cobra.imports.resolver"
+    if nombre not in USAR_COBRA_PUBLIC_MODULES and resolver_parcheado:
+        _resolution, modulo = resolver_cls().load_module(nombre, fallback_backend="python")
+        return modulo
+
+    try:
+        return importlib.import_module(nombre)
+    except ModuleNotFoundError as import_exc:
+        try:
+            _resolution, modulo = resolver_cls().load_module(nombre, fallback_backend="python")
+            return modulo
+        except Exception:
+            if not permitir_instalacion or os.environ.get("COBRA_USAR_INSTALL") != "1":
+                raise RuntimeError(
+                    f"Módulo '{nombre}' no instalado y la instalación automática está deshabilitada."
+                ) from import_exc
+
+            spec = USAR_WHITELIST[nombre]
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", *_argumentos_pip_desde_spec(spec)],
+                check=True,
+            )
+            return importlib.import_module(nombre)
+
+
+def _extraer_exports_modulo_cobra_proyecto(
+    ast: list[object],
+    entorno_modulo: object,
+    *,
+    ruta_modulo: Path,
+) -> dict[str, Any]:
+    """Extrae exports saneados de un módulo ``.co`` ya ejecutado."""
+
+    from pcobra.core.ast_nodes import NodoExport
+
+    valores_entorno = getattr(entorno_modulo, "values", {})
+    nombres_exportados = [
+        nodo.nombre for nodo in ast if isinstance(nodo, NodoExport)
+    ] or [nombre for nombre in valores_entorno if not nombre.startswith("_")]
+
+    simbolos_saneados: list[tuple[str, object]] = []
+    metadata_por_simbolo: dict[str, dict[str, object]] = {}
+    modulo_canonico = str(ruta_modulo.resolve(strict=False))
+    for nombre in nombres_exportados:
+        if nombre not in valores_entorno:
+            continue
+        simbolo = valores_entorno[nombre]
+        simbolos_saneados.append((nombre, simbolo))
+        metadata_por_simbolo[nombre] = build_and_validate_usar_symbol_metadata(
+            module_name=modulo_canonico,
+            symbol_name=nombre,
+            callable_obj=simbolo,
+        )
+
+    return {
+        "simbolos": simbolos_saneados,
+        "metadata": metadata_por_simbolo,
+    }
+
+
+def _cargar_exports_modulo_cobra_proyecto(
+    nombre: str,
+    *,
+    project_root: Path,
+    current_file: Path | None = None,
+    module_cache: dict[Path, dict[str, Any]] | None = None,
+    loading_stack: list[Path] | None = None,
+) -> dict[str, Any]:
+    """Carga un módulo Cobra de proyecto usando resolución canónica y cache."""
+
+    from pcobra.core.environment import Environment
+    from pcobra.core import import_utils
+    from pcobra.core.interpreter import InterpretadorCobra
+    from pcobra.core.ast_nodes import NodoExport, NodoUsar
+
+    root_canonico = canonicalizar_ruta_usar_proyecto(project_root)
+    cache = module_cache if module_cache is not None else _USAR_PROJECT_MODULE_CACHE
+    pila_carga = loading_stack if loading_stack is not None else _USAR_PROJECT_LOADING_STACK
+    current_canonico = (
+        canonicalizar_ruta_usar_proyecto(current_file) if current_file else None
+    )
+    if current_canonico is not None:
+        _verificar_path_dentro_de_root(current_canonico, root_canonico)
+
+    ruta_modulo = resolver_ruta_canonica_modulo_cobra_proyecto(
+        nombre,
+        project_root=root_canonico,
+        current_file=current_canonico,
+    )
+    _verificar_path_dentro_de_root(ruta_modulo, root_canonico)
+
+    if ruta_modulo in cache:
+        return cache[ruta_modulo]
+
+    if ruta_modulo in pila_carga:
+        cadena = formatear_ciclo_modulos_cobra_proyecto(
+            ruta_modulo, project_root=root_canonico, loading_stack=pila_carga
+        )
+        raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
+
+    pila_carga.append(ruta_modulo)
+    interpretador = None
+    try:
+        try:
+            ast = import_utils.cargar_ast_modulo(
+                str(ruta_modulo),
+                modules_path=str(root_canonico),
+                whitelist={root_canonico},
+            )
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
+
+        interpretador = InterpretadorCobra(
+            safe_mode=False, main_file=current_canonico or ruta_modulo
+        )
+        interpretador._project_root = root_canonico
+        interpretador._main_file = (
+            current_canonico if current_canonico else ruta_modulo
+        )
+        interpretador._usar_module_cache = cache
+        interpretador._usar_loading_stack = pila_carga
+        interpretador._current_module_stack.append(ruta_modulo)
+        interpretador.contextos.append(Environment(parent=interpretador.contextos[-1]))
+        interpretador.mem_contextos.append({})
+        for subnodo in ast:
+            if isinstance(subnodo, NodoExport):
+                continue
+            if isinstance(subnodo, NodoUsar) or subnodo.__class__.__name__ == "NodoUsar":
+                modulo_hijo = str(subnodo.modulo).strip().strip('\"\'')
+                ruta_hijo = resolver_ruta_canonica_modulo_cobra_proyecto(
+                    modulo_hijo,
+                    project_root=root_canonico,
+                    current_file=ruta_modulo,
+                )
+                _verificar_path_dentro_de_root(ruta_hijo, root_canonico)
+                if ruta_hijo in pila_carga:
+                    cadena = formatear_ciclo_modulos_cobra_proyecto(
+                        ruta_hijo, project_root=root_canonico, loading_stack=pila_carga
+                    )
+                    raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
+            interpretador.ejecutar_nodo(subnodo)
+        exports = _extraer_exports_modulo_cobra_proyecto(
+            ast,
+            interpretador.contextos[-1],
+            ruta_modulo=ruta_modulo,
+        )
+        cache[ruta_modulo] = _construir_exports_usar(
+            list(exports["simbolos"]),
+            {
+                nombre: dict(metadata)
+                for nombre, metadata in exports["metadata"].items()
+            },
+        )
+        return cache[ruta_modulo]
+    finally:
+        if interpretador is not None:
+            memoria_local = interpretador.mem_contextos.pop()
+            for idx, tam in memoria_local.values():
+                interpretador.liberar_memoria(idx, tam)
+            interpretador.contextos.pop()
+            interpretador._current_module_stack.pop()
+        if pila_carga and pila_carga[-1] == ruta_modulo:
+            pila_carga.pop()
+        elif ruta_modulo in pila_carga:
+            pila_carga.remove(ruta_modulo)
+
+
+def usar_modulo(
+    nombre: str,
+    *,
+    project_root: str | Path | None = None,
+    current_file: str | Path | None = None,
+    module_cache: dict[Path, dict[str, Any]] | None = None,
+    loading_stack: list[Path] | None = None,
+    permitir_modulos_proyecto: bool | None = None,
+    contexto_proyecto_verificado: bool | None = None,
+) -> dict[str, Any]:
+    """API única para resolver ``usar`` en runtime y transpilación Python.
+
+    - Los módulos oficiales preservan ``obtener_modulo`` y devuelven sus
+      símbolos públicos saneados.
+    - Los módulos Cobra de proyecto (``foo.bar`` -> ``foo/bar.co``) usan la
+      misma resolución canónica por ruta y una cache global por archivo.
+    """
+
+    nombre_raw = nombre.strip()
+    if not nombre_raw:
+        raise ValueError("Nombre de módulo vacío en 'usar'.")
+
+    # La señal nueva distingue un contexto derivado de un ``main_file``
+    # canonicalizado del mero hecho de recibir rutas. El parámetro histórico se
+    # conserva para callers externos, pero no interviene cuando la señal
+    # verificable está presente.
+    contexto_proyecto_autorizado = (
+        contexto_proyecto_verificado
+        if contexto_proyecto_verificado is not None
+        else (
+            permitir_modulos_proyecto
+            if permitir_modulos_proyecto is not None
+            else project_root is not None or current_file is not None
+        )
+    )
+
+    # Caso 1: alias oficial presente en la superficie pública Cobra.
+    try:
+        nombre_validado_oficial = validar_nombre_modulo_usar(nombre_raw, require_allowlist=True)
+        modulo = obtener_modulo(nombre_validado_oficial)
+        simbolos_saneados, metadata_por_simbolo, conflictos = _sanitizar_exports_publicos_detallado(
+            modulo,
+            normalizar_nombre_usar(nombre_validado_oficial),
+        )
+        if conflictos:
+            logging.debug(
+                "USAR sanitize conflicts en API única module=%s conflicts=%s",
+                nombre_validado_oficial,
+                conflictos,
+            )
+        if not simbolos_saneados:
+            raise ImportError(f"No se encontraron símbolos exportables para usar '{nombre_validado_oficial}'.")
+        return _construir_exports_usar(simbolos_saneados, metadata_por_simbolo)
+    except ModuloFueraCatalogoPublicoError as permiso_exc:
+        # Caso 3: un nombre externo/no canónico no puede convertirse
+        # implícitamente en módulo de proyecto desde el REPL estricto. Se
+        # conserva íntegro el PermissionError contractual de la allowlist.
+        if not str(permiso_exc).startswith("usar_error[modulo_fuera_catalogo_publico]"):
+            raise permiso_exc
+        if not contexto_proyecto_autorizado:
+            raise permiso_exc
+
+        # Caso 2: sólo un contexto de proyecto autorizado puede continuar al
+        # resolvedor Cobra de proyecto (incluida la compatibilidad legacy).
+        wrapper = sys.modules.get("pcobra.core.usar_loader") or sys.modules.get("core.usar_loader")
+        wrapper_obtener = getattr(wrapper, "obtener_modulo", None)
+        wrapper_obtener_oficial = getattr(wrapper, "obtener_modulo_cobra_oficial", None)
+        wrapper_legacy = (
+            wrapper_obtener is not None
+            and getattr(wrapper_obtener, "__module__", "") != "pcobra.core.usar_loader"
+        )
+        wrapper_oficial_legacy = (
+            wrapper_obtener_oficial is not None
+            and getattr(wrapper_obtener_oficial, "__module__", "")
+            != "pcobra.core.usar_loader"
+        )
+        if not (
+            wrapper_legacy or wrapper_oficial_legacy
+        ):
+            try:
+                validar_nombre_modulo_cobra_proyecto(nombre_raw)
+            except ValueError:
+                raise permiso_exc
+        else:
+            try:
+                if wrapper_oficial_legacy:
+                    modulo = wrapper_obtener_oficial(nombre_raw)
+                else:
+                    modulo = wrapper_obtener(nombre_raw)
+                simbolos_saneados, metadata_por_simbolo, conflictos = _sanitizar_exports_publicos_detallado(
+                    modulo,
+                    normalizar_nombre_usar(nombre_raw),
+                )
+                if conflictos:
+                    logging.debug(
+                        "USAR sanitize conflicts en API única legacy module=%s conflicts=%s",
+                        nombre_raw,
+                        conflictos,
+                    )
+                if not simbolos_saneados:
+                    raise ImportError(f"No se encontraron símbolos exportables para usar '{nombre_raw}'.")
+                return _construir_exports_usar(simbolos_saneados, metadata_por_simbolo)
+            except ModuleNotFoundError:
+                raise permiso_exc
+    except (ModuleNotFoundError, ValueError):
+        # Si no es un módulo oficial o no está permitido, intentar como módulo de proyecto
+        # Si es un ValueError, significa que el nombre no es válido para un módulo oficial,
+        # pero podría serlo para un módulo de proyecto (ej. contiene puntos).
+        pass
+
+    # Caso 2: resolver como módulo Cobra de proyecto únicamente después de
+    # comprobar que el caller aportó/autorizó ese contexto.
+    if not contexto_proyecto_autorizado:
+        validar_nombre_modulo_usar(nombre_raw, require_allowlist=True)
+
+    try:
+        segmentos_proyecto = validar_nombre_modulo_cobra_proyecto(nombre_raw)
+        nombre_validado_proyecto = ".".join(segmentos_proyecto)
+
+        current = (
+            Path(current_file).expanduser() if current_file is not None else None
+        )
+        root = (
+            canonicalizar_ruta_usar_proyecto(project_root)
+            if project_root is not None
+            else descubrir_raiz_proyecto(current, current)
+        )
+        try:
+            exports = _cargar_exports_modulo_cobra_proyecto(
+                nombre_validado_proyecto,
+                project_root=root,
+                current_file=current,
+                module_cache=module_cache,
+                loading_stack=loading_stack,
+            )
+            return exports
+        except ValueError:
+            raise
+        except FileNotFoundError as exc:
+            ruta_buscada = root.joinpath(
+                *nombre_validado_proyecto.split(".")
+            ).with_suffix(".co")
+            raise FileNotFoundError(
+                f"Módulo no encontrado: {nombre_validado_proyecto}. "
+                f"Módulo de proyecto no encontrado: {nombre_validado_proyecto}. "
+                f"Ruta buscada: {ruta_buscada}"
+            ) from exc
+    except ValueError as e:
+        # Si tampoco es un módulo de proyecto válido, entonces el nombre es inválido.
+        raise ValueError(f"Nombre de módulo inválido en 'usar': '{nombre_raw}'.") from e
+    except FileNotFoundError as e:
+        raise e
+
+
+def _registrar_conflicto_saneamiento_usar(
+    conflictos: list[dict[str, Any]],
+    conflicto: dict[str, Any],
+    *,
+    depuracion_habilitada: bool,
+) -> None:
+    """Registra un conflicto de saneamiento y emite trazas útiles cuando aplica."""
+
+    conflictos.append(conflicto)
+    debe_trazar = depuracion_habilitada or (
+        conflicto.get("module") == "datos" and conflicto.get("symbol") == "filtrar"
+    )
+    if debe_trazar:
+        logging.debug(
+            "USAR_SANITIZE_DEBUG %s",
+            {
+                "module": conflicto.get("module"),
+                "symbol": conflicto.get("symbol"),
+                "reason": conflicto.get("code"),
+                "message": conflicto.get("message"),
+            },
+        )
+
+
+def _sanitizar_exports_publicos_detallado(modulo: object, alias_modulo: str) -> tuple[list[tuple[str, Any]], dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    """Filtra exports públicos válidos para ``usar`` y reporta conflictos/rechazos.
+
+    Devuelve un mapa limpio ``nombre -> símbolo`` y una lista estructurada de
+    conflictos para que el caller pueda advertir y evitar sobreescrituras
+    silenciosas.
+    """
+
+    contrato = CANONICAL_MODULE_SURFACE_CONTRACTS.get(alias_modulo)
+    api_publica_modulo = set(USAR_RUNTIME_EXPORT_OVERRIDES.get(alias_modulo, ()))
+    if contrato is not None:
+        api_publica_modulo.update(contrato.required_functions)
+        api_publica_modulo.update(contrato.allowed_aliases)
+
+    exportables = getattr(modulo, "__all__", None)
+    if exportables is None:
+        candidatos = list(USAR_RUNTIME_EXPORT_OVERRIDES.get(alias_modulo, ()))
+        conflictos = [
+            {
+                "module": alias_modulo,
+                "symbol": "__all__",
+                "code": "missing___all__",
+                "message": "módulo sin __all__; se aplica whitelist explícita por política",
+            }
+        ]
+    else:
+        candidatos = exportables
+        conflictos = []
+
+    simbolos_brutos: list[tuple[str, object]] = []
+    vistos: set[str] = set()
+    depuracion_habilitada = depuracion_saneamiento_usar_habilitada()
+    for nombre in candidatos:
+        if not isinstance(nombre, str):
+            _registrar_conflicto_saneamiento_usar(
+                conflictos,
+                {
+                    "module": alias_modulo,
+                    "symbol": repr(nombre),
+                    "code": "invalid_export_name_type",
+                    "message": "nombre de export no es string",
+                },
+                depuracion_habilitada=depuracion_habilitada,
+            )
+            continue
+        if nombre in vistos:
+            _registrar_conflicto_saneamiento_usar(
+                conflictos,
+                {
+                    "module": alias_modulo,
+                    "symbol": nombre,
+                    "code": "duplicate_export_name",
+                    "message": "nombre exportado repetido en __all__/candidatos",
+                },
+                depuracion_habilitada=depuracion_habilitada,
+            )
+            continue
+        if not hasattr(modulo, nombre):
+            _registrar_conflicto_saneamiento_usar(
+                conflictos,
+                {
+                    "module": alias_modulo,
+                    "symbol": nombre,
+                    "code": "missing_export_attr",
+                    "message": "el nombre exportado no existe en el módulo",
+                },
+                depuracion_habilitada=depuracion_habilitada,
+            )
+            continue
+        if api_publica_modulo and nombre not in api_publica_modulo:
+            _registrar_conflicto_saneamiento_usar(
+                conflictos,
+                {
+                    "module": alias_modulo,
+                    "symbol": nombre,
+                    "code": "outside_public_api",
+                    "message": "símbolo descartado por no pertenecer a la API pública canónica",
+                },
+                depuracion_habilitada=depuracion_habilitada,
+            )
+            continue
+        vistos.add(nombre)
+        simbolos_brutos.append((nombre, getattr(modulo, nombre)))
+
+    simbolos_saneados, clasificacion, warnings = sanear_exportables_para_usar(
+        simbolos_brutos,
+        modulo_origen=alias_modulo,
+    )
+    metadata_por_simbolo: dict[str, dict[str, Any]] = {}
+    simbolos_con_metadata_valida: list[tuple[str, Any]] = []
+    for nombre, simbolo in simbolos_saneados:
+        try:
+            metadata_por_simbolo[nombre] = build_and_validate_usar_symbol_metadata(
+                module_name=alias_modulo,
+                symbol_name=nombre,
+                callable_obj=simbolo,
+            )
+        except ValueError as exc:
+            _registrar_conflicto_saneamiento_usar(
+                conflictos,
+                {
+                    "module": alias_modulo,
+                    "symbol": nombre,
+                    "code": "metadata_conflict",
+                    "message": f"metadata de símbolo inválida o inconsistente: {exc}",
+                },
+                depuracion_habilitada=depuracion_habilitada,
+            )
+            continue
+        simbolos_con_metadata_valida.append((nombre, simbolo))
+    simbolos_saneados = simbolos_con_metadata_valida
+
+    for resultado in [*clasificacion.rechazos_duros, *warnings]:
+        _registrar_conflicto_saneamiento_usar(
+            conflictos,
+            {
+                "module": alias_modulo,
+                "symbol": resultado.nombre,
+                "code": resultado.codigo or ("warning" if resultado.warning else "rejected"),
+                "message": resultado.mensaje or ("warning de saneamiento" if resultado.warning else "símbolo rechazado"),
+                "source_module": resultado.metadata.get("modulo_origen"),
+            },
+            depuracion_habilitada=depuracion_habilitada,
+        )
+
+    metricas_rechazo_por_codigo: dict[str, int] = {}
+    for conflicto in conflictos:
+        codigo = str(conflicto.get("code") or "unknown")
+        metricas_rechazo_por_codigo[codigo] = metricas_rechazo_por_codigo.get(codigo, 0) + 1
+    if metricas_rechazo_por_codigo:
+        logging.info(
+            "USAR_SANITIZE_REJECTION_METRICS %s",
+            {
+                "module": alias_modulo,
+                "rejection_metrics_by_codigo": metricas_rechazo_por_codigo,
+            },
+        )
+
+    return simbolos_saneados, metadata_por_simbolo, conflictos
+
+
+def sanitizar_exports_publicos(
+    modulo: object,
+    alias_modulo: str,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Devuelve el mapa público saneado y sus conflictos."""
+
+    simbolos_saneados, _metadata, conflictos = (
+        _sanitizar_exports_publicos_detallado(modulo, alias_modulo)
+    )
+    return dict(simbolos_saneados), conflictos
+
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/imports/resolver.py
+========================================================================================
+
+"""Resolvedor de imports Cobra con estrategia determinista por origen."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import os
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping
+
+from pcobra.cobra.backends.resolver import resolve_backend
+from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
+from pcobra.cobra.imports._module_map_api import get_toml_map, resolve_backend_for_module
+from pcobra.cobra.stdlib_contract import get_public_stdlib_module_contracts
+
+
+class ImportResolutionError(RuntimeError):
+    """Error base al resolver imports Cobra con código estable para tooling."""
+
+    def __init__(self, message: str, *, code: str = "IMP-RESOLUTION-000") -> None:
+        self.code = code
+        self.message = message
+        super().__init__(f"[{code}] {message}")
+
+
+
+
+@dataclass(frozen=True)
+class ImportResolutionAuditEvent:
+    """Evento de auditoría de una resolución de import."""
+
+    request: str
+    source: str
+    resolved_name: str
+    precedence_reason: str | None
+    collision_policy: str
+
+@dataclass(frozen=True)
+class HybridModuleSpec:
+    """Declaración de módulo híbrido."""
+
+    module: str
+    import_path: str
+    backend: str | None = None
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    """Resultado de resolución de un import Cobra."""
+
+    request: str
+    source: str
+    resolved_name: str
+    import_path: str | None = None
+    file_path: str | None = None
+    backend: str | None = None
+    backend_adapter: object | None = None
+    precedence_reason: str | None = None
+    conflict_candidates: tuple[str, ...] = ()
+
+
+API_CONTRACT_VERSION = "2026-04-import-resolution-v1"
+RESOLUTION_SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
+DEFAULT_COLLISION_POLICY = "namespace_required"
+RESOLUTION_SOURCE_ORDER_STABILITY = "major"
+# Backward-compatible alias (internal histórico).
+_SOURCE_ORDER: tuple[str, ...] = RESOLUTION_SOURCE_ORDER
+_SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
+    {"warn", "strict_error", "namespace_required"}
+)
+
+
+class CobraImportResolver:
+    """Resuelve imports con prioridad fija y conflictos explícitos."""
+    resolution_source_order = RESOLUTION_SOURCE_ORDER
+    resolution_source_order_stability = RESOLUTION_SOURCE_ORDER_STABILITY
+    default_collision_policy = DEFAULT_COLLISION_POLICY
+    api_contract_version = API_CONTRACT_VERSION
+
+    def __init__(
+        self,
+        *,
+        project_root: str | Path | None = None,
+        hybrid_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None = None,
+        default_backend: str = "python",
+        strict_ambiguous_imports: bool = False,
+        collision_policy: str | None = None,
+        audit_debug: bool | None = None,
+    ) -> None:
+        self.project_root = Path(project_root).resolve() if project_root else None
+        config = get_toml_map()
+        self.hybrid_modules = self._load_hybrid_modules(config, hybrid_modules)
+        assert_backend_allowed_for_scope(backend=default_backend, scope="public")
+        self.default_backend = default_backend
+        self.collision_policy = self._resolve_collision_policy(
+            config=config,
+            strict_ambiguous_imports=strict_ambiguous_imports,
+            explicit_policy=collision_policy,
+        )
+        self.audit_debug = self._resolve_audit_debug(config=config, explicit=audit_debug)
+        self.audit_events: list[ImportResolutionAuditEvent] = []
+        self.stdlib_modules = self._load_stdlib_modules()
+        self.project_modules = self._load_project_modules()
+
+    def _load_hybrid_modules(
+        self,
+        config: Mapping[str, Any],
+        explicit_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None,
+    ) -> dict[str, HybridModuleSpec]:
+        declared_in_config = self._hybrid_modules_from_config(config)
+        declared_explicit = self._normalize_hybrid_modules(explicit_modules or {})
+        declared_in_config.update(declared_explicit)
+        return declared_in_config
+
+    @staticmethod
+    def _hybrid_modules_from_config(config: Mapping[str, Any]) -> dict[str, HybridModuleSpec]:
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return {}
+        raw_hybrid = imports_section.get("hybrid_modules", {})
+        if not isinstance(raw_hybrid, Mapping):
+            return {}
+        return CobraImportResolver._normalize_hybrid_modules(raw_hybrid)
+
+    @staticmethod
+    def _resolve_collision_policy(
+        *,
+        config: Mapping[str, Any],
+        strict_ambiguous_imports: bool,
+        explicit_policy: str | None,
+    ) -> str:
+        if strict_ambiguous_imports:
+            return "strict_error"
+
+        configured_policy = CobraImportResolver._collision_policy_from_config(config)
+        migration_mode = CobraImportResolver._is_migration_mode_enabled(config)
+        migration_policy = "warn" if migration_mode else None
+        chosen = explicit_policy or configured_policy or migration_policy or DEFAULT_COLLISION_POLICY
+        if chosen == "warn" and not migration_mode and explicit_policy is None:
+            chosen = DEFAULT_COLLISION_POLICY
+        if chosen not in _SUPPORTED_COLLISION_POLICIES:
+            raise ImportResolutionError(
+                "Política de colisiones inválida. "
+                "Usa 'warn', 'strict_error' o 'namespace_required'.",
+                code="IMP-CONFIG-001",
+            )
+        return chosen
+
+    @staticmethod
+    def _collision_policy_from_config(config: Mapping[str, Any]) -> str | None:
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return None
+        policy = imports_section.get("collision_policy")
+        if isinstance(policy, str):
+            return policy.strip()
+        return None
+
+    @staticmethod
+    def _resolve_audit_debug(*, config: Mapping[str, Any], explicit: bool | None) -> bool:
+        if explicit is not None:
+            return explicit
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return False
+        return imports_section.get("audit_debug") is True
+
+    def _emit_audit(self, resolution: ResolutionResult) -> None:
+        if not self.audit_debug:
+            return
+        event = ImportResolutionAuditEvent(
+            request=resolution.request,
+            source=resolution.source,
+            resolved_name=resolution.resolved_name,
+            precedence_reason=resolution.precedence_reason,
+            collision_policy=self.collision_policy,
+        )
+        self.audit_events.append(event)
+        logging.getLogger(__name__).debug(
+            "IMPORT_AUDIT request=%s source=%s resolved_name=%s precedence_reason=%s collision_policy=%s",
+            event.request,
+            event.source,
+            event.resolved_name,
+            event.precedence_reason,
+            event.collision_policy,
+        )
+
+    @staticmethod
+    def _is_migration_mode_enabled(config: Mapping[str, Any]) -> bool:
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return False
+        migration_mode = imports_section.get("migration_mode")
+        return migration_mode is True
+
+    @staticmethod
+    def _normalize_hybrid_modules(
+        modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]],
+    ) -> dict[str, HybridModuleSpec]:
+        normalized: dict[str, HybridModuleSpec] = {}
+        for name, raw in modules.items():
+            if isinstance(raw, HybridModuleSpec):
+                normalized[name] = raw
+                continue
+            import_path = str(raw.get("import_path", name))
+            backend = raw.get("backend")
+            normalized[name] = HybridModuleSpec(
+                module=str(raw.get("module", name)),
+                import_path=import_path,
+                backend=str(backend) if isinstance(backend, str) else None,
+            )
+        return normalized
+
+    @staticmethod
+    def _load_stdlib_modules() -> dict[str, dict[str, object]]:
+        contracts = get_public_stdlib_module_contracts()
+        return {name: metadata for name, metadata in contracts.items() if name.startswith("cobra.")}
+
+    @staticmethod
+    def _load_project_modules() -> set[str]:
+        config = get_toml_map()
+        if not isinstance(config, dict):
+            return set()
+        modulos = config.get("modulos", {})
+        if not isinstance(modulos, dict):
+            return set()
+        return {name for name, value in modulos.items() if isinstance(name, str) and isinstance(value, dict)}
+
+    def resolve(self, module_name: str) -> ResolutionResult:
+        name = (module_name or "").strip()
+        if not name:
+            raise ImportResolutionError("Nombre de módulo vacío", code="IMP-REQUEST-001")
+
+        candidates: list[ResolutionResult] = []
+        for source in RESOLUTION_SOURCE_ORDER:
+            candidate = self._build_candidate(source, name)
+            if candidate is not None:
+                candidates.append(candidate)
+
+        if not candidates:
+            raise ImportResolutionError(
+                f"No se encontró módulo para '{name}'",
+                code="IMP-NOT-FOUND-001",
+            )
+
+        precedence_reason = (
+            f"unique_source:{candidates[0].source}"
+            if len(candidates) == 1
+            else f"source_order:{' > '.join(RESOLUTION_SOURCE_ORDER)}"
+        )
+
+        if "." not in name and len(candidates) > 1:
+            details = ", ".join(f"{c.source}:{c.resolved_name}" for c in candidates)
+            message = (
+                f"Colisión de import para '{name}'. Se aplica precedencia fija "
+                f"({RESOLUTION_SOURCE_ORDER[0]} > {RESOLUTION_SOURCE_ORDER[1]} > "
+                f"{RESOLUTION_SOURCE_ORDER[2]} > {RESOLUTION_SOURCE_ORDER[3]}). "
+                f"Seleccionado: {candidates[0].resolved_name}. Candidatos: {details}. "
+                f"Conflicto potencial: comando/import corto como 'importar {name}' puede colisionar "
+                f"con módulo local '{name}'. Recomendación explícita: usa 'cobra.{name}' para stdlib "
+                f"o 'app.{name}' para módulo de proyecto."
+            )
+            if self.collision_policy in {"strict_error", "namespace_required"}:
+                suffix = (
+                    " Modo namespace_required: debes importar con namespace explícito."
+                    if self.collision_policy == "namespace_required"
+                    else " Activa resolución explícita en strict mode."
+                )
+                raise ImportResolutionError(f"{message}{suffix}", code="IMP-COLLISION-001")
+            warnings.warn(message, category=UserWarning, stacklevel=2)
+
+        selected = ResolutionResult(
+            request=candidates[0].request,
+            source=candidates[0].source,
+            resolved_name=candidates[0].resolved_name,
+            import_path=candidates[0].import_path,
+            file_path=candidates[0].file_path,
+            backend=candidates[0].backend,
+            backend_adapter=candidates[0].backend_adapter,
+            precedence_reason=precedence_reason,
+            conflict_candidates=tuple(f"{c.source}:{c.resolved_name}" for c in candidates[1:]),
+        )
+        resolved = self._attach_backend_adapter(selected)
+        self._emit_audit(resolved)
+        return resolved
+
+    def load_module(
+        self,
+        module_name: str,
+        fallback_backend: str = "python",
+    ) -> tuple[ResolutionResult, ModuleType | None]:
+        """Carga módulo Python cuando aplique usando el resultado resuelto."""
+
+        resolution = self.resolve(module_name)
+        if resolution.import_path is None:
+            return resolution, None
+
+        module = importlib.import_module(resolution.import_path)
+        if resolution.backend:
+            setattr(module, "__cobra_backend__", resolution.backend)
+        if resolution.backend_adapter is not None:
+            setattr(module, "__cobra_backend_adapter__", resolution.backend_adapter)
+        elif fallback_backend:
+            effective_backend = resolve_backend_for_module(
+                resolution.resolved_name,
+                fallback_backend,
+            )
+            adapter = resolve_backend(effective_backend)
+            setattr(module, "__cobra_backend__", effective_backend)
+            setattr(module, "__cobra_backend_adapter__", adapter)
+        self._attach_module_metadata(module, resolution)
+        return resolution, module
+
+    def _attach_module_metadata(self, module: ModuleType, resolution: ResolutionResult) -> None:
+        metadata = {
+            "api_contract_version": API_CONTRACT_VERSION,
+            "resolution_source_order": list(RESOLUTION_SOURCE_ORDER),
+            "collision_policy": self.collision_policy,
+            "request": resolution.request,
+            "source": resolution.source,
+            "resolved_name": resolution.resolved_name,
+            "backend": resolution.backend,
+            "import_path": resolution.import_path,
+            "precedence_reason": resolution.precedence_reason,
+            "conflict_candidates": list(resolution.conflict_candidates),
+            "audit_debug": self.audit_debug,
+        }
+        if resolution.file_path is not None:
+            metadata["file_path"] = resolution.file_path
+        setattr(module, "__cobra_resolution_source__", resolution.source)
+        setattr(module, "__cobra_backend_injected__", resolution.backend)
+        setattr(module, "__cobra_resolution_metadata__", metadata)
+
+    def _attach_backend_adapter(self, resolution: ResolutionResult) -> ResolutionResult:
+        base_backend = resolution.backend or self.default_backend
+        effective_backend = resolve_backend_for_module(resolution.resolved_name, base_backend)
+        assert_backend_allowed_for_scope(backend=effective_backend, scope="public")
+        adapter = resolve_backend(effective_backend)
+        return ResolutionResult(
+            request=resolution.request,
+            source=resolution.source,
+            resolved_name=resolution.resolved_name,
+            import_path=resolution.import_path,
+            file_path=resolution.file_path,
+            backend=effective_backend,
+            backend_adapter=adapter,
+            precedence_reason=resolution.precedence_reason,
+            conflict_candidates=resolution.conflict_candidates,
+        )
+
+    def _build_candidate(self, source: str, name: str) -> ResolutionResult | None:
+        if source == "stdlib":
+            return self._resolve_stdlib_module(name)
+        if source == "project":
+            return self._resolve_project_module(name)
+        if source == "python_bridge":
+            return self._resolve_python_bridge(name)
+        if source == "hybrid":
+            return self._resolve_hybrid_module(name)
+        return None
+
+    def _resolve_project_module(self, name: str) -> ResolutionResult | None:
+        if name in self.project_modules:
+            return ResolutionResult(request=name, source="project", resolved_name=name)
+
+        file_candidate = self._resolve_local_file_module(name)
+        if file_candidate is not None:
+            return file_candidate
+        return None
+
+    def _resolve_local_file_module(self, name: str) -> ResolutionResult | None:
+        if self.project_root is None:
+            return None
+
+        relative = Path(*name.split("."))
+        local_patterns = (
+            relative.with_suffix(".co"),
+            relative.with_suffix(".cobra"),
+            relative / "__init__.co",
+            relative / "__init__.cobra",
+        )
+        for pattern in local_patterns:
+            candidate_path = self.project_root / pattern
+            if candidate_path.exists():
+                file_path = candidate_path.resolve()
+                self._verify_path_inside_project_root(file_path)
+                return ResolutionResult(
+                    request=name,
+                    source="project",
+                    resolved_name=name,
+                    import_path=None,
+                    file_path=str(file_path),
+                )
+        return None
+
+    def _verify_path_inside_project_root(self, file_path: Path) -> None:
+        if self.project_root is None:
+            return
+        try:
+            common = os.path.commonpath((str(self.project_root), str(file_path)))
+        except ValueError as exc:
+            raise ImportResolutionError(
+                "Ruta de módulo de proyecto fuera de la raíz autorizada.",
+                code="IMP-PROJECT-PATH-001",
+            ) from exc
+        if common != str(self.project_root):
+            raise ImportResolutionError(
+                "Ruta de módulo de proyecto fuera de la raíz autorizada.",
+                code="IMP-PROJECT-PATH-001",
+            )
+
+    def _resolve_stdlib_module(self, name: str) -> ResolutionResult | None:
+        if name.startswith("cobra."):
+            metadata = self.stdlib_modules.get(name)
+            if metadata is not None:
+                return ResolutionResult(
+                    request=name,
+                    source="stdlib",
+                    resolved_name=name,
+                    import_path=self._cobra_stdlib_to_python(name),
+                    backend=(
+                        str(metadata["backend_preferido"])
+                        if isinstance(metadata.get("backend_preferido"), str)
+                        else None
+                    ),
+                )
+            return None
+
+        qualified = f"cobra.{name}"
+        metadata = self.stdlib_modules.get(qualified)
+        if metadata is not None:
+            return ResolutionResult(
+                request=name,
+                source="stdlib",
+                resolved_name=qualified,
+                import_path=self._cobra_stdlib_to_python(qualified),
+                backend=(
+                    str(metadata["backend_preferido"])
+                    if isinstance(metadata.get("backend_preferido"), str)
+                    else None
+                ),
+            )
+        return None
+
+    @staticmethod
+    def _cobra_stdlib_to_python(qualified_name: str) -> str:
+        tail = qualified_name.removeprefix("cobra.")
+        return f"pcobra.standard_library.{tail}"
+
+    @staticmethod
+    def _resolve_python_bridge(name: str) -> ResolutionResult | None:
+        if name.startswith("cobra."):
+            return None
+        try:
+            spec = importlib.util.find_spec(name)
+        except ModuleNotFoundError:
+            return None
+        if spec is None:
+            return None
+        return ResolutionResult(
+            request=name,
+            source="python_bridge",
+            resolved_name=name,
+            import_path=name,
+        )
+
+    def _resolve_hybrid_module(self, name: str) -> ResolutionResult | None:
+        spec = self.hybrid_modules.get(name)
+        if spec is None:
+            return None
+        return ResolutionResult(
+            request=name,
+            source="hybrid",
+            resolved_name=spec.module,
+            import_path=spec.import_path,
+            backend=spec.backend,
+        )
+
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/cli/commands/crear_cmd.py
+========================================================================================
+
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+
+
+class CrearCommand(BaseCommand):
+    """Crea archivos o proyectos Cobra con extensión .co."""
+    
+    name = "crear"
+    
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
+        """Registra los argumentos del subcomando.
+        
+        Args:
+            subparsers: Objeto para registrar subcomandos
+            
+        Returns:
+            CustomArgumentParser: Parser configurado
+            
+        Note:
+            Crea subcomandos para crear archivos, carpetas y proyectos
+        """
+        parser = subparsers.add_parser(self.name, help=_("Crea archivos o proyectos"))
+        sub = parser.add_subparsers(dest="accion", required=True)
+        
+        arch = sub.add_parser("archivo", help=_("Crea un archivo .co"))
+        arch.add_argument("ruta", help=_("Ruta del archivo a crear"))
+        
+        carp = sub.add_parser("carpeta", help=_("Crea una carpeta"))
+        carp.add_argument("ruta", help=_("Ruta de la carpeta a crear"))
+        
+        proy = sub.add_parser("proyecto", help=_("Crea un proyecto básico"))
+        proy.add_argument("ruta", help=_("Ruta del proyecto a crear"))
+        
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        """Ejecuta la lógica del comando.
+        
+        Args:
+            args: Argumentos parseados del comando
+            
+        Returns:
+            int: 0 si éxito, 1 si error
+            
+        Raises:
+            PermissionError: Si no hay permisos suficientes
+            OSError: Si ocurre un error del sistema de archivos
+        """
+        if not args.ruta:
+            mostrar_error(_("La ruta no puede estar vacía"))
+            return 1
+            
+        try:
+            ruta = Path(args.ruta)
+            
+            return {
+                "archivo": lambda: self._crear_archivo(ruta),
+                "carpeta": lambda: self._crear_carpeta(ruta),
+                "proyecto": lambda: self._crear_proyecto(ruta)
+            }[args.accion]()
+            
+        except KeyError:
+            mostrar_error(_("Acción no reconocida"))
+            return 1
+        except PermissionError:
+            mostrar_error(_("Error de permisos al crear {path}").format(path=ruta))
+            return 1
+        except OSError as e:
+            mostrar_error(_("Error al crear {path}: {error}").format(
+                path=ruta, error=str(e)))
+            return 1
+
+    @staticmethod
+    def _crear_archivo(ruta: Path) -> int:
+        """Crea un archivo .co vacío.
+        
+        Args:
+            ruta: Ruta donde crear el archivo
+            
+        Returns:
+            int: 0 si éxito, 1 si error
+            
+        Raises:
+            PermissionError: Si no hay permisos suficientes
+            OSError: Si ocurre un error al crear el archivo
+        """
+        if not str(ruta).endswith(".co"):
+            ruta = ruta.with_suffix(".co")
+            
+        if ruta.exists():
+            mostrar_error(_("El archivo ya existe: {path}").format(path=ruta))
+            return 1
+            
+        ruta.parent.mkdir(parents=True, exist_ok=True)
+        ruta.touch()
+        mostrar_info(_("Archivo creado: {path}").format(path=ruta))
+        return 0
+
+    @staticmethod
+    def _crear_carpeta(ruta: Path) -> int:
+        """Crea una carpeta vacía.
+        
+        Args:
+            ruta: Ruta donde crear la carpeta
+            
+        Returns:
+            int: 0 si éxito, 1 si error
+            
+        Raises:
+            PermissionError: Si no hay permisos suficientes
+            OSError: Si ocurre un error al crear la carpeta
+        """
+        ruta.mkdir(parents=True, exist_ok=True)
+        mostrar_info(_("Carpeta creada: {path}").format(path=ruta))
+        return 0
+
+    @staticmethod
+    def _crear_proyecto(ruta: Path) -> int:
+        """Crea un proyecto Cobra básico.
+        
+        Args:
+            ruta: Ruta donde crear el proyecto
+            
+        Returns:
+            int: 0 si éxito, 1 si error
+            
+        Raises:
+            PermissionError: Si no hay permisos suficientes
+            OSError: Si ocurre un error al crear el proyecto
+        """
+        ruta.mkdir(parents=True, exist_ok=True)
+        main_file = ruta / "main.co"
+        
+        if main_file.exists():
+            mostrar_error(_("El archivo main.co ya existe en {path}").format(path=ruta))
+            return 1
+            
+        main_file.touch()
+        mostrar_info(_("Proyecto Cobra creado en {path}").format(path=ruta))
+        return 0
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/cli/commands/init_cmd.py
+========================================================================================
+
+import os
+from pathlib import Path
+from argparse import ArgumentParser
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cobra.cli.utils.messages import mostrar_info, mostrar_error
+
+class InitCommand(BaseCommand):
+    """Inicializa un proyecto Cobra básico."""
+    
+    name = "init"
+
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
+        """Registra los argumentos del subcomando.
+        
+        Args:
+            subparsers: Objeto para registrar subcomandos
+            
+        Returns:
+            CustomArgumentParser: El parser configurado para este subcomando
+        """
+        parser = subparsers.add_parser(
+            self.name, help=_("Inicializa un proyecto Cobra")
+        )
+        parser.add_argument("ruta", help=_("Ruta donde crear el proyecto"))
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        """Ejecuta la lógica del comando.
+        
+        Args:
+            args: Argumentos parseados del comando
+            
+        Returns:
+            int: 0 si la ejecución fue exitosa, 1 en caso de error
+        """
+        try:
+            ruta = Path(args.ruta)
+            ruta_abs = ruta.absolute()
+
+            # Validar longitud de ruta
+            if len(str(ruta_abs)) > 260:  # Límite Windows
+                mostrar_error(_("Error: Ruta demasiado larga"))
+                return 1
+
+            # Validar caracteres no permitidos
+            try:
+                ruta_abs.resolve()
+            except RuntimeError:
+                mostrar_error(_("Error: La ruta contiene caracteres no válidos"))
+                return 1
+
+            # Crear directorio si no existe
+            ruta.mkdir(parents=True, exist_ok=True)
+            
+            # Crear archivo main.co con template básico
+            main = ruta / "main.co"
+            if not main.exists():
+                template = (
+                    "# Proyecto Cobra\n"
+                    "\n"
+                    "func main() {\n"
+                    "    # Tu código aquí\n"
+                    "}\n"
+                )
+                main.write_text(template, encoding="utf-8")
+                    
+            mostrar_info(_("Proyecto Cobra inicializado en {path}").format(path=ruta))
+            return 0
+            
+        except PermissionError:
+            mostrar_error(_("Error: No hay permisos para escribir en {path}").format(path=ruta))
+            return 1
+        except FileExistsError:
+            mostrar_error(_("Error: Ya existe un archivo con ese nombre"))
+            return 1
+        except NotADirectoryError:
+            mostrar_error(_("Error: La ruta padre debe ser un directorio"))
+            return 1
+        except OSError as e:
+            mostrar_error(_("Error al crear el proyecto: {err}").format(err=str(e)))
+            return 1
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/cli/services/mod_service.py
+========================================================================================
+
+import logging
+import os
+import shutil
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.contracts import ModRequest, normalize_mod_request
+from pcobra.cobra.cli.utils.module_paths import MODULES_PATH, USER_CONFIG_DIR
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.cli.utils.semver import es_nueva_version, es_version_valida
+from pcobra.cobra.semantico import mod_validator
+from pcobra.cobra.transpilers.module_map import MODULE_MAP_PATH
+
+try:  # pragma: no cover
+    from filelock import FileLock
+except ModuleNotFoundError:  # pragma: no cover
+    FileLock = None  # type: ignore[assignment]
+
+try:  # pragma: no cover
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover
+    yaml = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+_client: Optional[CobraHubClient] = None
+
+LOCK_FILE: Path = USER_CONFIG_DIR / "module_map.toml"
+LOCK_KEY = "lock"
+MODULE_EXTENSION = ".co"
+
+
+def get_client() -> CobraHubClient:
+    global _client
+    if _client is None:
+        _client = CobraHubClient()
+    return _client
+
+
+def lock_context(path: Path):
+    if FileLock is None:
+        return nullcontext()
+    return FileLock(f"{path}.lock")
+
+
+def ensure_modules_dir() -> bool:
+    modules_dir = Path(MODULES_PATH)
+    try:
+        modules_dir.mkdir(parents=True, exist_ok=True)
+        return True
+    except PermissionError as exc:
+        logger.error("Sin permisos para crear directorio de módulos: %s", exc)
+        mostrar_error(_("No se pudo preparar el directorio de módulos en {ruta}: {err}").format(ruta=modules_dir, err=str(exc)))
+    except OSError as exc:
+        logger.error("Error al preparar directorio de módulos: %s", exc)
+        mostrar_error(_("Error al preparar el directorio de módulos en {ruta}: {err}").format(ruta=modules_dir, err=str(exc)))
+    return False
+
+
+def ensure_lock_parent() -> bool:
+    lock_parent = Path(LOCK_FILE).parent
+    try:
+        lock_parent.mkdir(parents=True, exist_ok=True)
+        return True
+    except PermissionError as exc:
+        logger.error("Sin permisos para preparar lock de módulos: %s", exc)
+        mostrar_error(_("No se pudo preparar el archivo de lock en {ruta}: {err}").format(ruta=lock_parent, err=str(exc)))
+    except OSError as exc:
+        logger.error("Error al preparar lock de módulos: %s", exc)
+        mostrar_error(_("Error al preparar el archivo de lock en {ruta}: {err}").format(ruta=lock_parent, err=str(exc)))
+    return False
+
+
+def validar_nombre_modulo(nombre: str) -> bool:
+    return bool(nombre and not any(c in nombre for c in r'<>:"/\\|?*'))
+
+
+def validar_ruta(ruta: str) -> bool:
+    try:
+        ruta_abs = os.path.abspath(ruta)
+        return not any(parte.startswith(".") for parte in Path(ruta_abs).parts)
+    except Exception:
+        return False
+
+
+def cargar_lock() -> Dict:
+    data: Dict = {}
+    if yaml is None:
+        mostrar_error(_("La gestión del archivo lock requiere la dependencia 'PyYAML'."))
+        return {LOCK_KEY: {}}
+
+    try:
+        lock_path = Path(LOCK_FILE)
+        if lock_path.exists():
+            with lock_context(lock_path):
+                with open(lock_path, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f) or {}
+    except (IOError, yaml.YAMLError) as e:
+        logger.error("Error al cargar lock: %s", e)
+        mostrar_error(_("Error al cargar lock: {err}").format(err=str(e)))
+    data.setdefault(LOCK_KEY, {})
+    return data
+
+
+def obtener_version_lock(nombre: str) -> Optional[str]:
+    if not nombre or not validar_nombre_modulo(nombre):
+        return None
+    data = cargar_lock()
+    return data.get(LOCK_KEY, {}).get(nombre)
+
+
+def actualizar_lock(nombre: str, version: Optional[str]) -> None:
+    if yaml is None:
+        mostrar_error(_("Actualizar el lock de módulos requiere la dependencia 'PyYAML'."))
+        return
+
+    if not nombre or not validar_nombre_modulo(nombre):
+        return
+    if not ensure_lock_parent():
+        return
+
+    try:
+        lock_path = Path(LOCK_FILE)
+        with lock_context(lock_path):
+            data = cargar_lock()
+            data[LOCK_KEY][nombre] = version
+            with open(lock_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(data, f)
+    except (IOError, yaml.YAMLError) as e:
+        logger.error("Error al actualizar lock: %s", e)
+        mostrar_error(_("Error al actualizar lock: {err}").format(err=str(e)))
+
+
+def obtener_version(ruta: str) -> Optional[str]:
+    if yaml is None:
+        mostrar_error(_("La lectura de versiones de módulos requiere la dependencia 'PyYAML'."))
+        return None
+
+    try:
+        if os.path.exists(MODULE_MAP_PATH):
+            with open(MODULE_MAP_PATH, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+                for mod_path, info in data.items():
+                    if mod_path == LOCK_KEY:
+                        continue
+                    if os.path.basename(mod_path) == os.path.basename(ruta):
+                        return info.get("version")
+    except (IOError, yaml.YAMLError) as e:
+        logger.error("Error al leer versión: %s", e)
+        mostrar_error(_("Error al leer versión: {err}").format(err=str(e)))
+    return None
+
+
+class ModService:
+    def run(self, request: ModRequest) -> int:
+        try:
+            request = normalize_mod_request(request)
+        except ValueError as err:
+            mostrar_error(str(err))
+            return 1
+
+        accion = request.accion
+
+        if yaml is None and accion in {"publicar", "buscar"}:
+            mostrar_error(_("El comando de módulos requiere la dependencia opcional 'PyYAML' para la acción solicitada."))
+            return 1
+
+        acciones = {
+            "listar": listar_modulos,
+            "instalar": lambda: instalar_modulo(request.ruta),
+            "remover": lambda: remover_modulo(request.nombre),
+            "publicar": lambda: 0 if get_client().publicar_modulo(request.ruta) else 1,
+            "buscar": lambda: buscar_modulo(request.nombre),
+        }
+
+        try:
+            if accion not in acciones:
+                raise ValueError(_("Acción de módulos no reconocida"))
+            return acciones[accion]()
+        except Exception as e:
+            logger.error("Error en comando de módulos: %s", e)
+            mostrar_error(str(e))
+            return 1
+
+
+def listar_modulos() -> int:
+    try:
+        mod_validator.validar_mod(MODULE_MAP_PATH)
+        modules_dir = Path(MODULES_PATH)
+        if not modules_dir.exists():
+            mostrar_info(_("No hay módulos instalados"))
+            return 0
+
+        mods = [f.name for f in modules_dir.iterdir() if f.is_file() and f.name.endswith(MODULE_EXTENSION)]
+        if not mods:
+            mostrar_info(_("No hay módulos instalados"))
+        else:
+            for m in sorted(mods):
+                mostrar_info(m)
+        return 0
+    except (ValueError, OSError) as e:
+        logger.error("Error al listar módulos: %s", e)
+        mostrar_error(str(e))
+        return 1
+
+
+def instalar_modulo(ruta: str) -> int:
+    try:
+        if not validar_ruta(ruta):
+            raise ValueError(_("Ruta de módulo inválida"))
+
+        if yaml is not None:
+            mod_validator.validar_mod(MODULE_MAP_PATH)
+        ruta_abs = os.path.abspath(ruta)
+
+        if not os.path.exists(ruta_abs):
+            raise ValueError(_("No se encontró el módulo {path}").format(path=ruta))
+
+        if os.path.islink(ruta_abs) or not os.path.isfile(ruta_abs) or not ruta.endswith(MODULE_EXTENSION):
+            raise ValueError(_("Ruta de módulo inválida"))
+
+        nombre = os.path.basename(ruta_abs)
+        if not validar_nombre_modulo(nombre):
+            raise ValueError(_("Nombre de módulo inválido"))
+
+        if not ensure_modules_dir():
+            return 1
+
+        modules_dir = Path(MODULES_PATH)
+        destino = modules_dir / nombre
+        if destino.exists() and destino.is_symlink():
+            raise ValueError(_("El destino {dest} es un enlace simbólico").format(dest=destino))
+
+        try:
+            shutil.copy2(ruta_abs, destino)
+        except PermissionError as exc:
+            raise ValueError(_("Sin permisos para copiar a {dest}: {err}").format(dest=destino, err=str(exc))) from exc
+        except OSError as exc:
+            raise ValueError(_("No se pudo copiar el módulo a {dest}: {err}").format(dest=destino, err=str(exc))) from exc
+        mostrar_info(_("Módulo instalado en {dest}").format(dest=destino))
+
+        version = None
+        if yaml is not None:
+            version = obtener_version(ruta_abs)
+            if version and not es_version_valida(version):
+                raise ValueError(_("Versión de módulo inválida"))
+
+            actual = obtener_version_lock(nombre)
+            if actual and version and not es_nueva_version(version, actual):
+                raise ValueError(_("La nueva versión {v} no supera a {a}").format(v=version, a=actual))
+
+            actualizar_lock(nombre, version)
+        return 0
+
+    except Exception as e:
+        logger.error("Error al instalar módulo: %s", e)
+        mostrar_error(str(e))
+        return 1
+
+
+def remover_modulo(nombre: str) -> int:
+    if not nombre or not validar_nombre_modulo(nombre):
+        mostrar_error(_("Nombre de módulo inválido"))
+        return 1
+
+    try:
+        if not ensure_modules_dir():
+            return 1
+
+        modules_dir = Path(MODULES_PATH)
+        archivo = modules_dir / nombre
+        if not archivo.exists():
+            raise ValueError(_("El módulo {name} no existe").format(name=nombre))
+
+        try:
+            archivo.unlink()
+        except OSError as e:
+            raise ValueError(_("Error al eliminar módulo: {err}").format(err=str(e)))
+
+        mostrar_info(_("Módulo {name} eliminado").format(name=nombre))
+
+        if yaml is not None:
+            if not ensure_lock_parent():
+                return 1
+
+            lock_path = Path(LOCK_FILE)
+            with lock_context(lock_path):
+                data = cargar_lock()
+                if nombre in data.get(LOCK_KEY, {}):
+                    del data[LOCK_KEY][nombre]
+                    with open(lock_path, "w", encoding="utf-8") as f:
+                        yaml.safe_dump(data, f)
+        return 0
+
+    except Exception as e:
+        logger.error("Error al remover módulo: %s", e)
+        mostrar_error(str(e))
+        return 1
+
+
+def buscar_modulo(nombre: str) -> int:
+    if not nombre or not validar_nombre_modulo(nombre):
+        mostrar_error(_("Nombre de módulo inválido"))
+        return 1
+
+    try:
+        if not ensure_modules_dir():
+            return 1
+
+        modules_dir = Path(MODULES_PATH).resolve()
+        destino = str((modules_dir / nombre).resolve(strict=False))
+        ok = get_client().descargar_modulo(nombre, destino, base_permitida=str(modules_dir))
+        if ok:
+            actualizar_lock(nombre, None)
+        return 0 if ok else 1
+    except Exception as e:
+        logger.error("Error al buscar módulo: %s", e)
+        mostrar_error(str(e))
+        return 1
+
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/cli/services/test_service.py
+========================================================================================
+
+import concurrent.futures
+import logging
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
+from pcobra.cobra.cli.mode_policy import validar_politica_modo
+from pcobra.cobra.cli.services.contracts import TestRequest, normalize_test_request
+from pcobra.cobra.cli.target_policies import (
+    OFFICIAL_TRANSPILATION_TARGETS,
+    VERIFICATION_EXECUTABLE_TARGETS,
+)
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.cli.utils.source import read_cobra_source
+from pcobra.cobra.cli.utils.validators import validar_archivo_existente
+from pcobra.cobra.core import Lexer, Parser
+
+MAX_FILE_SIZE = 10 * 1024 * 1024
+VALID_EXTENSIONS = {".cobra", ".cbr", ".co"}
+
+
+def target_cli_choices(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    return tuple(values)
+
+
+class TestService:
+    OFFICIAL_LANGUAGE_CHOICES = target_cli_choices(OFFICIAL_TRANSPILATION_TARGETS)
+    SUPPORTED_LANGUAGES = target_cli_choices(VERIFICATION_EXECUTABLE_TARGETS)
+
+    def __init__(self) -> None:
+        self._interprete = construir_interprete_seguro_canonico(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=True,
+            extra_validators=None,
+        )
+        self._logger = logging.getLogger(__name__)
+
+    def run(self, request: TestRequest) -> int:
+        request = normalize_test_request(request)
+        try:
+            validar_politica_modo("verificar", request, capability="codegen")
+
+            lenguajes = list(request.lenguajes)
+            self.validate_languages(lenguajes)
+
+            codigo = self.read_source_file(request.archivo)
+            tokens = Lexer(codigo).tokenizar()
+            ast = Parser(tokens).parsear()
+
+            with patch("sys.stdout", new_callable=StringIO) as out:
+                self._interprete.ejecutar_ast(ast)
+            esperado = out.getvalue().replace("\r\n", "\n")
+
+            diferencias: Dict[str, str] = {}
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                futuros = {
+                    executor.submit(self.verify_language, lang, ast, esperado): lang for lang in lenguajes
+                }
+
+                for futuro in concurrent.futures.as_completed(futuros):
+                    lang, error = futuro.result()
+                    if error:
+                        diferencias[lang] = error
+
+            if diferencias:
+                mostrar_error(_("Se encontraron diferencias:"))
+                for lang, salida in diferencias.items():
+                    mostrar_error(f"{lang}: {salida.strip()}")
+                return 1
+
+            mostrar_info(_("Todas las salidas coinciden"))
+            return 0
+
+        except (ValueError, PermissionError) as e:
+            mostrar_error(str(e))
+            return 1
+        except Exception as e:
+            self._logger.exception("Error inesperado")
+            mostrar_error(f"Error inesperado: {str(e)}")
+            return 1
+
+    def validate_languages(self, languages: List[str]) -> None:
+        if not languages:
+            raise ValueError(_("La lista de lenguajes no puede estar vacía"))
+
+        unsupported = set(languages) - set(self.SUPPORTED_LANGUAGES)
+        if unsupported:
+            raise ValueError(
+                _("Lenguajes no soportados: {unsupported}. Soportados: {supported}").format(
+                    unsupported=", ".join(sorted(unsupported)),
+                    supported=", ".join(self.SUPPORTED_LANGUAGES),
+                )
+            )
+
+    def validate_file(self, file_path: str) -> None:
+        path = Path(file_path)
+        if path.suffix not in VALID_EXTENSIONS:
+            raise ValueError(_("Extensión de archivo no válida. Debe ser: {}").format(", ".join(sorted(VALID_EXTENSIONS))))
+
+        if path.stat().st_size > MAX_FILE_SIZE:
+            raise ValueError(_("El archivo es demasiado grande (máximo {} MB)").format(MAX_FILE_SIZE // (1024 * 1024)))
+
+    def read_source_file(self, file_path: str) -> str:
+        validar_archivo_existente(file_path)
+        self.validate_file(file_path)
+
+        try:
+            return read_cobra_source(file_path)
+        except PermissionError:
+            raise PermissionError(_("No hay permisos para leer el archivo '{}'").format(file_path))
+        except UnicodeDecodeError as e:
+            self._logger.error("Error decodificando archivo: %s", str(e))
+            raise ValueError(_("Error al decodificar el archivo '{}'").format(file_path))
+
+    def compile_and_execute(self, ast: Any, lang: str) -> Tuple[Optional[str], Optional[str]]:
+        try:
+            codigo_gen = backend_pipeline.transpile(ast, lang)
+
+            if lang == "python":
+                salida = ejecutar_en_sandbox(codigo_gen)
+            elif lang == "javascript":
+                salida = ejecutar_en_sandbox_js(codigo_gen)
+            elif lang in {"cpp", "rust"}:
+                salida = ejecutar_en_contenedor(codigo_gen, lang)
+            else:
+                return None, _("Runtime no soportado para {}").format(lang)
+
+            return salida.replace("\r\n", "\n"), None
+
+        except ValueError:
+            return None, _("Transpilador no encontrado para {}").format(lang)
+        except Exception as e:
+            self._logger.error("Error en %s: %s", lang, str(e))
+            return None, str(e)
+
+    def verify_language(self, lang: str, ast: Any, esperado: str) -> Tuple[str, Optional[str]]:
+        salida, error = self.compile_and_execute(ast, lang)
+
+        if error:
+            return lang, error
+        if salida != esperado:
+            return lang, salida
+
+        return lang, None
+
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/cli/services/verification_service.py
+========================================================================================
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any
+from unittest.mock import patch
+
+from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
+from pcobra.cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
+from pcobra.cobra.core import Lexer, Parser
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.cli.utils.validators import validar_archivo_existente
+from pcobra.cobra.qa.syntax_validation import SUPPORTED_VALIDATOR_TARGETS
+
+
+MAX_FILE_SIZE = 10 * 1024 * 1024
+VALID_EXTENSIONS = {".cobra", ".cbr", ".co"}
+
+
+@dataclass
+class RuntimeVerificationExecution:
+    exit_code: int
+    requested_targets: list[str]
+    executable_targets: list[str]
+
+
+def parse_verification_targets(targets_raw: str) -> list[str]:
+    if not targets_raw.strip():
+        return list(SUPPORTED_VALIDATOR_TARGETS)
+    parsed = [item.strip().lower() for item in targets_raw.split(",") if item.strip()]
+    if not parsed:
+        raise ValueError(_("La lista --targets está vacía"))
+    invalid = sorted(set(parsed) - set(SUPPORTED_VALIDATOR_TARGETS))
+    if invalid:
+        raise ValueError(_("Targets no soportados en --targets: {}.").format(", ".join(invalid)))
+    return parsed
+
+
+def resolve_executable_targets(requested_targets: list[str]) -> list[str]:
+    return [target for target in requested_targets if target in VERIFICATION_EXECUTABLE_TARGETS]
+
+
+def _compile_and_execute(ast: Any, lang: str) -> tuple[str | None, str | None]:
+    try:
+        code = backend_pipeline.transpile(ast, lang)
+        if lang == "python":
+            output = ejecutar_en_sandbox(code)
+        elif lang == "javascript":
+            output = ejecutar_en_sandbox_js(code)
+        elif lang in {"cpp", "rust"}:
+            output = ejecutar_en_contenedor(code, lang)
+        else:
+            return None, _("Runtime no soportado para {}").format(lang)
+        return output.replace("\r\n", "\n"), None
+    except ValueError:
+        return None, _("Transpilador no encontrado para {}").format(lang)
+    except Exception as exc:
+        return None, str(exc)
+
+
+def execute_runtime_verification(archivo: str, lenguajes: list[str]) -> int:
+    if not lenguajes:
+        raise ValueError(_("La lista de lenguajes no puede estar vacía"))
+
+    unsupported = set(lenguajes) - set(VERIFICATION_EXECUTABLE_TARGETS)
+    if unsupported:
+        raise ValueError(
+            _("Lenguajes no soportados: {unsupported}. Soportados: {supported}").format(
+                unsupported=", ".join(sorted(unsupported)),
+                supported=", ".join(VERIFICATION_EXECUTABLE_TARGETS),
+            )
+        )
+
+    path = validar_archivo_existente(archivo)
+    if path.suffix not in VALID_EXTENSIONS:
+        raise ValueError(_("Extensión de archivo no válida. Debe ser: {}").format(", ".join(sorted(VALID_EXTENSIONS))))
+    if path.stat().st_size > MAX_FILE_SIZE:
+        raise ValueError(_("El archivo es demasiado grande (máximo {} MB)").format(MAX_FILE_SIZE // (1024 * 1024)))
+
+    code = path.read_text(encoding="utf-8")
+    tokens = Lexer(code).tokenizar()
+    ast = Parser(tokens).parsear()
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        construir_interprete_seguro_canonico(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=True,
+            extra_validators=None,
+        ).ejecutar_ast(ast)
+    expected = out.getvalue().replace("\r\n", "\n")
+
+    for language in lenguajes:
+        output, error = _compile_and_execute(ast, language)
+        if error is not None:
+            return 1
+        if output != expected:
+            return 1
+    return 0
+
+
+========================================================================================
+ARCHIVO: src/pcobra/gui/runtime.py
+========================================================================================
+
+"""Runtime compartido para las interfaces GUI de Cobra."""
+
+import io
+import importlib.util
+import os
+import re
+import shutil
+import warnings
+from contextlib import redirect_stdout, redirect_stderr
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.packaging import es_paquete_cobra
+from pcobra.corelibs.archivo import _resolver_ruta as resolver_ruta_sandbox
+
+
+@lru_cache(maxsize=1)
+def require_gui_dependencies() -> dict[str, Any]:
+    """Importa dependencias de núcleo/transpiladores de forma diferida."""
+    try:
+        from pcobra.cobra.gui import deps as gui_deps
+    except (
+        ImportError,
+        ModuleNotFoundError,
+    ) as exc:  # pragma: no cover - validado desde CLI
+        missing_target, action = _parse_missing_target(exc)
+        detail = str(exc) or repr(exc)
+        raise RuntimeError(
+            "Error de importación GUI en 'pcobra.gui.runtime': "
+            f"faltante detectado '{missing_target}'. "
+            f"Detalle: {detail}. "
+            f"Acción sugerida: {action}"
+        ) from exc
+
+    return {
+        "Lexer": gui_deps.Lexer,
+        "LexerError": gui_deps.LexerError,
+        "Parser": gui_deps.Parser,
+        "ParserError": gui_deps.ParserError,
+        "target_cli_choices": gui_deps.target_cli_choices,
+        "OFFICIAL_TARGETS": gui_deps.OFFICIAL_TARGETS,
+        "InterpretadorCobra": gui_deps.InterpretadorCobra,
+        "TRANSPILERS": gui_deps.get_transpilers(),
+    }
+
+
+def _parse_missing_target(exc: ImportError) -> tuple[str, str]:
+    """Detecta el objetivo de importación faltante y sugiere acción."""
+    detail = str(exc) or repr(exc)
+    if isinstance(exc, ModuleNotFoundError):
+        missing_module = getattr(exc, "name", None) or "desconocido"
+        return missing_module, _dependency_action(missing_module)
+
+    cannot_import_match = re.search(
+        r"cannot import name '([^']+)' from '([^']+)'", detail
+    )
+    if cannot_import_match:
+        symbol_name, module_name = cannot_import_match.groups()
+        target = f"{module_name}.{symbol_name}"
+        return target, _local_import_action(module_name, symbol_name)
+
+    missing_module = getattr(exc, "name", None) or "desconocido"
+    return missing_module, _dependency_action(missing_module)
+
+
+def _dependency_action(missing_module: str) -> str:
+    if missing_module.startswith("pcobra."):
+        return (
+            "corrige el import local y verifica que el módulo exista; "
+            "si hace falta reinstala con 'pip install -e .'."
+        )
+    return f"instala la dependencia que provee '{missing_module}' o ajusta el import local."
+
+
+def _local_import_action(module_name: str, symbol_name: str) -> str:
+    return (
+        f"corrige el import local de '{module_name}.{symbol_name}' "
+        "o actualiza la dependencia que lo expone."
+    )
+
+
+TIPO_ARCHIVO_COBRA = "cobra"
+TIPO_ARCHIVO_PAQUETE_COBRA = "paquete_cobra"
+TIPO_ARCHIVO_MARKDOWN = "markdown"
+TIPO_ARCHIVO_TEXTO = "texto"
+TIPO_ARCHIVO_CONFIG = "config"
+TIPO_ARCHIVO_DOCKER = "docker"
+TIPO_ARCHIVO_IGNORE = "ignore"
+TIPO_ARCHIVO_ENV_EXAMPLE = "env_example"
+TIPO_ARCHIVO_DESCONOCIDO = "desconocido"
+
+ACCION_EDITAR = "editar"
+ACCION_GUARDAR = "guardar"
+ACCION_RECARGAR = "recargar"
+ACCION_BORRAR = "borrar"
+ACCION_EJECUTAR = "ejecutar"
+ACCION_TOKENS = "tokens"
+ACCION_AST = "ast"
+ACCION_SUGERENCIAS = "sugerencias"
+ACCION_CORRECCION = "correccion"
+ACCION_ABRIR_PAQUETE = "abrir_paquete"
+ACCION_VALIDAR_PAQUETE = "validar_paquete"
+ACCION_CONSTRUIR_PAQUETE = "construir_paquete"
+ACCION_PUBLICAR_PAQUETE = "publicar_paquete"
+
+ACCIONES_ARCHIVO_BASE: frozenset[str] = frozenset(
+    {ACCION_EDITAR, ACCION_GUARDAR, ACCION_RECARGAR, ACCION_BORRAR}
+)
+"""Acciones comunes para archivos manipulables desde la GUI."""
+
+ACCIONES_ARCHIVO_COBRA: frozenset[str] = ACCIONES_ARCHIVO_BASE | frozenset(
+    {
+        ACCION_EJECUTAR,
+        ACCION_TOKENS,
+        ACCION_AST,
+        ACCION_SUGERENCIAS,
+        ACCION_CORRECCION,
+    }
+)
+"""Acciones disponibles para archivos Cobra."""
+
+ACCIONES_PAQUETE_COBRA: frozenset[str] = frozenset(
+    {
+        ACCION_ABRIR_PAQUETE,
+        ACCION_VALIDAR_PAQUETE,
+        ACCION_CONSTRUIR_PAQUETE,
+        ACCION_PUBLICAR_PAQUETE,
+    }
+)
+"""Acciones disponibles para paquetes Cobra ``.co``."""
+
+COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".cobra", ".co")
+"""Extensiones Cobra aceptadas y priorizadas para el explorador del IDLE."""
+
+MARKDOWN_FILE_EXTENSIONS: frozenset[str] = frozenset({".md", ".markdown"})
+TEXT_FILE_EXTENSIONS: frozenset[str] = frozenset({".txt"})
+CONFIG_FILE_EXTENSIONS: frozenset[str] = frozenset({".json", ".yml", ".yaml", ".toml"})
+IGNORE_FILE_NAMES: frozenset[str] = frozenset({".gitignore", ".dockerignore"})
+ENV_EXAMPLE_FILE_NAMES: frozenset[str] = frozenset({".env.example"})
+"""Nombres especiales de archivos de entorno de ejemplo."""
+
+CAPACIDADES_POR_TIPO: dict[str, frozenset[str]] = {
+    TIPO_ARCHIVO_COBRA: ACCIONES_ARCHIVO_COBRA,
+    TIPO_ARCHIVO_PAQUETE_COBRA: ACCIONES_PAQUETE_COBRA,
+    TIPO_ARCHIVO_MARKDOWN: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_TEXTO: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_CONFIG: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_DOCKER: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_IGNORE: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_ENV_EXAMPLE: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_DESCONOCIDO: ACCIONES_ARCHIVO_BASE,
+}
+"""Acciones permitidas por tipo de archivo detectado."""
+
+ETIQUETAS_TIPO_ARCHIVO: dict[str, str] = {
+    TIPO_ARCHIVO_COBRA: "Archivo Cobra",
+    TIPO_ARCHIVO_PAQUETE_COBRA: "Paquete Cobra",
+    TIPO_ARCHIVO_MARKDOWN: "Archivo Markdown",
+    TIPO_ARCHIVO_TEXTO: "Archivo de texto",
+    TIPO_ARCHIVO_CONFIG: "Archivo de configuración",
+    TIPO_ARCHIVO_DOCKER: "Archivo Docker",
+    TIPO_ARCHIVO_IGNORE: "Archivo ignore",
+    TIPO_ARCHIVO_ENV_EXAMPLE: "Archivo de entorno de ejemplo",
+    TIPO_ARCHIVO_DESCONOCIDO: "Archivo de texto",
+}
+"""Etiquetas visibles por tipo de archivo detectado."""
+
+MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE = True
+"""Bandera interna para exponer archivos desconocidos como texto plano.
+
+El valor por defecto muestra también los archivos no clasificados del proyecto
+activo para que puedan abrirse como texto plano desde el árbol del IDLE. Estas
+rutas conservan solo acciones base de archivo: nunca habilitan ejecución,
+tokens, AST, sugerencias ni corrección Cobra.
+"""
+
+SUGERENCIAS_BUTTON_TEXT = "Sugerencias del Libro"
+"""Etiqueta homogénea para la acción de sugerencias trazables en las GUIs."""
+
+CORRECCION_BUTTON_TEXT = "Corrección"
+"""Etiqueta para solicitar un reporte de corrección tipográfica sin modificar el editor."""
+
+CANONICAL_SUGGESTION_ENGINE = "agix"
+"""Motor opcional canónico para sugerencias de Cobra."""
+
+
+def resolver_workspace_root_idle() -> Path:
+    """Resuelve y crea la raíz de trabajo inicial del IDLE sin usar ``Path.cwd()``."""
+
+    configured_root = os.environ.get("COBRA_PROJECTS_DIR")
+    if configured_root:
+        workspace_root = Path(configured_root).expanduser().resolve()
+    else:
+        workspace_root = (Path.home() / "CobraProjects").expanduser().resolve()
+
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    return workspace_root
+
+
+def resolver_repo_root_gui() -> Path:
+    """Resuelve la raíz del repositorio de Cobra relativa a este módulo GUI."""
+
+    return Path(__file__).resolve().parents[3]
+
+
+def _es_misma_ruta(candidata: Path, prohibida: Path) -> bool:
+    """Compara rutas canónicas usando ``Path.relative_to()`` de forma portable."""
+
+    try:
+        relativa = candidata.relative_to(prohibida)
+    except ValueError:
+        return False
+    return relativa == Path(".")
+
+
+def validar_project_root_idle(project_root: str | Path) -> Path:
+    """Valida que la raíz de proyecto del IDLE no sea una ruta interna del repo.
+
+    El IDLE debe abrir proyectos de usuario, no la raíz del repositorio ni las
+    carpetas de código fuente de la propia aplicación. La comparación usa rutas
+    resueltas y ``Path.relative_to()`` para conservar compatibilidad con Windows.
+    """
+
+    candidata = Path(project_root).expanduser().resolve()
+    repo_root = resolver_repo_root_gui()
+    rutas_prohibidas = {
+        repo_root: "la raíz del repositorio",
+        repo_root / "src": "src/",
+        repo_root / "src" / "pcobra": "src/pcobra/",
+        repo_root / "src" / "pcobra" / "gui": "src/pcobra/gui/",
+    }
+
+    for ruta_prohibida, descripcion in rutas_prohibidas.items():
+        ruta_prohibida_resuelta = ruta_prohibida.resolve()
+        if _es_misma_ruta(candidata, ruta_prohibida_resuelta):
+            raise ValueError(
+                "No se puede abrir como proyecto del IDLE "
+                f"{descripcion}: {ruta_prohibida_resuelta}. "
+                "Elige una carpeta de proyecto fuera del código fuente de Cobra."
+            )
+
+    return candidata
+
+
+@dataclass(frozen=True, slots=True)
+class MotorIASugerencias:
+    """Resultado liviano de disponibilidad del motor IA para sugerencias."""
+
+    disponible: bool
+    nombre: str = CANONICAL_SUGGESTION_ENGINE
+    detalle: str = ""
+
+    @property
+    def tooltip(self) -> str:
+        """Mensaje breve para explicar el estado en la GUI."""
+
+        if self.disponible:
+            return (
+                "Motor IA opcional disponible. "
+                "Las sugerencias validarán primero el código Cobra."
+            )
+        return self.detalle or (
+            "Sugerencias deshabilitadas: instala la dependencia opcional "
+            f"de sugerencias {CANONICAL_SUGGESTION_ENGINE!r} para activar esta acción."
+        )
+
+
+@dataclass(slots=True)
+class GuiFileState:
+    """Estado mínimo del archivo editado en la GUI."""
+
+    ruta: Path | None = None
+    contenido_cargado: str = ""
+    cambios_sin_guardar: bool = False
+
+
+@lru_cache(maxsize=1)
+def detectar_motor_ia_sugerencias() -> MotorIASugerencias:
+    """Detecta de forma liviana si el motor IA opcional está instalado.
+
+    La comprobación usa metadatos de importación y no importa la dependencia
+    opcional ni la fachada de sugerencias, evitando cargar dependencias pesadas
+    al abrir la GUI.
+    """
+
+    try:
+        spec = importlib.util.find_spec(CANONICAL_SUGGESTION_ENGINE)
+    except (ImportError, ModuleNotFoundError, ValueError) as exc:
+        return MotorIASugerencias(
+            disponible=False,
+            detalle=(
+                "Sugerencias deshabilitadas: no se pudo comprobar la "
+                f"dependencia opcional {CANONICAL_SUGGESTION_ENGINE!r} ({exc})."
+            ),
+        )
+
+    if spec is None:
+        return MotorIASugerencias(
+            disponible=False,
+            detalle=(
+                "Sugerencias deshabilitadas: instala la dependencia opcional "
+                f"{CANONICAL_SUGGESTION_ENGINE!r} para activar esta acción."
+            ),
+        )
+    return MotorIASugerencias(disponible=True)
+
+
+def generar_sugerencias(codigo: str) -> list[str]:
+    """Importa bajo demanda la fachada IA y genera sugerencias."""
+
+    from pcobra.ia.analizador_sugerencias import generar_sugerencias as _generar
+
+    return _generar(codigo)
+
+
+def detectar_tipo_archivo(path: str | Path) -> str:
+    """Clasifica una ruta según los tipos de archivo conocidos por la GUI."""
+
+    ruta = Path(path)
+    nombre = ruta.name
+    nombre_lower = nombre.lower()
+    extension = ruta.suffix.lower()
+
+    if (
+        nombre == "Dockerfile"
+        or nombre.startswith("Dockerfile.")
+        or nombre == "docker-compose.yml"
+    ):
+        return TIPO_ARCHIVO_DOCKER
+    if extension == ".co" and es_paquete_cobra(ruta):
+        return TIPO_ARCHIVO_PAQUETE_COBRA
+    if extension in COBRA_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_COBRA
+    if extension in MARKDOWN_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_MARKDOWN
+    if extension in TEXT_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_TEXTO
+    if extension in CONFIG_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_CONFIG
+    if nombre_lower in IGNORE_FILE_NAMES:
+        return TIPO_ARCHIVO_IGNORE
+    if nombre_lower in ENV_EXAMPLE_FILE_NAMES:
+        return TIPO_ARCHIVO_ENV_EXAMPLE
+    return TIPO_ARCHIVO_DESCONOCIDO
+
+
+def etiqueta_tipo_archivo(path: str | Path) -> str:
+    """Devuelve la etiqueta visible para el tipo detectado de una ruta."""
+
+    tipo_archivo = detectar_tipo_archivo(path)
+    return ETIQUETAS_TIPO_ARCHIVO.get(
+        tipo_archivo, ETIQUETAS_TIPO_ARCHIVO[TIPO_ARCHIVO_DESCONOCIDO]
+    )
+
+
+def obtener_capacidades_archivo(path: str | Path) -> frozenset[str]:
+    """Devuelve las acciones permitidas para el tipo detectado de una ruta."""
+
+    tipo_archivo = detectar_tipo_archivo(path)
+    return CAPACIDADES_POR_TIPO.get(tipo_archivo, ACCIONES_ARCHIVO_BASE)
+
+
+def archivo_permite_accion(path: str | Path, accion: str) -> bool:
+    """Indica si una ruta permite ejecutar una acción concreta en la GUI."""
+
+    return accion in obtener_capacidades_archivo(path)
+
+
+def es_archivo_cobra(path: str | Path) -> bool:
+    """Indica si una ruta parece contener código Cobra editable."""
+
+    return detectar_tipo_archivo(path) == TIPO_ARCHIVO_COBRA
+
+
+def es_paquete_cobra_gui(path: str | Path) -> bool:
+    """Indica si una ruta es un paquete Cobra ``.co`` no editable como texto."""
+
+    return detectar_tipo_archivo(path) == TIPO_ARCHIVO_PAQUETE_COBRA
+
+
+def resolver_ruta_archivo_en_project_root(
+    ruta: str | Path, project_root: str | Path
+) -> Path:
+    """Resuelve una ruta de archivo Cobra dentro de la raíz del proyecto IDLE.
+
+    Las rutas relativas se interpretan desde ``project_root`` y las absolutas
+    se aceptan únicamente si su ruta canónica queda dentro de esa raíz. La
+    resolución con ``Path.resolve()`` y la validación con ``Path.relative_to()``
+    bloquean escapes mediante ``..`` y enlaces simbólicos externos.
+    """
+
+    raiz = Path(project_root).expanduser().resolve()
+    if raiz.exists() and not raiz.is_dir():
+        raise NotADirectoryError(f"La raíz del proyecto debe ser un directorio: {raiz}")
+
+    ruta_expandida = Path(ruta).expanduser()
+    ruta_con_extension = (
+        ruta_expandida.with_suffix(".cobra")
+        if not ruta_expandida.suffix
+        else ruta_expandida
+    )
+    if ruta_con_extension.suffix.lower() not in COBRA_FILE_EXTENSIONS:
+        raise ValueError("El archivo debe usar la extensión .cobra o .co.")
+
+    candidata_original = (
+        ruta_expandida if ruta_expandida.is_absolute() else raiz / ruta_expandida
+    ).resolve()
+    if candidata_original.exists() and candidata_original.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; indica un archivo Cobra."
+        )
+
+    candidata = (
+        ruta_con_extension
+        if ruta_con_extension.is_absolute()
+        else raiz / ruta_con_extension
+    )
+    ruta_resuelta = candidata.resolve()
+
+    try:
+        ruta_resuelta.relative_to(raiz)
+    except ValueError as exc:
+        raise ValueError(
+            f"La ruta del archivo debe estar dentro de la raíz del proyecto: {raiz}"
+        ) from exc
+
+    if ruta_resuelta.exists() and ruta_resuelta.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; indica un archivo Cobra."
+        )
+
+    return ruta_resuelta
+
+
+def resolver_ruta_texto_en_project_root(
+    ruta: str | Path, project_root: str | Path
+) -> Path:
+    """Resuelve una ruta de archivo de texto dentro de ``project_root``.
+
+    Las rutas relativas se interpretan desde ``project_root``. Las rutas
+    absolutas se aceptan solo si su ruta canónica queda dentro de esa raíz.
+    ``Path.resolve()`` junto con ``Path.relative_to()`` bloquea escapes con
+    ``..`` y enlaces simbólicos externos. Este helper no añade extensiones ni
+    exige que el archivo sea Cobra.
+    """
+
+    raiz = Path(project_root).expanduser().resolve()
+    if raiz.exists() and not raiz.is_dir():
+        raise NotADirectoryError(f"La raíz del proyecto debe ser un directorio: {raiz}")
+
+    ruta_expandida = Path(ruta).expanduser()
+    candidata = (
+        ruta_expandida if ruta_expandida.is_absolute() else raiz / ruta_expandida
+    )
+    ruta_resuelta = candidata.resolve()
+
+    try:
+        ruta_resuelta.relative_to(raiz)
+    except ValueError as exc:
+        raise ValueError(
+            f"La ruta del archivo debe estar dentro de la raíz del proyecto: {raiz}"
+        ) from exc
+
+    if ruta_resuelta.exists() and ruta_resuelta.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; "
+            "indica un archivo de texto del proyecto."
+        )
+
+    return ruta_resuelta
+
+
+TIPOS_ARCHIVO_TEXTO_IDLE: frozenset[str] = frozenset(CAPACIDADES_POR_TIPO)
+"""Tipos de archivo no directorio visibles y abribles como texto en el IDLE."""
+
+
+def listar_directorio_idle(
+    root: str | Path,
+    *,
+    incluir_desconocidos: bool = MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE,
+) -> list[Path]:
+    """Lista carpetas y archivos visibles del IDLE, con orden estable.
+
+    La política general muestra siempre directorios, archivos Cobra y archivos
+    auxiliares de texto/configuración clasificados por ``detectar_tipo_archivo()``
+    (por ejemplo Markdown, TXT, JSON/YAML/TOML, Dockerfile, ignore y
+    ``.env.example``). ``incluir_desconocidos`` permite ocultar o exponer archivos
+    no clasificados, que se tratan únicamente como texto plano.
+    """
+
+    base = Path(root).expanduser()
+    entradas = list(base.iterdir())
+    visibles = []
+    for entry in entradas:
+        if entry.is_dir():
+            visibles.append(entry)
+            continue
+        tipo_archivo = detectar_tipo_archivo(entry)
+        if tipo_archivo == TIPO_ARCHIVO_DESCONOCIDO:
+            if incluir_desconocidos:
+                visibles.append(entry)
+            continue
+        if tipo_archivo in TIPOS_ARCHIVO_TEXTO_IDLE:
+            visibles.append(entry)
+
+    return sorted(visibles, key=lambda entry: (not entry.is_dir(), entry.name.lower()))
+
+
+def listar_directorio_cobra(
+    root: str | Path,
+    *,
+    mostrar_todos: bool = MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE,
+) -> list[Path]:
+    """Lista entradas visibles del IDLE usando la política general actual.
+
+    Legado: se conserva por compatibilidad con integraciones que aún llaman al
+    helper histórico centrado en Cobra. Delegue nuevo código en
+    ``listar_directorio_idle()``. El parámetro ``mostrar_todos`` se conserva como
+    alias compatible para incluir archivos desconocidos como texto plano.
+    """
+
+    return listar_directorio_idle(root, incluir_desconocidos=mostrar_todos)
+
+
+def normalizar_ruta_archivo_gui(path: str | Path) -> Path:
+    """Normaliza rutas de la GUI según el sandbox Cobra compartido."""
+
+    return resolver_ruta_sandbox(path, permitir_absoluta_dentro_base=True)
+
+
+def leer_archivo_texto(path: str | Path, *, encoding: str = "utf-8") -> str:
+    """Lee un archivo Cobra como texto UTF-8 dentro del sandbox configurado."""
+
+    return normalizar_ruta_archivo_gui(path).read_text(encoding=encoding)
+
+
+def escribir_archivo_texto(
+    path: str | Path, contenido: str | None, *, encoding: str = "utf-8"
+) -> str:
+    """Escribe una sola vez el contenido normalizado del editor y lo devuelve."""
+
+    codigo = normalizar_codigo(contenido)
+    destino = normalizar_ruta_archivo_gui(path)
+    destino.write_text(codigo, encoding=encoding)
+    return codigo
+
+
+def crear_titulo_archivo(estado: GuiFileState) -> str:
+    """Devuelve la etiqueta común del archivo activo en la GUI."""
+
+    if estado.ruta is None:
+        nombre = "Archivo nuevo (sin guardar)"
+    else:
+        nombre = f"{etiqueta_tipo_archivo(estado.ruta)}: {estado.ruta}"
+    return f"{nombre}{' *' if estado.cambios_sin_guardar else ''}"
+
+
+def marcar_cambios_editor(estado: GuiFileState, contenido: str | None) -> bool:
+    """Actualiza el estado sucio comparando editor y contenido cargado."""
+
+    estado.cambios_sin_guardar = (
+        normalizar_codigo(contenido) != estado.contenido_cargado
+    )
+    return estado.cambios_sin_guardar
+
+
+def nuevo_archivo(estado: GuiFileState) -> str:
+    """Reinicia el estado de archivo y devuelve contenido vacío para el editor."""
+
+    estado.ruta = None
+    estado.contenido_cargado = ""
+    estado.cambios_sin_guardar = False
+    return ""
+
+
+def cargar_archivo_en_estado(ruta: str | Path, estado: GuiFileState) -> str:
+    """Carga un archivo de texto, actualiza estado y devuelve su contenido."""
+
+    ruta_resuelta = normalizar_ruta_archivo_gui(ruta)
+    contenido = leer_archivo_texto(ruta_resuelta)
+    estado.ruta = ruta_resuelta
+    estado.contenido_cargado = contenido
+    estado.cambios_sin_guardar = False
+    return contenido
+
+
+def guardar_archivo_en_estado(
+    ruta: str | Path, contenido: str | None, estado: GuiFileState
+) -> str:
+    """Guarda contenido del editor, actualiza estado y devuelve el texto guardado."""
+
+    ruta_resuelta = normalizar_ruta_archivo_gui(ruta)
+    contenido_guardado = escribir_archivo_texto(ruta_resuelta, contenido)
+    estado.ruta = ruta_resuelta
+    estado.contenido_cargado = contenido_guardado
+    estado.cambios_sin_guardar = False
+    return contenido_guardado
+
+
+def construir_entradas_directorio(
+    directorio: str | Path,
+) -> tuple[Path | None, list[tuple[str, Path]]]:
+    """Devuelve padre opcional y entradas visibles para renderizar árboles GUI."""
+
+    actual = Path(directorio).expanduser().resolve()
+    padre = actual.parent if actual.parent != actual else None
+    entradas = [
+        ("dir" if ruta.is_dir() else "file", ruta)
+        for ruta in listar_directorio_idle(actual)
+    ]
+    return padre, entradas
+
+
+def crear_archivo_nuevo_en_editor(estado: GuiFileState) -> tuple[str, str]:
+    """Prepara un archivo nuevo y devuelve contenido/mensaje para la GUI."""
+
+    return nuevo_archivo(estado), "Archivo nuevo creado en memoria."
+
+
+def abrir_archivo_desde_ruta(ruta: str | Path, estado: GuiFileState) -> tuple[str, str]:
+    """Abre una ruta de archivo, actualiza estado y devuelve contenido/mensaje."""
+
+    contenido = cargar_archivo_en_estado(ruta, estado)
+    return contenido, f"Archivo cargado: {estado.ruta}"
+
+
+def guardar_archivo_activo(
+    contenido: str | None, estado: GuiFileState
+) -> tuple[str, str]:
+    """Guarda el archivo activo y devuelve contenido normalizado/mensaje."""
+
+    if estado.ruta is None:
+        raise ValueError("No hay archivo activo que guardar.")
+    contenido_guardado = guardar_archivo_en_estado(estado.ruta, contenido, estado)
+    return contenido_guardado, f"Archivo guardado: {estado.ruta}"
+
+
+def guardar_archivo_como(
+    ruta: str | Path, contenido: str | None, estado: GuiFileState
+) -> tuple[str, str]:
+    """Guarda el editor en una ruta nueva y devuelve contenido/mensaje."""
+
+    contenido_guardado = guardar_archivo_en_estado(ruta, contenido, estado)
+    return contenido_guardado, f"Archivo guardado: {estado.ruta}"
+
+
+def escribir_archivo_texto_validado(
+    path: str | Path, contenido: str | None, *, encoding: str = "utf-8"
+) -> str:
+    """Escribe en una ruta ya validada por el IDLE principal.
+
+    Esta función no revalida contra el sandbox global porque el flujo del IDLE
+    principal ya validó la ruta contra project_root mediante
+    resolver_ruta_texto_en_project_root().
+    """
+
+    destino = Path(path).expanduser().resolve()
+    if destino.exists() and destino.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; indica un archivo de texto del proyecto."
+        )
+
+    destino.parent.mkdir(parents=True, exist_ok=True)
+    codigo = normalizar_codigo(contenido)
+    destino.write_text(codigo, encoding=encoding)
+    return codigo
+
+
+def guardar_archivo_como_validado(
+    ruta: str | Path, contenido: str | None, estado: GuiFileState
+) -> tuple[str, str]:
+    """Guarda un archivo cuya ruta ya fue validada contra project_root."""
+
+    destino = Path(ruta).expanduser().resolve()
+    codigo = escribir_archivo_texto_validado(destino, contenido)
+    estado.ruta = destino
+    estado.contenido_cargado = codigo
+    estado.cambios_sin_guardar = False
+    return codigo, f"Archivo guardado: {destino}"
+
+
+def guardar_archivo_activo_validado(
+    contenido: str | None, estado: GuiFileState
+) -> tuple[str, str]:
+    """Guarda el archivo activo cuya ruta ya fue validada contra project_root."""
+
+    if estado.ruta is None:
+        raise ValueError("No hay archivo activo que guardar.")
+
+    destino = Path(estado.ruta).expanduser().resolve()
+    codigo = escribir_archivo_texto_validado(destino, contenido)
+    estado.ruta = destino
+    estado.contenido_cargado = codigo
+    estado.cambios_sin_guardar = False
+    return codigo, f"Archivo guardado: {destino}"
+
+
+def eliminar_archivo_validado(ruta: Path) -> None:
+    """Elimina un archivo cuya ruta ya fue validada por el IDLE principal."""
+
+    destino = Path(ruta).resolve()
+    if not destino.exists():
+        raise FileNotFoundError(
+            f"No existe el archivo que se quiere eliminar: {destino}"
+        )
+    if not destino.is_file():
+        raise ValueError(f"La ruta indicada no es un archivo: {destino}")
+    destino.unlink()
+
+
+def validar_y_crear_carpeta_idle(
+    ruta: str | Path, project_root: str | Path, workspace_root: str | Path
+) -> Path:
+    """Valida y crea una carpeta dentro del proyecto activo.
+
+    Bloquea escapes con ``..``, rutas absolutas externas y la creación de la
+    propia raíz del proyecto o del workspace.
+    """
+    project_root_resuelto = Path(project_root).expanduser().resolve()
+    workspace_root_resuelto = Path(workspace_root).expanduser().resolve()
+
+    if not project_root_resuelto.is_dir():
+        raise NotADirectoryError(
+            f"La raíz del proyecto no es un directorio: {project_root_resuelto}"
+        )
+
+    ruta_expandida = Path(ruta).expanduser()
+    if ruta_expandida.is_absolute():
+        raise ValueError("La ruta de la carpeta debe ser relativa al proyecto.")
+
+    # Construir la ruta candidata y resolverla para detectar escapes
+    candidata = (project_root_resuelto / ruta_expandida).resolve()
+
+    try:
+        candidata.relative_to(project_root_resuelto)
+    except ValueError as exc:
+        raise ValueError(
+            f"La ruta de la carpeta debe estar dentro del proyecto activo: {project_root_resuelto}"
+        ) from exc
+
+    if candidata == project_root_resuelto:
+        raise ValueError("No se puede crear la raíz del proyecto como una carpeta.")
+    if candidata == workspace_root_resuelto:
+        raise ValueError("No se puede crear la raíz del workspace como una carpeta.")
+
+    candidata.mkdir(parents=True, exist_ok=True)
+    return candidata
+
+
+def eliminar_directorio_validado(ruta: Path) -> None:
+    """Elimina un directorio cuya ruta ya fue validada por el IDLE principal."""
+
+    destino = Path(ruta).resolve()
+    if not destino.exists():
+        raise FileNotFoundError(
+            f"No existe el directorio que se quiere eliminar: {destino}"
+        )
+    if not destino.is_dir():
+        raise NotADirectoryError(f"La ruta indicada no es un directorio: {destino}")
+    shutil.rmtree(destino)
+
+
+def eliminar_proyecto_validado(project_root: Path, workspace_root: Path) -> None:
+    """Elimina un proyecto cuya raíz ya fue validada por el IDLE principal."""
+
+    proyecto = Path(project_root).resolve()
+    workspace = Path(workspace_root).resolve()
+    if proyecto == workspace:
+        raise ValueError("No se puede eliminar la raíz completa del workspace.")
+    if proyecto.parent != workspace:
+        raise ValueError(
+            "La raíz del proyecto debe ser hija directa de la raíz del workspace."
+        )
+    if not proyecto.exists():
+        raise FileNotFoundError(
+            f"No existe el proyecto que se quiere eliminar: {proyecto}"
+        )
+    if not proyecto.is_dir():
+        raise NotADirectoryError(
+            f"La ruta del proyecto no es un directorio: {proyecto}"
+        )
+    shutil.rmtree(proyecto)
+
+
+def leer_archivo_texto_validado(path: str | Path, *, encoding: str = "utf-8") -> str:
+    """Lee una ruta ya validada por el IDLE principal."""
+
+    origen = Path(path).expanduser().resolve()
+    if origen.exists() and origen.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; indica un archivo de texto del proyecto."
+        )
+    return origen.read_text(encoding=encoding)
+
+
+def abrir_archivo_desde_ruta_validada(
+    ruta: str | Path, estado: GuiFileState
+) -> tuple[str, str]:
+    """Abre un archivo cuya ruta ya fue validada contra project_root."""
+
+    origen = Path(ruta).expanduser().resolve()
+    contenido = leer_archivo_texto_validado(origen)
+    estado.ruta = origen
+    estado.contenido_cargado = contenido
+    estado.cambios_sin_guardar = False
+    return contenido, f"Archivo cargado: {origen}"
+
+
+def recargar_archivo_activo_validado(
+    estado: GuiFileState,
+) -> tuple[str, str]:
+    """Recarga el archivo activo cuya ruta ya fue validada contra project_root."""
+
+    if estado.ruta is None:
+        raise ValueError("No hay archivo activo que recargar.")
+
+    origen = Path(estado.ruta).expanduser().resolve()
+    contenido = leer_archivo_texto_validado(origen)
+    estado.ruta = origen
+    estado.contenido_cargado = contenido
+    estado.cambios_sin_guardar = False
+    return contenido, f"Archivo cargado: {origen}"
+
+
+def recargar_archivo_activo(estado: GuiFileState) -> tuple[str, str]:
+    """Recarga el archivo activo desde disco y devuelve contenido/mensaje."""
+
+    if estado.ruta is None:
+        raise ValueError("No hay archivo activo que recargar.")
+    return abrir_archivo_desde_ruta(estado.ruta, estado)
+
+
+def cargar_archivo_desde_arbol(
+    ruta: str | Path, estado: GuiFileState
+) -> tuple[str, str]:
+    """Carga una entrada de árbol si es un archivo de texto clasificado."""
+
+    origen = Path(ruta).expanduser().resolve()
+    if origen.exists() and origen.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; "
+            "indica un archivo de texto del proyecto."
+        )
+
+    tipo_archivo = detectar_tipo_archivo(origen)
+    if tipo_archivo == TIPO_ARCHIVO_PAQUETE_COBRA:
+        estado.ruta = origen
+        estado.contenido_cargado = ""
+        estado.cambios_sin_guardar = False
+        return "", (
+            f"Paquete Cobra seleccionado: {origen}. "
+            "Usa Abrir paquete, Validar paquete o Publicar CobraHub."
+        )
+
+    if tipo_archivo not in TIPOS_ARCHIVO_TEXTO_IDLE:
+        raise ValueError("Selecciona un archivo de texto del proyecto.")
+
+    return abrir_archivo_desde_ruta_validada(origen, estado)
+
+
+def require_flet() -> Any:
+    """Importa Flet de forma diferida para no romper imports de CLI."""
+    try:
+        import flet as ft
+    except ModuleNotFoundError as exc:  # pragma: no cover - validado desde CLI
+        raise RuntimeError(
+            "Falta la dependencia 'flet'. Ejecuta: pip install flet."
+        ) from exc
+    return ft
+
+
+def require_flet_code_editor() -> Any:
+    """Importa el editor de código de forma diferida para preservar la CLI."""
+
+    try:
+        from flet_code_editor import CodeEditor
+    except ModuleNotFoundError as exc:  # pragma: no cover - validado desde CLI
+        raise RuntimeError(
+            "Falta la dependencia 'flet-code-editor'. "
+            "Ejecuta: pip install flet-code-editor."
+        ) from exc
+    return CodeEditor
+
+
+def _flet_attr(ft: Any, attr_name: str, api_name: str) -> Any:
+    """Devuelve una API raíz de Flet o falla con un mensaje homogéneo."""
+
+    attr = getattr(ft, attr_name, None)
+    if attr is None:
+        raise RuntimeError(f"La versión instalada de 'flet' no expone {api_name}.")
+    return attr
+
+
+def flet_app(target: Any, *args: Any, ft: Any | None = None, **kwargs: Any) -> Any:
+    """Lanza ``ft.app`` desde un único adaptador compatible."""
+
+    flet_runtime = ft if ft is not None else require_flet()
+    app_factory = _flet_attr(flet_runtime, "app", "app")
+    return app_factory(*args, target=target, **kwargs)
+
+
+def flet_text_field(ft: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.TextField`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "TextField", "TextField")(**kwargs)
+
+
+def flet_text(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Text`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Text", "Text")(*args, **kwargs)
+
+
+def flet_dropdown(ft: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Dropdown`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Dropdown", "Dropdown")(**kwargs)
+
+
+def flet_switch(ft: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Switch`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Switch", "Switch")(**kwargs)
+
+
+def flet_elevated_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.ElevatedButton`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "ElevatedButton", "ElevatedButton")(*args, **kwargs)
+
+
+def _crear_boton_motor_ia(ft: Any, texto: str, *, on_click: Any) -> Any:
+    """Crea un botón dependiente del motor IA opcional de sugerencias."""
+
+    motor = detectar_motor_ia_sugerencias()
+    return flet_elevated_button(
+        ft,
+        texto,
+        on_click=on_click if motor.disponible else None,
+        disabled=not motor.disponible,
+        tooltip=motor.tooltip,
+    )
+
+
+def crear_boton_sugerencias_libro(ft: Any, *, on_click: Any) -> Any:
+    """Crea el botón de sugerencias con estado visual según motor IA."""
+
+    return _crear_boton_motor_ia(ft, SUGERENCIAS_BUTTON_TEXT, on_click=on_click)
+
+
+def crear_boton_correccion(ft: Any, *, on_click: Any) -> Any:
+    """Crea el botón visible de corrección sin modificar automáticamente el editor."""
+
+    return _crear_boton_motor_ia(ft, CORRECCION_BUTTON_TEXT, on_click=on_click)
+
+
+def flet_text_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.TextButton`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "TextButton", "TextButton")(*args, **kwargs)
+
+
+def flet_row(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Row`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Row", "Row")(*args, **kwargs)
+
+
+def flet_column(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Column`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Column", "Column")(*args, **kwargs)
+
+
+def flet_container(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Container`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Container", "Container")(*args, **kwargs)
+
+
+def flet_list_view(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.ListView`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "ListView", "ListView")(*args, **kwargs)
+
+
+def flet_dropdown_option(ft: Any, value: str) -> Any:
+    """Crea una opción de Dropdown compatible con versiones recientes de Flet."""
+
+    option_factory = getattr(ft, "Option", None)
+    if option_factory is not None:
+        return option_factory(value)
+
+    dropdown_module = getattr(ft, "dropdown", None)
+    option_factory = getattr(dropdown_module, "Option", None)
+    if option_factory is None:
+        raise RuntimeError(
+            "La versión instalada de 'flet' no expone Option ni dropdown.Option."
+        )
+    return option_factory(value)
+
+
+class EditorCodigo:
+    """Adapta el control visual usado como editor de código.
+
+    El resto de la GUI depende de estas operaciones y no de los atributos
+    concretos de ``TextField``, lo que permite sustituir el control visual sin
+    propagar detalles de Flet.
+    """
+
+    def __init__(self, control: Any) -> None:
+        self._control = control
+
+    def obtener_contenido(self) -> str:
+        """Devuelve el texto actual del editor, normalizando valores nulos."""
+
+        return normalizar_codigo(self._control.value)
+
+    def establecer_contenido(self, contenido: str | None) -> None:
+        """Reemplaza el texto mostrado por ``contenido``."""
+
+        self._control.value = normalizar_codigo(contenido)
+
+    def limpiar(self) -> None:
+        """Vacía el contenido del editor."""
+
+        self.establecer_contenido("")
+
+    def solicitar_foco(self) -> Any:
+        """Solicita el foco mediante la API del control visual."""
+
+        return self._control.focus()
+
+    def registrar_callback_cambios(self, callback: Any) -> None:
+        """Registra el callback invocado cuando cambia el contenido."""
+
+        self._control.on_change = callback
+
+    def registrar_callback_seleccion(self, callback: Any) -> None:
+        """Registra el callback público de cambios de selección."""
+
+        self._control.on_selection_change = callback
+
+    def obtener_control(self) -> Any:
+        """Devuelve el control visual que debe incorporarse al layout."""
+
+        return self._control
+
+
+def crear_editor_codigo(ft: Any, **kwargs: Any) -> EditorCodigo:
+    """Crea el adaptador del ``CodeEditor`` compartido por las interfaces."""
+
+    opciones = {"expand": True}
+    opciones.update(kwargs)
+    # La fábrica privada solo permite aislar la extensión en dobles de prueba;
+    # la aplicación real siempre obtiene el control del paquete oficial.
+    fabrica = getattr(ft, "_code_editor_factory", None) or require_flet_code_editor()
+    return EditorCodigo(fabrica(**opciones))
+
+
+def ajustar_indentacion_editor(
+    texto: str,
+    inicio: int,
+    fin: int,
+    direccion: str,
+) -> tuple[str, int, int]:
+    """Aplica un nivel de cuatro espacios y devuelve texto y selección.
+
+    ``direccion`` admite ``"indentar"`` y ``"desindentar"``. Los extremos son
+    offsets de caracteres y pueden venir invertidos. Sin selección, indentar
+    inserta exactamente cuatro espacios. Al desindentar se retiran, por cada
+    línea intersectada, hasta cuatro espacios iniciales o un tabulador literal.
+    """
+
+    if direccion not in {"indentar", "desindentar"}:
+        raise ValueError("direccion debe ser 'indentar' o 'desindentar'")
+    if not 0 <= inicio <= len(texto) or not 0 <= fin <= len(texto):
+        raise ValueError("los extremos deben estar dentro del texto")
+
+    if inicio == fin and direccion == "indentar":
+        return texto[:inicio] + "    " + texto[inicio:], inicio + 4, fin + 4
+
+    menor, mayor = sorted((inicio, fin))
+    inicio_linea = texto.rfind("\n", 0, menor) + 1
+    # Una selección que termina justo al comienzo de una línea no la intersecta.
+    limite = mayor - 1 if mayor > menor and texto[mayor - 1 : mayor] == "\n" else mayor
+    inicios = [inicio_linea]
+    posicion = texto.find("\n", inicio_linea, limite)
+    while posicion != -1:
+        inicios.append(posicion + 1)
+        posicion = texto.find("\n", posicion + 1, limite)
+
+    cambios: list[tuple[int, int, str]] = []
+    for posicion in inicios:
+        if direccion == "indentar":
+            cambios.append((posicion, 0, "    "))
+            continue
+        if texto.startswith("\t", posicion):
+            cambios.append((posicion, 1, ""))
+        else:
+            espacios = len(texto[posicion : posicion + 4]) - len(
+                texto[posicion : posicion + 4].lstrip(" ")
+            )
+            if espacios:
+                cambios.append((posicion, espacios, ""))
+
+    def trasladar(extremo: int) -> int:
+        desplazamiento = 0
+        for posicion, eliminados, agregado in cambios:
+            if extremo < posicion:
+                continue
+            if extremo <= posicion + eliminados:
+                return posicion + desplazamiento + len(agregado)
+            desplazamiento += len(agregado) - eliminados
+        return extremo + desplazamiento
+
+    partes: list[str] = []
+    cursor = 0
+    for posicion, eliminados, agregado in cambios:
+        partes.extend((texto[cursor:posicion], agregado))
+        cursor = posicion + eliminados
+    partes.append(texto[cursor:])
+    return "".join(partes), trasladar(inicio), trasladar(fin)
+
+
+def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
+    """Crea la salida seleccionable compartida por la app mínima y el IDLE."""
+
+    opciones = {"value": "", "selectable": True}
+    opciones.update(kwargs)
+    return flet_text(ft, **opciones)
+
+
+def crear_arbol_directorios(
+    ft: Any, *, on_click: Any, root_path: str | Path | None = None
+) -> Any:
+    """Crea un árbol de directorios con carga diferida de subcarpetas.
+
+    Si no se proporciona ``root_path``, usa la raíz de trabajo canónica del
+    IDLE como fallback explícito en lugar de depender del directorio actual del
+    proceso.
+    """
+    if root_path is None:
+        root_path = resolver_workspace_root_idle()
+
+    def _crear_nodo_archivo(path: Path) -> Any:
+        return ft.ListTile(
+            title=ft.Text(path.name),
+            leading=ft.Icon(ft.Icons.INSERT_DRIVE_FILE),
+            data=str(path),
+            on_click=on_click,
+        )
+
+    def _crear_nodo_directorio(path: Path) -> Any:
+        tile = ft.ExpansionTile(
+            title=ft.Text(path.name),
+            leading=ft.Icon(ft.Icons.FOLDER),
+            controls=[],
+        )
+        tile.data = {"path": path, "children_loaded": False}
+
+        def _cargar_hijos_al_expandir(_e: Any) -> None:
+            data = getattr(tile, "data", {})
+            if data.get("children_loaded"):
+                return
+            tile.controls = [
+                _crear_nodo(entrada) for entrada in listar_directorio_idle(path)
+            ]
+            data["children_loaded"] = True
+            tile.data = data
+            update = getattr(tile, "update", None)
+            if callable(update):
+                update()
+
+        tile.on_change = _cargar_hijos_al_expandir
+        return tile
+
+    def _crear_nodo(path: Path) -> Any:
+        if path.is_dir():
+            return _crear_nodo_directorio(path)
+        return _crear_nodo_archivo(path)
+
+    entradas = listar_directorio_idle(root_path)
+    if not entradas:
+        return ft.Column(
+            [flet_text(ft, value="No hay archivos visibles en esta carpeta")],
+            scroll=ft.ScrollMode.ALWAYS,
+        )
+
+    elementos_arbol = [_crear_nodo(entrada) for entrada in entradas]
+
+    return ft.Column(elementos_arbol, scroll=ft.ScrollMode.ALWAYS)
+
+
+def crear_selector_target(ft: Any, *, lenguajes: list[str] | None = None) -> Any:
+    """Crea el selector de target compartido para transpilación en GUI."""
+
+    targets = list(gui_target_choices()) if lenguajes is None else lenguajes
+    selector = flet_dropdown(
+        ft, options=[flet_dropdown_option(ft, lang) for lang in targets]
+    )
+    if targets:
+        selector.value = targets[0]
+    return selector
+
+
+def crear_switch_transpilacion(ft: Any, *, lenguajes: list[str] | None = None) -> Any:
+    """Crea el switch compartido que alterna ejecución y transpilación."""
+
+    targets = list(gui_target_choices()) if lenguajes is None else lenguajes
+    return flet_switch(ft, label="Transpilar", disabled=not targets)
+
+
+def ejecutar_o_transpilar(
+    codigo: str,
+    *,
+    transpilacion_activa: bool,
+    target: str,
+    main_file: str | Path | None = None,
+) -> str:
+    """Ejecuta o transpila código Cobra desde el contexto del archivo activo.
+
+    ``main_file`` solo interviene en la ejecución. La transpilación conserva
+    su comportamiento actual porque opera sobre el código y el AST recibidos.
+    """
+
+    deps = require_gui_dependencies()
+    if transpilacion_activa and target not in deps["TRANSPILERS"]:
+        return "Selecciona un lenguaje destino para transpilar"
+    if transpilacion_activa:
+        return transpilar_codigo(codigo, target)
+    return ejecutar_codigo(codigo, main_file=main_file)
+
+def crear_handler_ejecucion(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    obtener_main_file: Any | None = None,
+    salida: Any,
+    selector: Any,
+    activar: Any,
+    page: Any,
+) -> Any:
+    """Crea el handler compartido de ejecutar/transpilar.
+
+    ``obtener_main_file`` se consulta en cada ejecución para usar siempre
+    la ruta activa más reciente. Las GUIs de código en memoria pueden
+    omitirlo y conservar el contexto ``None``.
+    """
+
+    lector = leer_codigo or (lambda: entrada.value)
+    lector_main_file = obtener_main_file or (lambda: None)
+
+    def ejecutar_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        codigo = normalizar_codigo(lector())
+        try:
+            salida.value = ejecutar_o_transpilar(
+                codigo,
+                transpilacion_activa=bool(activar.value),
+                target=str(selector.value or ""),
+                main_file=lector_main_file(),
+            )
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return ejecutar_handler
+
+def _guardar_archivo(
+    page: Any, entrada: Any, estado_archivo: GuiFileState, ruta: Path
+) -> None:
+    """Guarda el editor usando la misma lógica y mensajes de ``Guardar como``."""
+    flet_runtime = require_flet()
+    try:
+        _contenido, mensaje = guardar_archivo_como(ruta, entrada.value, estado_archivo)
+        page.snack_bar.open = True
+        page.snack_bar.content = flet_text(flet_runtime, mensaje)
+    except Exception as exc:
+        page.snack_bar.open = True
+        page.snack_bar.content = flet_text(flet_runtime, f"Error al guardar: {exc}")
+    finally:
+        page.update()
+
+
+def crear_handler_guardar(
+    *,
+    entrada: Any,
+    estado_archivo: GuiFileState,
+    page: Any,
+) -> Any:
+    """Crea el handler para guardar el archivo actual."""
+
+    def guardar_handler(_e: Any) -> None:
+        if estado_archivo.ruta:
+            _guardar_archivo(page, entrada, estado_archivo, estado_archivo.ruta)
+        else:
+            # Si no hay ruta, invocar "Guardar como"
+            crear_handler_guardar_como(
+                entrada=entrada, estado_archivo=estado_archivo, page=page
+            )(_e)
+
+    return guardar_handler
+
+
+def crear_handler_guardar_como(
+    *,
+    entrada: Any,
+    estado_archivo: GuiFileState,
+    page: Any,
+) -> Any:
+    """Crea un helper de ``Guardar como`` basado en ``FilePicker``.
+
+    El flujo canónico del IDLE principal conserva el campo ``Ruta`` para que
+    abrir, guardar como y la ruta activa compartan una única entrada visible.
+    Este helper queda disponible para integraciones GUI alternativas que
+    prefieran delegar la selección de destino al diálogo nativo de Flet.
+
+    El diálogo nativo anuncia las extensiones auxiliares que Cobra trata como
+    texto/configuración editable. Nombres especiales sin una extensión final
+    estándar, como ``Dockerfile``, ``.gitignore``, ``.dockerignore`` o
+    ``.env.example``, siguen teniendo como flujo canónico el campo ``Ruta``
+    del IDLE, ya que no encajan bien en el filtrado por ``allowed_extensions``.
+    """
+
+    def guardar_como_handler(_e: Any) -> None:
+        flet_runtime = require_flet()
+
+        def on_file_dialog_result(e: Any) -> None:
+            if e.path:
+                _guardar_archivo(page, entrada, estado_archivo, Path(e.path))
+
+        file_picker = _flet_attr(flet_runtime, "FilePicker", "FilePicker")(
+            on_result=on_file_dialog_result
+        )
+        page.overlay.append(file_picker)
+        page.update()
+        file_picker.save_file(
+            dialog_title="Guardar archivo del proyecto Cobra",
+            file_name="nuevo_archivo.txt",
+            allowed_extensions=[
+                "cobra",
+                "co",
+                "md",
+                "markdown",
+                "txt",
+                "json",
+                "yml",
+                "yaml",
+                "toml",
+                "docker-compose.yml",
+            ],
+        )
+
+    return guardar_como_handler
+
+
+def analizar_codigo(codigo: str) -> tuple[list[Any], Any]:
+    """Ejecuta Lexer y Parser una vez y devuelve tokens y AST."""
+
+    deps = require_gui_dependencies()
+    tokens = deps["Lexer"](codigo).tokenizar()
+    ast = deps["Parser"](tokens).parsear()
+    return tokens, ast
+
+
+_CATEGORIAS_SUGERENCIAS = (
+    ("léxico/sintaxis", "Léxico/sintaxis"),
+    ("estilo", "Estilo"),
+    ("nombres", "Nombres"),
+    ("forma canónica", "Forma canónica"),
+    ("observabilidad", "Observabilidad"),
+)
+
+
+def _categoria_sugerencia(sugerencia: str) -> str:
+    """Clasifica una sugerencia del Libro para mostrarla agrupada en GUI."""
+
+    texto = sugerencia.lower()
+    if "lp-3.1-nombres" in texto or "nombres descriptivos" in texto:
+        return "nombres"
+    if "lp-3.3-impresion" in texto or "imprimir" in texto:
+        return "observabilidad"
+    if "lp-3.3-retorno" in texto or "retorno" in texto or "retornar" in texto:
+        return "forma canónica"
+    if "lp-3.9-funciones" in texto or "funcion" in texto:
+        return "léxico/sintaxis"
+    if "lp-3.6-usar" in texto or "usar" in texto or "alias" in texto:
+        return "estilo"
+    return "estilo"
+
+
+def _formatear_sugerencias_agrupadas(sugerencias: list[str]) -> str:
+    """Devuelve sugerencias visibles agrupadas por tipo pedagógico."""
+
+    agrupadas = {clave: [] for clave, _titulo in _CATEGORIAS_SUGERENCIAS}
+    for sugerencia in sugerencias:
+        agrupadas[_categoria_sugerencia(sugerencia)].append(sugerencia)
+
+    bloques: list[str] = []
+    for clave, titulo in _CATEGORIAS_SUGERENCIAS:
+        items = agrupadas[clave]
+        if items:
+            cuerpo = "\n".join(f"  - {item}" for item in items)
+        else:
+            cuerpo = "  - Sin sugerencias."
+        bloques.append(f"- {titulo}:\n{cuerpo}")
+    return "\n".join(bloques)
+
+
+def _extraer_metadatos_sugerencia(sugerencia: str) -> tuple[str, str]:
+    """Extrae regla y sección del Libro si el motor las incluye en el texto."""
+
+    regla = "regla no especificada"
+    seccion = "sección no especificada"
+    match = re.search(r"\[regla:\s*([^;\]]+)(?:;\s*([^\]]+))?\]", sugerencia)
+    if match:
+        regla = match.group(1).strip()
+        if match.group(2):
+            seccion = match.group(2).strip()
+    else:
+        seccion_match = re.search(r"(§\s*\d+(?:\.\d+)?[^:;\]]*)", sugerencia)
+        if seccion_match:
+            seccion = seccion_match.group(1).strip()
+    return regla, seccion
+
+
+def _ubicacion_aproximada_sugerencia(codigo: str, sugerencia: str) -> str:
+    """Calcula una ubicación aproximada sin alterar el editor."""
+
+    texto = sugerencia.lower()
+    pistas = (
+        ("retorno", ("retornar", "retorno")),
+        ("función", ("funcion ", "func ", "definir ")),
+        ("módulo", ("usar ",)),
+        ("impresión", ("imprimir",)),
+        (
+            "nombre",
+            (
+                "var ",
+                "=",
+            ),
+        ),
+    )
+    for _nombre, patrones in pistas:
+        if any(patron.strip() in texto for patron in patrones):
+            for numero, linea in enumerate(codigo.splitlines(), start=1):
+                linea_normalizada = linea.lower()
+                if any(patron in linea_normalizada for patron in patrones):
+                    return f"línea {numero}"
+    return "ubicación no disponible"
+
+
+def _limpiar_explicacion_sugerencia(sugerencia: str) -> str:
+    """Elimina metadatos compactos para dejar una explicación legible."""
+
+    return re.sub(r"\s*\[regla:[^\]]+\]\s*$", "", sugerencia).strip() or sugerencia
+
+
+def _formatear_sugerencias_detalladas(codigo: str, sugerencias: list[str]) -> str:
+    """Devuelve una lista agrupada con regla, sección, ubicación y explicación."""
+
+    agrupadas = {clave: [] for clave, _titulo in _CATEGORIAS_SUGERENCIAS}
+    for sugerencia in sugerencias:
+        regla, seccion = _extraer_metadatos_sugerencia(sugerencia)
+        ubicacion = _ubicacion_aproximada_sugerencia(codigo, sugerencia)
+        explicacion = _limpiar_explicacion_sugerencia(sugerencia)
+        item = (
+            f"  - Regla: {regla} | Sección: {seccion} | "
+            f"Ubicación: {ubicacion} | Explicación: {explicacion}"
+        )
+        agrupadas[_categoria_sugerencia(sugerencia)].append(item)
+
+    bloques: list[str] = []
+    for clave, titulo in _CATEGORIAS_SUGERENCIAS:
+        items = agrupadas[clave]
+        cuerpo = "\n".join(items) if items else "  - Sin sugerencias."
+        bloques.append(f"- {titulo}:\n{cuerpo}")
+    return "\n".join(bloques)
+
+
+def generar_reporte_correccion_tipografica(codigo: str) -> str:
+    """Valida código y genera un reporte de corrección sin editar automáticamente."""
+
+    deps = require_gui_dependencies()
+    try:
+        analizar_codigo(codigo)
+    except Exception as exc:
+        error = formatear_error(
+            exc,
+            lexer_error_type=deps.get("LexerError"),
+            parser_error_type=deps.get("ParserError"),
+        )
+        return (
+            "Errores léxicos/sintácticos:\n"
+            f"- {error}\n\n"
+            "Corrección tipográfica del Libro:\n"
+            "- Corrige primero los errores anteriores para solicitar sugerencias."
+        )
+
+    motor = detectar_motor_ia_sugerencias()
+    if not motor.disponible:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Corrección tipográfica del Libro:\n"
+            f"- {motor.tooltip}"
+        )
+
+    try:
+        sugerencias = generar_sugerencias(codigo)
+    except ImportError as exc:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Corrección tipográfica del Libro:\n"
+            f"- No se pudieron generar sugerencias: {exc}. "
+            "Instala la dependencia opcional de sugerencias para activar esta acción."
+        )
+
+    if sugerencias:
+        sugerencias_legibles = _formatear_sugerencias_detalladas(codigo, sugerencias)
+    else:
+        sugerencias_legibles = "- No se recibieron sugerencias."
+    return (
+        "Errores léxicos/sintácticos:\n"
+        "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+        "Corrección tipográfica del Libro:\n"
+        f"{sugerencias_legibles}\n\n"
+        "Nota: el editor no se modifica automáticamente."
+    )
+
+
+def generar_reporte_sugerencias(codigo: str) -> str:
+    """Valida código y genera reporte común de sugerencias estilísticas."""
+
+    deps = require_gui_dependencies()
+    try:
+        analizar_codigo(codigo)
+    except Exception as exc:
+        error = formatear_error(
+            exc,
+            lexer_error_type=deps.get("LexerError"),
+            parser_error_type=deps.get("ParserError"),
+        )
+        return (
+            "Errores léxicos/sintácticos:\n"
+            f"- {error}\n\n"
+            "Sugerencias del Libro:\n"
+            "- Corrige primero los errores anteriores para solicitar sugerencias."
+        )
+
+    motor = detectar_motor_ia_sugerencias()
+    if not motor.disponible:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Sugerencias del Libro:\n"
+            f"- {motor.tooltip}"
+        )
+
+    try:
+        sugerencias = generar_sugerencias(codigo)
+    except ImportError as exc:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Sugerencias del Libro:\n"
+            f"- No se pudieron generar sugerencias: {exc}. "
+            "Instala la dependencia opcional de sugerencias para activar esta acción."
+        )
+
+    if sugerencias:
+        sugerencias_legibles = _formatear_sugerencias_agrupadas(sugerencias)
+    else:
+        sugerencias_legibles = "- No se recibieron sugerencias."
+    return (
+        "Errores léxicos/sintácticos:\n"
+        "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+        "Sugerencias del Libro:\n"
+        f"{sugerencias_legibles}"
+    )
+
+
+def crear_handler_tokens(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
+    """Crea handler compartido para mostrar tokens Cobra."""
+
+    lector = leer_codigo or (lambda: entrada.value)
+
+    def tokens_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = mostrar_tokens(normalizar_codigo(lector()))
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return tokens_handler
+
+
+def crear_handler_ast(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
+    """Crea handler compartido para mostrar el AST Cobra."""
+
+    lector = leer_codigo or (lambda: entrada.value)
+
+    def ast_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = mostrar_ast(normalizar_codigo(lector()))
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return ast_handler
+
+
+def crear_handler_correccion_tipografica(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
+    """Crea handler para corrección tipográfica validada y no destructiva."""
+
+    lector = leer_codigo or (lambda: entrada.value)
+
+    def correccion_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = generar_reporte_correccion_tipografica(
+                normalizar_codigo(lector())
+            )
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return correccion_handler
+
+
+def crear_handler_sugerencias(
+    *,
+    entrada: Any | None = None,
+    leer_codigo: Any | None = None,
+    salida: Any,
+    page: Any,
+) -> Any:
+    """Crea handler compartido para sugerencias con validación léxica/sintáctica."""
+
+    lector = leer_codigo or (lambda: entrada.value)
+
+    def sugerencias_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = generar_reporte_sugerencias(normalizar_codigo(lector()))
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return sugerencias_handler
+
+
+# Compatibilidad interna: conservar temporalmente el nombre antiguo sin
+# recomendarlo como API de GUI. La ruta canónica es crear_handler_sugerencias.
+def crear_handler_sugerencias_agix(
+    *,
+    entrada: Any,
+    salida: Any,
+    page: Any,
+) -> Any:
+    """Alias interno de compatibilidad; usar ``crear_handler_sugerencias``."""
+
+    warnings.warn(
+        "crear_handler_sugerencias_agix está deprecado; usa crear_handler_sugerencias.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return crear_handler_sugerencias(entrada=entrada, salida=salida, page=page)
+
+
+def normalizar_codigo(codigo: str | None) -> str:
+    """Normaliza la entrada para evitar valores ``None``."""
+    return codigo or ""
+
+
+def _analizar_codigo_gui_con_declaraciones_implicitas(codigo: str) -> Any:
+    """Analiza código GUI permitiendo primeras asignaciones como declaraciones.
+
+    El editor/IDLE acepta fragmentos cortos como ``x = 1`` para facilitar la
+    ejecución interactiva. El parser conserva esas asignaciones como mutaciones;
+    aquí las marcamos como declaración solo cuando introducen un nombre nuevo en
+    el nivel superior, sin alterar el error de lectura de variables inexistentes.
+    """
+    from pcobra.cobra.cli.execution_pipeline import analizar_codigo
+
+    ast = analizar_codigo(codigo)
+    declarados: set[str] = set()
+    for nodo in ast if isinstance(ast, list) else []:
+        if type(nodo).__name__ != "NodoAsignacion":
+            continue
+
+        nombre = getattr(nodo, "identificador", None)
+        if nombre is None:
+            nombre = getattr(nodo, "variable", None)
+        if not isinstance(nombre, str):
+            continue
+
+        if nombre not in declarados:
+            setattr(nodo, "declaracion", True)
+        declarados.add(nombre)
+    return ast
+
+
+def ejecutar_codigo(codigo: str, *, main_file: str | Path | None = None) -> str:
+    """Ejecuta código Cobra y captura la salida impresa.
+
+    ``main_file`` identifica de forma explícita el contexto autorizado del
+    proyecto desde el que se resuelven módulos Cobra locales.
+    """
+    from pcobra.cobra.cli.execution_pipeline import (
+        PipelineInput,
+        ejecutar_pipeline_explicito,
+    )
+
+    deps = require_gui_dependencies()
+    buffer = io.StringIO()
+    with redirect_stdout(buffer), redirect_stderr(buffer):
+        try:
+            ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo=codigo,
+                    interpretador_cls=deps["InterpretadorCobra"],
+                    safe_mode=True,
+                    extra_validators=None,
+                    main_file=main_file,
+                ),
+                analizar_codigo_fn=_analizar_codigo_gui_con_declaraciones_implicitas,
+            )
+        except FileNotFoundError as exc:
+            # Sólo presentamos el error contractual de resolución. Cualquier
+            # FileNotFoundError inesperado conserva intactos su tipo y traceback.
+            if str(exc).startswith("Módulo no encontrado:"):
+                raise FileNotFoundError(str(exc)) from exc
+            raise
+    return buffer.getvalue()
+
+
+def transpilar_codigo(codigo: str, lang: str) -> str:
+    """Transpila código Cobra al lenguaje especificado."""
+    deps = require_gui_dependencies()
+    _tokens, ast = analizar_codigo(codigo)
+    transp = deps["TRANSPILERS"][lang]()
+    return transp.generate_code(ast)
+
+
+def mostrar_tokens(codigo: str) -> str:
+    deps = require_gui_dependencies()
+    tokens, _ast = analizar_codigo(codigo)
+    return "\n".join(str(token) for token in tokens)
+
+
+def mostrar_ast(codigo: str) -> str:
+    """Parsea código Cobra y devuelve una representación serializada del AST."""
+    deps = require_gui_dependencies()
+    _tokens, ast = analizar_codigo(codigo)
+    return str(ast)
+
+
+def formatear_error(
+    exc: Exception,
+    *,
+    lexer_error_type: type[BaseException] | None = None,
+    parser_error_type: type[BaseException] | None = None,
+) -> str:
+    """Convierte excepciones en mensajes legibles para la GUI.
+
+    ``lexer_error_type`` y ``parser_error_type`` se inyectan desde una capa ya
+    inicializada (GUI handlers) para evitar imports/reloads en esta ruta de
+    manejo de errores.
+    """
+    if lexer_error_type is not None and isinstance(exc, lexer_error_type):
+        linea = getattr(exc, "linea", "?")
+        columna = getattr(exc, "columna", "?")
+        return f"Error léxico (línea {linea}, columna {columna}): {exc}"
+    if parser_error_type is not None and isinstance(exc, parser_error_type):
+        return f"Error de sintaxis: {exc}"
+    return f"Error de ejecución: {exc}"
+
+
+def gui_target_choices() -> tuple[str, ...]:
+    """Devuelve targets públicos canónicos visibles en GUI preservando el orden oficial."""
+    deps = require_gui_dependencies()
+    official_targets = tuple(deps["OFFICIAL_TARGETS"])
+    if official_targets != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "Contrato público inválido en GUI: OFFICIAL_TARGETS debe coincidir con PUBLIC_BACKENDS. "
+            f"official={official_targets}; public={PUBLIC_BACKENDS}"
+        )
+    return deps["target_cli_choices"](set(PUBLIC_BACKENDS) & set(deps["TRANSPILERS"]))
+
+
+# Acciones de empaquetado CobraHub reutilizadas por CLI e IDLE. Estas funciones
+# son una capa de herramientas sobre archivos, no invocan Lexer ni Parser.
+def idle_crear_paquete(
+    project_root: str | Path, nombre: str, version: str = "0.1.0"
+) -> Path:
+    from pcobra.cobra.packaging import crear_paquete
+
+    root = validar_project_root_idle(project_root)
+    return crear_paquete(root, nombre=nombre, version=version)
+
+
+def idle_validar_paquete(paquete: str | Path):
+    from pcobra.cobra.packaging import validar_paquete
+
+    return validar_paquete(paquete)
+
+
+def idle_construir_paquete(
+    project_root: str | Path, salida: str | Path | None = None
+) -> Path:
+    from pcobra.cobra.packaging import MANIFEST_NAME, construir_paquete
+
+    root = validar_project_root_idle(project_root)
+    manifest = root / MANIFEST_NAME
+    if not manifest.is_file():
+        raise FileNotFoundError(
+            "Usa 'Crear paquete' antes de construir: falta cobra.pkg.json"
+        )
+    return construir_paquete(root, salida)
+
+
+def idle_abrir_paquete(paquete: str | Path, destino: str | Path) -> Path:
+    from pcobra.cobra.packaging import extraer_paquete
+
+    destino_path = Path(destino)
+    if not destino_path.is_dir():
+        raise FileNotFoundError(f"Destino de extracción inexistente: {destino_path}")
+    return extraer_paquete(paquete, destino_path)
+
+
+def idle_publicar_paquete(paquete: str | Path) -> bool:
+    from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+    from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
+
+    return CobraHubPackages(CobraHubClient()).publicar_paquete(str(paquete))
+
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra_installer/validator.py
+========================================================================================
+
+"""Validación de proyectos para el instalador Cobra."""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from pcobra.cobra.packaging import es_paquete_cobra
+
+from .project import BuildOptions, CobraInstallerError, CobraProject
+from .targets import validate_target
+
+COBRA_EXTENSIONS = (".cobra", ".co")
+_EXECUTABLE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_RESERVED_EXECUTABLE_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+}
+_ICON_SUFFIXES = {".ico", ".icns", ".png", ".svg"}
+_CONFIG_PATH_KEYS = ("icon", "icon_path")
+_EXECUTABLE_NAME_KEYS = ("name", "executable_name", "executable", "app_name")
+_REQUIRED_TOML_TOP_LEVEL = ("project", "package", "build", "app", "cobra")
+_LOCK_REQUIRED_KEYS = {"version", "package", "packages", "dependencies", "metadata"}
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationErrorDetail:
+    """Detalle serializable de un problema detectado al validar un proyecto."""
+
+    code: str
+    message: str
+    path: Path | None = None
+    field: str | None = None
+    hint: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationResult:
+    """Resultado acumulado para que el IDLE muestre todos los errores juntos."""
+
+    project: CobraProject
+    errors: tuple[ValidationErrorDetail, ...] = field(default_factory=tuple)
+
+    @property
+    def is_valid(self) -> bool:
+        """Indica si el proyecto no tiene errores de validación."""
+
+        return not self.errors
+
+    def raise_for_errors(self) -> None:
+        """Convierte el resultado acumulado en una excepción clásica si hace falta."""
+
+        if self.is_valid:
+            return
+        formatted = "\n".join(f"- {error.message}" for error in self.errors)
+        raise CobraInstallerError(f"El proyecto Cobra no es válido:\n{formatted}")
+
+
+# La API pública nueva valida CobraProject y acumula errores. La validación de
+# BuildOptions se conserva abajo para compatibilidad interna del builder.
+def validate_project(project: CobraProject) -> ValidationResult:
+    """Valida un proyecto Cobra sin detenerse en el primer error."""
+
+    normalized = project.normalized()
+    root = Path(normalized.project_root)
+    errors: list[ValidationErrorDetail] = []
+
+    if not root.exists() or not root.is_dir():
+        errors.append(
+            ValidationErrorDetail(
+                code="project_root_missing",
+                message=f"La raíz del proyecto no existe o no es una carpeta: {root}",
+                path=root,
+            )
+        )
+        return ValidationResult(project=normalized, errors=tuple(errors))
+
+    _validate_entrypoint(normalized, root, errors)
+    _validate_cobra_toml(normalized, root, errors)
+    _validate_cobra_lock(normalized, root, errors)
+    _validate_resource_paths(normalized.assets, root, "assets", errors)
+    _validate_resource_paths(normalized.config_dirs, root, "config_dirs", errors)
+    _validate_resource_paths(normalized.documentation, root, "documentation", errors)
+    _validate_resource_paths(
+        normalized.auxiliary_resources, root, "auxiliary_resources", errors
+    )
+    _validate_resource_paths(normalized.co_packages, root, "co_packages", errors)
+    _validate_configured_executable_names(normalized.config, errors)
+    _validate_configured_icon(normalized.config, root, errors)
+    _validate_co_package_distinction(normalized, errors)
+
+    return ValidationResult(project=normalized, errors=tuple(errors))
+
+
+def validate_build_options(options: BuildOptions) -> BuildOptions:
+    """Valida opciones de build y devuelve una versión normalizada.
+
+    Mantiene el comportamiento previo para el orquestador de empaquetado, que
+    debe seguir recibiendo ``BuildOptions`` normalizadas o lanzar
+    ``CobraInstallerError``.
+    """
+
+    try:
+        normalized = options.normalized()
+    except (RuntimeError, ValueError) as exc:
+        raise CobraInstallerError(str(exc)) from exc
+    entrypoint = normalized.entrypoint or discover_entrypoint(
+        Path(normalized.project_root)
+    )
+    project = CobraProject(
+        project_root=normalized.project_root,
+        entrypoint=entrypoint,
+        assets=normalized.assets,
+        config=normalized.config,
+    )
+    result = validate_project(project)
+    extra_errors = list(result.errors)
+    try:
+        validate_target(normalized.target)
+    except (RuntimeError, ValueError) as exc:
+        extra_errors.append(
+            ValidationErrorDetail(
+                code="target_invalid",
+                message=str(exc),
+                field="target",
+                hint="Usa windows, linux, macos o current.",
+            )
+        )
+    if normalized.icon is not None:
+        _validate_icon_path(
+            normalized.icon,
+            Path(normalized.project_root),
+            extra_errors,
+            field_name="icon",
+        )
+    if normalized.name is not None:
+        _validate_executable_name(normalized.name, extra_errors, field_name="name")
+    if extra_errors:
+        ValidationResult(
+            project=result.project, errors=tuple(extra_errors)
+        ).raise_for_errors()
+    return normalized
+
+
+def discover_entrypoint(project_root: Path) -> Path | None:
+    """Busca un punto de entrada Cobra común dentro del proyecto."""
+
+    for name in ("main.cobra", "main.co", "app.cobra", "app.co"):
+        candidate = project_root / name
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    for extension in COBRA_EXTENSIONS:
+        matches = sorted(project_root.glob(f"*{extension}"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _validate_entrypoint(
+    project: CobraProject, root: Path, errors: list[ValidationErrorDetail]
+) -> None:
+    entrypoint = project.entrypoint
+    if entrypoint is None:
+        errors.append(
+            ValidationErrorDetail(
+                code="entrypoint_missing",
+                message="El proyecto no declara un entrypoint Cobra.",
+                path=root,
+                field="entrypoint",
+                hint="Crea main.cobra o configura entrypoint/main/source/script en cobra.toml.",
+            )
+        )
+        return
+    if not entrypoint.is_file():
+        errors.append(
+            ValidationErrorDetail(
+                "entrypoint_not_found",
+                f"El punto de entrada no existe: {entrypoint}",
+                entrypoint,
+                "entrypoint",
+            )
+        )
+        return
+    if not _is_inside_project(entrypoint, root):
+        errors.append(
+            ValidationErrorDetail(
+                "entrypoint_outside_project",
+                f"El entrypoint está fuera del proyecto: {entrypoint}",
+                entrypoint,
+                "entrypoint",
+            )
+        )
+    if entrypoint.suffix.lower() != ".cobra":
+        errors.append(
+            ValidationErrorDetail(
+                code="entrypoint_extension_invalid",
+                message=f"El entrypoint principal debe usar extensión .cobra: {entrypoint}",
+                path=entrypoint,
+                field="entrypoint",
+            )
+        )
+
+
+def _validate_cobra_toml(
+    project: CobraProject, root: Path, errors: list[ValidationErrorDetail]
+) -> None:
+    path = project.cobra_toml
+    if path is None:
+        return
+    if path.name != "cobra.toml":
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_name_invalid",
+                f"El manifiesto debe llamarse cobra.toml: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
+    if not _is_inside_project(path, root):
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_outside_project",
+                f"cobra.toml está fuera del proyecto: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
+    if not path.exists():
+        if path == root / "cobra.toml":
+            return
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_not_found",
+                f"cobra.toml no existe: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
+        return
+    if not path.is_file():
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_not_file",
+                f"cobra.toml no es un archivo: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
+        return
+    data = _read_toml_mapping(path, errors, "cobra_toml")
+    if data is not None and not any(key in data for key in _REQUIRED_TOML_TOP_LEVEL):
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_format_invalid",
+                "cobra.toml debe declarar al menos una sección reconocida: [project], [package], [build], [app] o [cobra].",
+                path,
+                "cobra_toml",
+            )
+        )
+
+
+def _validate_cobra_lock(
+    project: CobraProject, root: Path, errors: list[ValidationErrorDetail]
+) -> None:
+    path = project.cobra_lock
+    if path is None or not path.exists():
+        return
+    if path.name != "cobra.lock":
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_name_invalid",
+                f"El lockfile debe llamarse cobra.lock: {path}",
+                path,
+                "cobra_lock",
+            )
+        )
+    if not _is_inside_project(path, root):
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_outside_project",
+                f"cobra.lock está fuera del proyecto: {path}",
+                path,
+                "cobra_lock",
+            )
+        )
+    if not path.is_file():
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_not_file",
+                f"cobra.lock no es un archivo: {path}",
+                path,
+                "cobra_lock",
+            )
+        )
+        return
+    parsed = _read_lock_mapping(path, errors)
+    if (
+        parsed is not None
+        and parsed
+        and not any(key in parsed for key in _LOCK_REQUIRED_KEYS)
+    ):
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_format_invalid",
+                "cobra.lock no contiene claves reconocibles de lockfile.",
+                path,
+                "cobra_lock",
+            )
+        )
+
+
+def _validate_resource_paths(
+    paths: Sequence[Path | str],
+    root: Path,
+    field_name: str,
+    errors: list[ValidationErrorDetail],
+) -> None:
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not _is_inside_project(path, root):
+            errors.append(
+                ValidationErrorDetail(
+                    f"{field_name}_outside_project",
+                    f"La ruta de {field_name} está fuera del proyecto: {path}",
+                    path,
+                    field_name,
+                )
+            )
+        if not path.exists():
+            errors.append(
+                ValidationErrorDetail(
+                    f"{field_name}_not_found",
+                    f"La ruta de {field_name} no existe: {path}",
+                    path,
+                    field_name,
+                )
+            )
+
+
+def _validate_configured_executable_names(
+    config: Mapping[str, object], errors: list[ValidationErrorDetail]
+) -> None:
+    for field_name, value in _iter_config_values(config, _EXECUTABLE_NAME_KEYS):
+        if isinstance(value, str):
+            _validate_executable_name(value, errors, field_name=field_name)
+        elif value is not None:
+            errors.append(
+                ValidationErrorDetail(
+                    "executable_name_type_invalid",
+                    f"El nombre de ejecutable en {field_name} debe ser texto.",
+                    field=field_name,
+                )
+            )
+
+
+def _validate_executable_name(
+    name: str, errors: list[ValidationErrorDetail], *, field_name: str
+) -> None:
+    if (
+        not name
+        or not _EXECUTABLE_NAME_RE.fullmatch(name)
+        or name.endswith(".")
+        or name.endswith(" ")
+    ):
+        errors.append(
+            ValidationErrorDetail(
+                "executable_name_invalid",
+                f"Nombre de ejecutable inválido: {name!r}",
+                field=field_name,
+                hint="Usa letras, números, guion, guion bajo o punto, empezando por un carácter alfanumérico.",
+            )
+        )
+        return
+    if name.split(".", 1)[0].upper() in _RESERVED_EXECUTABLE_NAMES:
+        errors.append(
+            ValidationErrorDetail(
+                "executable_name_reserved",
+                f"Nombre de ejecutable reservado por Windows: {name!r}",
+                field=field_name,
+            )
+        )
+
+
+def _validate_configured_icon(
+    config: Mapping[str, object], root: Path, errors: list[ValidationErrorDetail]
+) -> None:
+    for field_name, value in _iter_config_values(config, _CONFIG_PATH_KEYS):
+        if isinstance(value, str) and value:
+            _validate_icon_path(
+                Path(value) if Path(value).is_absolute() else root / value,
+                root,
+                errors,
+                field_name=field_name,
+            )
+        elif value is not None:
+            errors.append(
+                ValidationErrorDetail(
+                    "icon_type_invalid",
+                    f"El icono opcional en {field_name} debe ser una ruta de texto.",
+                    field=field_name,
+                )
+            )
+
+
+def _validate_icon_path(
+    path: Path, root: Path, errors: list[ValidationErrorDetail], *, field_name: str
+) -> None:
+    path = path.expanduser().resolve()
+    if not _is_inside_project(path, root):
+        errors.append(
+            ValidationErrorDetail(
+                "icon_outside_project",
+                f"El icono está fuera del proyecto: {path}",
+                path,
+                field_name,
+            )
+        )
+    if not path.is_file():
+        errors.append(
+            ValidationErrorDetail(
+                "icon_not_found",
+                f"El icono configurado no existe: {path}",
+                path,
+                field_name,
+            )
+        )
+    if path.suffix.lower() not in _ICON_SUFFIXES:
+        errors.append(
+            ValidationErrorDetail(
+                "icon_extension_invalid",
+                f"El icono debe usar una extensión compatible ({', '.join(sorted(_ICON_SUFFIXES))}): {path}",
+                path,
+                field_name,
+            )
+        )
+
+
+def _validate_co_package_distinction(
+    project: CobraProject, errors: list[ValidationErrorDetail]
+) -> None:
+    entrypoint = project.entrypoint
+    if (
+        entrypoint is not None
+        and entrypoint.suffix.lower() == ".co"
+        and entrypoint.exists()
+        and es_paquete_cobra(entrypoint)
+    ):
+        errors.append(
+            ValidationErrorDetail(
+                "entrypoint_co_is_package",
+                f"El entrypoint .co parece ser un paquete binario Cobra, no una fuente editable: {entrypoint}",
+                entrypoint,
+                "entrypoint",
+            )
+        )
+    for raw_path in project.co_packages:
+        path = Path(raw_path)
+        if (
+            path.suffix.lower() == ".co"
+            and path.exists()
+            and not es_paquete_cobra(path)
+            and not zipfile.is_zipfile(path)
+        ):
+            errors.append(
+                ValidationErrorDetail(
+                    "co_package_is_text_source",
+                    f"El paquete .co declarado parece una fuente de texto; muévelo a fuentes o conviértelo en paquete Cobra: {path}",
+                    path,
+                    "co_packages",
+                )
+            )
+
+
+def _read_toml_mapping(
+    path: Path, errors: list[ValidationErrorDetail], field_name: str
+) -> dict[str, object] | None:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:  # type: ignore[union-attr]
+        errors.append(
+            ValidationErrorDetail(
+                f"{field_name}_syntax_invalid",
+                f"{path.name} no es TOML válido: {exc}",
+                path,
+                field_name,
+            )
+        )
+        return None
+    except UnicodeDecodeError as exc:
+        errors.append(
+            ValidationErrorDetail(
+                f"{field_name}_encoding_invalid",
+                f"{path.name} debe poder leerse como UTF-8: {exc}",
+                path,
+                field_name,
+            )
+        )
+        return None
+    if not isinstance(data, dict):
+        errors.append(
+            ValidationErrorDetail(
+                f"{field_name}_format_invalid",
+                f"{path.name} debe contener un documento TOML de tablas/clave-valor.",
+                path,
+                field_name,
+            )
+        )
+        return None
+    return data
+
+
+def _read_lock_mapping(
+    path: Path, errors: list[ValidationErrorDetail]
+) -> Mapping[str, object] | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_encoding_invalid",
+                f"cobra.lock debe poder leerse como UTF-8: {exc}",
+                path,
+                "cobra_lock",
+            )
+        )
+        return None
+    stripped = text.strip()
+    if not stripped:
+        return {}
+    if stripped.startswith(("{", "[")):
+        try:
+            data = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            errors.append(
+                ValidationErrorDetail(
+                    "cobra_lock_syntax_invalid",
+                    f"cobra.lock no es JSON válido: {exc}",
+                    path,
+                    "cobra_lock",
+                )
+            )
+            return None
+        if isinstance(data, Mapping):
+            return data
+        if isinstance(data, list):
+            return {"packages": data}
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_format_invalid",
+                "cobra.lock JSON debe ser un objeto o lista.",
+                path,
+                "cobra_lock",
+            )
+        )
+        return None
+    return _read_toml_mapping(path, errors, "cobra_lock")
+
+
+def _iter_config_values(
+    config: Mapping[str, object], keys: Sequence[str]
+) -> list[tuple[str, object]]:
+    values: list[tuple[str, object]] = []
+    for key, value in config.items():
+        if key in keys:
+            values.append((key, value))
+        if isinstance(value, Mapping):
+            for nested_key, nested_value in _iter_config_values(value, keys):
+                values.append((f"{key}.{nested_key}", nested_value))
+    return values
+
+
+def _is_inside_project(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "COBRA_EXTENSIONS",
+    "ValidationErrorDetail",
+    "ValidationResult",
+    "discover_entrypoint",
+    "validate_build_options",
+    "validate_project",
+]
+
+
+========================================================================================
+ARCHIVO: src/pcobra/jupyter_kernel/__init__.py
+========================================================================================
+
+"""Kernel de Jupyter que permite ejecutar código Cobra en notebooks."""
+
+import contextlib
+import importlib
+import io
+import json
+import os
+import sys
+import tempfile
+from importlib.metadata import PackageNotFoundError, version
+from ipykernel.kernelbase import Kernel
+from jupyter_client.kernelspec import KernelSpecManager
+
+
+def _importar_modulo_runtime(
+    canonical: str,
+    *,
+    legacy: str | None = None,
+    atributos_requeridos: tuple[str, ...] = (),
+):
+    """Importa un módulo runtime priorizando namespace canónico y valida atributos."""
+
+    try:
+        modulo = importlib.import_module(canonical)
+    except ModuleNotFoundError as canon_exc:
+        if legacy is None:
+            raise
+        try:
+            modulo = importlib.import_module(legacy)
+        except ModuleNotFoundError:
+            raise canon_exc
+
+    faltantes = [attr for attr in atributos_requeridos if not hasattr(modulo, attr)]
+    if faltantes:
+        raise ImportError(
+            f"El módulo '{modulo.__name__}' no expone atributos requeridos: {', '.join(faltantes)}"
+        )
+    return modulo
+
+
+def _resolver_dependencias_kernel() -> dict[str, object]:
+    """Resuelve dependencias del kernel con prioridad en imports canónicos."""
+
+    core_mod = _importar_modulo_runtime(
+        "pcobra.cobra.core",
+        legacy="cobra.core",
+        atributos_requeridos=("Lexer", "Parser"),
+    )
+    core_utils_mod = _importar_modulo_runtime(
+        "pcobra.cobra.core.utils",
+        legacy="cobra.core.utils",
+        atributos_requeridos=("PALABRAS_RESERVADAS",),
+    )
+    interpreter_mod = _importar_modulo_runtime(
+        "pcobra.core.interpreter",
+        legacy="core.interpreter",
+        atributos_requeridos=("InterpretadorCobra",),
+    )
+    qualia_mod = _importar_modulo_runtime(
+        "pcobra.core.qualia_bridge",
+        legacy="core.qualia_bridge",
+        atributos_requeridos=("get_suggestions",),
+    )
+    sandbox_mod = _importar_modulo_runtime(
+        "pcobra.core.sandbox",
+        legacy="core.sandbox",
+        atributos_requeridos=("ejecutar_en_sandbox",),
+    )
+    return {
+        "Lexer": core_mod.Lexer,
+        "Parser": core_mod.Parser,
+        "PALABRAS_RESERVADAS": core_utils_mod.PALABRAS_RESERVADAS,
+        "InterpretadorCobra": interpreter_mod.InterpretadorCobra,
+        "get_suggestions": qualia_mod.get_suggestions,
+        "sandbox": sandbox_mod,
+    }
+
+
+def _get_version() -> str:
+    """Obtiene la versión instalada del paquete."""
+    try:
+        return version("pcobra")
+    except PackageNotFoundError:
+        return "10.0.12"
+
+
+__version__ = _get_version()
+
+
+def install(user=True):
+    """Instala el kernel de Cobra para Jupyter."""
+    kernel_spec = {
+        "argv": [
+            sys.executable,
+            "-c",
+            (
+                "from ipykernel.kernelapp import IPKernelApp; "
+                "from pcobra.jupyter_kernel import CobraKernel; "
+                "IPKernelApp.launch_instance(kernel_class=CobraKernel)"
+            ),
+            "-f",
+            "{connection_file}",
+        ],
+        "display_name": "Cobra",
+        "language": "cobra",
+    }
+
+    with tempfile.TemporaryDirectory() as kernelspec_dir:
+        kernel_json = os.path.join(kernelspec_dir, "kernel.json")
+        with open(kernel_json, "w", encoding="utf-8") as spec_file:
+            json.dump(kernel_spec, spec_file, ensure_ascii=False, indent=2)
+
+        return KernelSpecManager().install_kernel_spec(
+            kernelspec_dir,
+            kernel_name="cobra",
+            user=user,
+        )
+
+
+class CobraKernel(Kernel):
+    implementation = "Cobra"
+    implementation_version = __version__
+    language = "cobra"
+    language_version = __version__
+    language_info = {
+        "name": "cobra",
+        "mimetype": "text/plain",
+        "file_extension": ".co",
+    }
+    banner = "Cobra kernel"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        deps = _resolver_dependencias_kernel()
+        self._lexer_cls = deps["Lexer"]
+        self._parser_cls = deps["Parser"]
+        self._palabras_reservadas = deps["PALABRAS_RESERVADAS"]
+        self._get_suggestions = deps["get_suggestions"]
+        self._sandbox = deps["sandbox"]
+        self.interpreter = deps["InterpretadorCobra"]()
+        if not hasattr(self, "execution_count"):
+            self.execution_count = 0
+        self.use_python = os.getenv("COBRA_JUPYTER_PYTHON", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        self._warned_python = False
+
+    def do_execute(
+        self, code, silent, store_history=True, user_expressions=None, allow_stdin=False
+    ):
+        if code.strip() == "%sugerencias":
+            texto = "\n".join(self._get_suggestions())
+            if not silent:
+                self.send_response(
+                    self.iopub_socket, "stream", {"name": "stdout", "text": texto}
+                )
+            return {
+                "status": "ok",
+                "execution_count": self.execution_count,
+                "payload": [],
+                "user_expressions": {},
+            }
+
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                tokens = self._lexer_cls(code).tokenizar()
+                ast = self._parser_cls(tokens).parsear()
+                python_error: Exception | None = None
+                if self.use_python:
+                    try:
+                        from pcobra.cobra.transpilers.transpiler.to_python import (
+                            TranspiladorPython,
+                        )
+
+                        py_code = TranspiladorPython().generate_code(ast)
+                    except (ImportError, ModuleNotFoundError) as exc:
+                        python_error = exc
+                    else:
+                        if not self._warned_python and not silent:
+                            self.send_response(
+                                self.iopub_socket,
+                                "stream",
+                                {
+                                    "name": "stderr",
+                                    "text": (
+                                        "Advertencia: se ejecutará código Python; esto puede ser inseguro.\n"
+                                    ),
+                                },
+                            )
+                            self._warned_python = True
+                        try:
+                            output = self._sandbox.ejecutar_en_sandbox(
+                                py_code, timeout=5, memoria_mb=64
+                            )
+                            error = ""
+                            result = None
+                        except TimeoutError:
+                            output = ""
+                            error = (
+                                "Error: la ejecución de Python excedió el tiempo límite de 5 segundos"
+                            )
+                            result = None
+                        except MemoryError:
+                            output = ""
+                            error = (
+                                "Error: la ejecución de Python excedió el límite de memoria"
+                            )
+                            result = None
+                        except Exception as exc:
+                            if isinstance(exc, ModuleNotFoundError):
+                                python_error = exc
+                            else:
+                                output = ""
+                                error = f"Error al ejecutar código Python: {exc}"
+                                result = None
+                if not self.use_python or python_error is not None:
+                    if python_error is not None and not silent:
+                        self.send_response(
+                            self.iopub_socket,
+                            "stream",
+                            {
+                                "name": "stderr",
+                                "text": (
+                                    "Advertencia: modo Python no disponible, se usa el intérprete nativo.\n"
+                                ),
+                            },
+                        )
+                    result = self.interpreter.ejecutar_ast(ast)
+                    output = stdout.getvalue()
+                    error = ""
+                    if python_error is not None and not output and result is None:
+                        try:
+                            output = self._sandbox.ejecutar_en_sandbox(
+                                "# Python fallback deshabilitado",
+                                timeout=5,
+                                memoria_mb=64,
+                            )
+                        except Exception:
+                            output = ""
+
+            if not silent:
+                if output:
+                    self.send_response(
+                        self.iopub_socket, "stream", {"name": "stdout", "text": output}
+                    )
+                if error:
+                    self.send_response(
+                        self.iopub_socket, "stream", {"name": "stderr", "text": error}
+                    )
+                if result is not None and not output and not error:
+                    self.send_response(
+                        self.iopub_socket,
+                        "execute_result",
+                        {
+                            "execution_count": self.execution_count,
+                            "data": {"text/plain": str(result)},
+                            "metadata": {},
+                        },
+                    )
+            return {
+                "status": "ok",
+                "execution_count": self.execution_count,
+                "payload": [],
+                "user_expressions": {},
+            }
+        except Exception as e:
+            if not silent:
+                self.send_response(
+                    self.iopub_socket, "stream", {"name": "stderr", "text": f"{e}\n"}
+                )
+            return {
+                "status": "error",
+                "execution_count": self.execution_count,
+                "ename": e.__class__.__name__,
+                "evalue": str(e),
+                "traceback": [],
+            }
+
+    def do_complete(self, code, cursor_pos):
+        prefix = code[:cursor_pos].split()[-1]
+        matches = [w for w in self._palabras_reservadas if w.startswith(prefix)]
+        matches += [
+            n
+            for n in self.interpreter.variables.keys()
+            if isinstance(n, str) and n.startswith(prefix)
+        ]
+        start = cursor_pos - len(prefix)
+        return {
+            "matches": matches,
+            "cursor_start": start,
+            "cursor_end": cursor_pos,
+            "metadata": {},
+            "status": "ok",
+        }
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "install":
+        install()
+
+
+if __name__ == "__main__":
+    main()
+
+
+========================================================================================
+ARCHIVO: src/pcobra/cobra/transpilers/transpiler/python_nodes/importar.py
+========================================================================================
+
+from pathlib import Path
+from pcobra.cobra.core import Lexer
+from pcobra.cobra.core import Parser
+from pcobra.cobra.transpilers.common.utils import load_mapped_module
+from pcobra.cobra.usar_loader import obtener_cache_ast_import_co, canonicalizar_ruta_usar_proyecto, obtener_pila_carga_modulos_cobra_proyecto
+from pcobra.core.import_utils import cargar_ast_modulo
+
+
+def visit_import(self, nodo):
+    """Transpila una declaración de importación consultando el mapeo."""
+    codigo, ruta_str = load_mapped_module(nodo.ruta, "python")
+
+    if ruta_str.endswith(".co"):
+        ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta_str)
+        ast_cache = obtener_cache_ast_import_co()
+        loading_stack = obtener_pila_carga_modulos_cobra_proyecto()
+
+        if ruta_canonica in ast_cache:
+            ast = ast_cache[ruta_canonica]
+        else:
+            # cargar_ast_modulo ya maneja la lectura del archivo y el parseo
+            ast = cargar_ast_modulo(
+                str(ruta_canonica),
+                modules_path=str(ruta_canonica.parent),
+                whitelist={ruta_canonica.parent},
+                loading_stack=loading_stack,
+            )
+            ast_cache[ruta_canonica] = ast
+
+        for subnodo in ast:
+            subnodo.aceptar(self)
+    else:
+        self.codigo += codigo + "\n"
+
+
+========================================================================================
+ARCHIVO: tests/integration/test_usar_project_modules.py
+========================================================================================
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from pcobra.cobra.core import Lexer, Parser, ParserError
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.usar_loader import (
+    obtener_cache_ast_import_co,
+    obtener_cache_modulos_cobra_proyecto,
+    obtener_pila_carga_modulos_cobra_proyecto,
+    usar_modulo,
+)
+
+
+@pytest.fixture(autouse=True)
+def limpiar_caches_usar():
+    obtener_cache_ast_import_co().clear()
+    obtener_cache_modulos_cobra_proyecto().clear()
+    obtener_pila_carga_modulos_cobra_proyecto().clear()
+    yield
+    obtener_cache_ast_import_co().clear()
+    obtener_cache_modulos_cobra_proyecto().clear()
+    obtener_pila_carga_modulos_cobra_proyecto().clear()
+
+
+@pytest.fixture
+def crear_modulo_cobra(tmp_path):
+    def _crear_modulo(ruta_relativa: str, contenido: str) -> Path:
+        ruta_abs = tmp_path / ruta_relativa
+        ruta_abs.parent.mkdir(parents=True, exist_ok=True)
+        ruta_abs.write_text(dedent(contenido).strip() + "\n", encoding="utf-8")
+        return ruta_abs
+
+    return _crear_modulo
+
+
+def ejecutar_archivo(ruta: Path) -> InterpretadorCobra:
+    codigo = ruta.read_text(encoding="utf-8")
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    interprete = InterpretadorCobra(safe_mode=False, main_file=ruta)
+    interprete.ejecutar_ast(ast)
+    return interprete
+
+
+def test_usar_modulo_en_misma_carpeta_util(crear_modulo_cobra, tmp_path):
+    crear_modulo_cobra("util.co", 'variable saludo := "Hola desde util"')
+    main = crear_modulo_cobra(
+        "main.co",
+        """
+        usar "util"
+        """,
+    )
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("saludo") == "Hola desde util"
+
+
+def test_usar_subcarpeta_punteada_utilidades_fechas(crear_modulo_cobra, tmp_path):
+    crear_modulo_cobra("utilidades/fechas.co", 'variable hoy := "2026-06-13"')
+    main = crear_modulo_cobra(
+        "main.co",
+        """
+        usar "utilidades.fechas"
+        """,
+    )
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("hoy") == "2026-06-13"
+
+
+def test_usar_modulo_anidado_a_b_c(crear_modulo_cobra):
+    crear_modulo_cobra("a/b/c.co", "variable secreto := 42")
+    main = crear_modulo_cobra("main.co", 'usar "a.b.c"')
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("secreto") == 42
+
+
+def test_usar_desde_otro_directorio_respeta_cobra_toml(tmp_path, monkeypatch):
+    proyecto = tmp_path / "proyecto"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\nnombre = 'demo'\n", encoding="utf-8")
+    (proyecto / "util.co").write_text('variable desde_root := "ok"\n', encoding="utf-8")
+    app = proyecto / "app"
+    app.mkdir()
+    main = app / "main.co"
+    main.write_text('usar "util"\n', encoding="utf-8")
+    otro_directorio = tmp_path / "otro"
+    otro_directorio.mkdir()
+    monkeypatch.chdir(otro_directorio)
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("desde_root") == "ok"
+
+
+def test_usar_carga_una_sola_vez_con_cache_y_monkeypatch(crear_modulo_cobra, monkeypatch):
+    crear_modulo_cobra("util.co", "variable valor := 7")
+    main = crear_modulo_cobra(
+        "main.co",
+        """
+        usar "util"
+        usar "util"
+        """,
+    )
+    import pcobra.core.import_utils as import_utils
+
+    cargar_original = import_utils.cargar_ast_modulo
+    llamadas = []
+
+    def cargar_contando(*args, **kwargs):
+        llamadas.append(Path(args[0]).name)
+        return cargar_original(*args, **kwargs)
+
+    monkeypatch.setattr(import_utils, "cargar_ast_modulo", cargar_contando)
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("valor") == 7
+    assert llamadas.count("util.co") == 1
+
+
+def test_usar_detecta_ciclo_directo(crear_modulo_cobra):
+    crear_modulo_cobra("a.co", 'usar "a"\nvariable valor_a := 1')
+    main = crear_modulo_cobra("main.co", 'usar "a"')
+
+    with pytest.raises(ImportError, match=r"Ciclo de módulos detectado en usar: .*a\.co"):
+        ejecutar_archivo(main)
+
+
+def test_usar_detecta_ciclo_indirecto(crear_modulo_cobra):
+    crear_modulo_cobra("a.co", 'usar "b"\nvariable valor_a := 1')
+    crear_modulo_cobra("b.co", 'usar "c"\nvariable valor_b := 2')
+    crear_modulo_cobra("c.co", 'usar "a"\nvariable valor_c := 3')
+    main = crear_modulo_cobra("main.co", 'usar "a"')
+
+    with pytest.raises(ImportError, match=r"Ciclo de módulos detectado en usar: .*a\.co.*b\.co.*c\.co.*a\.co"):
+        ejecutar_archivo(main)
+
+
+def test_usar_modulo_inexistente_muestra_error_claro(crear_modulo_cobra, tmp_path):
+    main = crear_modulo_cobra("main.co", 'usar "modulo_que_no_existe"')
+
+    with pytest.raises(FileNotFoundError, match=r"Módulo de proyecto no encontrado: modulo_que_no_existe\. Ruta buscada: .*modulo_que_no_existe\.co"):
+        ejecutar_archivo(main)
+
+
+def test_compatibilidad_import_archivo_co_relativo_al_main(crear_modulo_cobra):
+    crear_modulo_cobra("archivo.co", 'variable legacy_var := "Soy legacy"')
+    main = crear_modulo_cobra(
+        "main.co",
+        """
+        import 'archivo.co'
+        """,
+    )
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("legacy_var") == "Soy legacy"
+
+
+def test_import_archivo_co_no_delega_en_usar_modulo(crear_modulo_cobra, monkeypatch):
+    """`import 'archivo.co'` debe conservar el flujo legacy de `NodoImport`."""
+
+    crear_modulo_cobra("archivo.co", 'variable legacy_var := "Soy legacy"')
+    main = crear_modulo_cobra("main.co", "import 'archivo.co'")
+
+    def fail_usar_modulo(*_args, **_kwargs):
+        raise AssertionError("import 'archivo.co' no debe delegar en usar_modulo")
+
+    monkeypatch.setattr("pcobra.core.interpreter.usar_modulo", fail_usar_modulo)
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("legacy_var") == "Soy legacy"
+
+
+@pytest.mark.parametrize("nombre", ["dir/modulo", r"dir\\modulo", r"C:\\tmp\\modulo"])
+def test_usar_strings_windows_posix_son_rechazados(tmp_path, nombre):
+    with pytest.raises(
+        (ValueError, PermissionError),
+        match=r"Nombre de módulo inválido en 'usar'",
+    ):
+        usar_modulo(nombre, project_root=tmp_path, current_file=tmp_path / "main.co")
+
+
+def test_usar_bloquea_traversal_con_puntos_dobles(tmp_path):
+    with pytest.raises((ValueError, PermissionError), match="traversal|inválido|fuera"):
+        usar_modulo("../secreto", project_root=tmp_path, current_file=tmp_path / "main.co")
+
+
+def test_usar_bloquea_escape_de_raiz_autorizada(crear_modulo_cobra, tmp_path):
+    # Crear un módulo fuera de la raíz del proyecto
+    (tmp_path.parent / "modulo_secreto.co").write_text("variable secreto := 'valor_secreto'")
+
+    main = crear_modulo_cobra("main.co", 'usar "../modulo_secreto"')
+
+    with pytest.raises(
+        ValueError,
+        match=r"Nombre de módulo inválido en 'usar': '\.\./modulo_secreto'\.",
+    ):
+        ejecutar_archivo(main)
+
+
+def test_usar_canonicaliza_rutas_y_carga_una_sola_vez(crear_modulo_cobra, monkeypatch):
+    crear_modulo_cobra("utilidades/fechas.co", "variable valor := 1")
+    main = crear_modulo_cobra(
+        "main.co",
+        """
+        usar "utilidades.fechas"
+        usar "utilidades.fechas"
+        """,
+    )
+    import pcobra.core.import_utils as import_utils
+
+    cargar_original = import_utils.cargar_ast_modulo
+    llamadas = []
+
+    def cargar_contando(*args, **kwargs):
+        llamadas.append(Path(args[0]).name)
+        return cargar_original(*args, **kwargs)
+
+    monkeypatch.setattr(import_utils, "cargar_ast_modulo", cargar_contando)
+
+    ejecutar_archivo(main)
+
+    assert llamadas.count("fechas.co") == 1
+
+
+def test_usar_no_soporta_sintaxis_desde(crear_modulo_cobra):
+    main = crear_modulo_cobra("main.co", "usar desde modulo importar simbolo")
+    with pytest.raises(ParserError, match="Se esperaba una ruta de módulo entre comillas o identificadores separados por puntos"):
+        ejecutar_archivo(main)
+
+
+def test_usar_no_soporta_sintaxis_exportar(crear_modulo_cobra):
+    main = crear_modulo_cobra("main.co", "usar exportar modulo")
+    with pytest.raises(ParserError, match="Se esperaba una ruta de módulo entre comillas o identificadores separados por puntos"):
+        ejecutar_archivo(main)
+
+
+========================================================================================
+ARCHIVO: tests/gui/test_gui_runtime_local_modules.py
+========================================================================================
+
+"""Regresión de módulos Cobra locales ejecutados por la ruta GUI."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from pcobra.gui import runtime
+
+
+def _crear_proyecto(
+    raiz: Path,
+    *,
+    factor: int,
+) -> tuple[Path, str]:
+    raiz.mkdir(parents=True)
+
+    (raiz / "utilidades.co").write_text(
+        (
+            "func duplicar(valor):\n"
+            f"    retorno valor * {factor}\n"
+            "fin\n"
+        ),
+        encoding="utf-8",
+    )
+
+    codigo = 'usar "utilidades"\nimprimir(duplicar(21))\n'
+    principal = raiz / "principal.co"
+    principal.write_text(codigo, encoding="utf-8")
+    return principal, codigo
+
+
+def test_handler_gui_resuelve_modulo_local_desde_archivo_activo(
+    tmp_path: Path,
+) -> None:
+    principal_a, codigo = _crear_proyecto(
+        tmp_path / "proyecto_a",
+        factor=2,
+    )
+    principal_b, _ = _crear_proyecto(
+        tmp_path / "proyecto_b",
+        factor=3,
+    )
+
+    estado = runtime.GuiFileState(ruta=principal_a)
+    salida = SimpleNamespace(value="")
+    selector = SimpleNamespace(value="python")
+    activar = SimpleNamespace(value=False)
+    actualizaciones: list[bool] = []
+    page = SimpleNamespace(
+        update=lambda: actualizaciones.append(True)
+    )
+
+    handler = runtime.crear_handler_ejecucion(
+        leer_codigo=lambda: codigo,
+        obtener_main_file=lambda: estado.ruta,
+        salida=salida,
+        selector=selector,
+        activar=activar,
+        page=page,
+    )
+
+    handler(None)
+    assert salida.value.strip() == "42"
+
+    # Debe consultar el archivo activo al ejecutar, no al crear el handler.
+    estado.ruta = principal_b
+    handler(None)
+
+    assert salida.value.strip() == "63"
+    assert len(actualizaciones) == 2
+
+
+========================================================================================
+ARCHIVO: tests/unit/test_gui_runtime.py
+========================================================================================
+
+"""Pruebas unitarias para el runtime compartido de GUI."""
+
+from __future__ import annotations
+
+import ast
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pcobra.cobra.core import Lexer, LexerError, Parser, ParserError
+from pcobra.gui import runtime
+
+
+def _deps_lexer_parser_reales() -> dict[str, object]:
+    return {
+        "Lexer": Lexer,
+        "LexerError": LexerError,
+        "Parser": Parser,
+        "ParserError": ParserError,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch: pytest.MonkeyPatch):
+    cache_clear = getattr(runtime.require_gui_dependencies, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+    motor_cache_clear = getattr(
+        runtime.detectar_motor_ia_sugerencias, "cache_clear", None
+    )
+    if motor_cache_clear is not None:
+        motor_cache_clear()
+    monkeypatch.setattr(
+        runtime,
+        "detectar_motor_ia_sugerencias",
+        lambda: runtime.MotorIASugerencias(disponible=True),
+    )
+    yield
+    cache_clear = getattr(runtime.require_gui_dependencies, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+    motor_cache_clear = getattr(
+        runtime.detectar_motor_ia_sugerencias, "cache_clear", None
+    )
+    if motor_cache_clear is not None:
+        motor_cache_clear()
+
+
+def _fake_flet_buttons():
+    class ElevatedButton:
+        def __init__(self, text, on_click=None, **kwargs):
+            self.text = text
+            self.on_click = on_click
+            self.disabled = kwargs.get("disabled", False)
+            self.tooltip = kwargs.get("tooltip", "")
+
+    return SimpleNamespace(ElevatedButton=ElevatedButton)
+
+
+def test_crear_editor_codigo_encapsula_el_control_visual(monkeypatch) -> None:
+    callback = object()
+    callback_seleccion = object()
+
+    class CodeEditor:
+        def __init__(self, **kwargs):
+            self.value = kwargs.get("value")
+            self.expand = kwargs["expand"]
+            self.on_change = None
+            self.on_selection_change = None
+            self.focos = 0
+
+        def focus(self):
+            self.focos += 1
+            return "foco solicitado"
+
+    monkeypatch.setattr(runtime, "require_flet_code_editor", lambda: CodeEditor)
+    editor = runtime.crear_editor_codigo(SimpleNamespace(), value=None)
+    control = editor.obtener_control()
+
+    assert editor.obtener_contenido() == ""
+    editor.establecer_contenido("imprimir('Hola')")
+    assert editor.obtener_contenido() == "imprimir('Hola')"
+    editor.registrar_callback_cambios(callback)
+    assert control.on_change is callback
+    editor.registrar_callback_seleccion(callback_seleccion)
+    assert control.on_selection_change is callback_seleccion
+    assert editor.solicitar_foco() == "foco solicitado"
+    assert control.focos == 1
+    editor.limpiar()
+    assert editor.obtener_contenido() == ""
+    assert control.expand is True
+
+
+@pytest.mark.parametrize(
+    ("texto", "inicio", "fin", "direccion", "esperado"),
+    [
+        pytest.param(
+            "abc", 1, 1, "indentar", ("a    bc", 5, 5), id="cursor-sin-seleccion"
+        ),
+        pytest.param(
+            "uno\ndos", 4, 4, "indentar", ("uno\n    dos", 8, 8), id="inicio-de-linea"
+        ),
+        pytest.param("uno\n", 4, 4, "indentar", ("uno\n    ", 8, 8), id="linea-vacia"),
+        pytest.param(
+            "uno\ndos",
+            0,
+            3,
+            "indentar",
+            ("    uno\ndos", 4, 7),
+            id="una-linea-seleccionada",
+        ),
+        pytest.param(
+            "uno\ndos",
+            0,
+            7,
+            "indentar",
+            ("    uno\n    dos", 4, 15),
+            id="seleccion-multilinea-lf",
+        ),
+        pytest.param("á🐍", 1, 1, "indentar", ("á    🐍", 5, 5), id="unicode"),
+        pytest.param(
+            "uno\r\ndos\r\n",
+            0,
+            8,
+            "indentar",
+            ("    uno\r\n    dos\r\n", 4, 16),
+            id="seleccion-multilinea-crlf",
+        ),
+        pytest.param(
+            "uno\n\ndos",
+            0,
+            8,
+            "indentar",
+            ("    uno\n    \n    dos", 4, 20),
+            id="linea-vacia-seleccionada",
+        ),
+        pytest.param(
+            "  uno", 0, 5, "desindentar", ("uno", 0, 3), id="espacios-parciales"
+        ),
+        pytest.param(
+            "\tuno", 0, 4, "desindentar", ("uno", 0, 3), id="tabulador-literal"
+        ),
+        pytest.param(
+            "    uno\n  dos\n\ttres",
+            0,
+            19,
+            "desindentar",
+            ("uno\ndos\ntres", 0, 12),
+            id="desindentar-multilinea-mixta",
+        ),
+        pytest.param(
+            "abc\ndef",
+            7,
+            0,
+            "indentar",
+            ("    abc\n    def", 15, 4),
+            id="seleccion-invertida",
+        ),
+    ],
+)
+def test_ajustar_indentacion_editor(texto, inicio, fin, direccion, esperado) -> None:
+    assert runtime.ajustar_indentacion_editor(texto, inicio, fin, direccion) == esperado
+
+
+def test_ajustar_indentacion_editor_no_elimina_texto_no_indentado() -> None:
+    assert runtime.ajustar_indentacion_editor("texto", 2, 2, "desindentar") == (
+        "texto",
+        2,
+        2,
+    )
+
+
+def test_boton_sugerencias_se_habilita_si_motor_canonico_disponible(monkeypatch):
+    handler = object()
+    monkeypatch.setattr(
+        runtime,
+        "detectar_motor_ia_sugerencias",
+        lambda: runtime.MotorIASugerencias(disponible=True),
+    )
+
+    boton = runtime.crear_boton_sugerencias_libro(
+        _fake_flet_buttons(), on_click=handler
+    )
+
+    assert boton.text == runtime.SUGERENCIAS_BUTTON_TEXT
+    assert boton.disabled is False
+    assert boton.on_click is handler
+    assert runtime.CANONICAL_SUGGESTION_ENGINE == "agix"
+    assert "agi-core" not in boton.tooltip
+
+
+def test_boton_sugerencias_se_deshabilita_y_menciona_paquete_correcto(monkeypatch):
+    monkeypatch.setattr(
+        runtime,
+        "detectar_motor_ia_sugerencias",
+        lambda: runtime.MotorIASugerencias(disponible=False),
+    )
+
+    boton = runtime.crear_boton_sugerencias_libro(
+        _fake_flet_buttons(), on_click=object()
+    )
+
+    assert boton.disabled is True
+    assert boton.on_click is None
+    assert "agix" in boton.tooltip
+    assert "agi-core" not in boton.tooltip
+
+
+def test_es_archivo_cobra_reconoce_extensiones_seguras_documentadas() -> None:
+    assert runtime.COBRA_FILE_EXTENSIONS == (".cobra", ".co")
+    assert runtime.es_archivo_cobra("programa.co")
+    assert runtime.es_archivo_cobra("modulo.COBRA")
+    assert not runtime.es_archivo_cobra("notas.txt")
+
+
+def test_detectar_tipo_archivo_co_de_texto_sigue_siendo_archivo_cobra(
+    tmp_path: Path,
+) -> None:
+    archivo = tmp_path / "programa.co"
+    archivo.write_text("imprimir('hola')\n", encoding="utf-8")
+
+    assert runtime.detectar_tipo_archivo(archivo) == runtime.TIPO_ARCHIVO_COBRA
+    assert runtime.es_archivo_cobra(archivo)
+
+
+def test_detectar_tipo_archivo_co_zip_con_manifest_es_paquete_cobra(
+    tmp_path: Path,
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    with zipfile.ZipFile(paquete, "w") as zf:
+        zf.writestr("cobra.pkg.json", '{"name":"demo","version":"1.0.0"}')
+        zf.writestr("main.co", "imprimir('hola')\n")
+
+    assert runtime.detectar_tipo_archivo(paquete) == runtime.TIPO_ARCHIVO_PAQUETE_COBRA
+    assert runtime.es_paquete_cobra_gui(paquete)
+    assert not runtime.es_archivo_cobra(paquete)
+
+
+def test_detectar_tipo_archivo_co_zip_sin_manifest_no_es_paquete_cobra_valido(
+    tmp_path: Path,
+) -> None:
+    archivo = tmp_path / "archivo.co"
+    with zipfile.ZipFile(archivo, "w") as zf:
+        zf.writestr("main.co", "imprimir('hola')\n")
+
+    assert runtime.detectar_tipo_archivo(archivo) == runtime.TIPO_ARCHIVO_COBRA
+    assert not runtime.es_paquete_cobra_gui(archivo)
+    assert runtime.es_archivo_cobra(archivo)
+
+
+def test_cargar_archivo_desde_arbol_no_lee_paquete_cobra_zip_como_texto(
+    tmp_path: Path,
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    with zipfile.ZipFile(paquete, "w") as zf:
+        zf.writestr("cobra.pkg.json", '{"name":"demo","version":"1.0.0"}')
+        zf.writestr("main.co", "imprimir('hola')\n")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(paquete, estado)
+
+    assert contenido == ""
+    assert "Paquete Cobra seleccionado" in mensaje
+    assert estado.ruta == paquete.resolve()
+    assert estado.contenido_cargado == ""
+    assert not estado.cambios_sin_guardar
+
+
+def test_detectar_tipo_archivo_clasifica_extensiones_y_nombres_conocidos() -> None:
+    casos = {
+        "main.cobra": runtime.TIPO_ARCHIVO_COBRA,
+        "main.co": runtime.TIPO_ARCHIVO_COBRA,
+        "README.md": runtime.TIPO_ARCHIVO_MARKDOWN,
+        "README.markdown": runtime.TIPO_ARCHIVO_MARKDOWN,
+        "notas.txt": runtime.TIPO_ARCHIVO_TEXTO,
+        "docker-compose.yml": runtime.TIPO_ARCHIVO_DOCKER,
+        "config.json": runtime.TIPO_ARCHIVO_CONFIG,
+        "compose.yaml": runtime.TIPO_ARCHIVO_CONFIG,
+        "pyproject.toml": runtime.TIPO_ARCHIVO_CONFIG,
+        "Dockerfile": runtime.TIPO_ARCHIVO_DOCKER,
+        "Dockerfile.dev": runtime.TIPO_ARCHIVO_DOCKER,
+        ".gitignore": runtime.TIPO_ARCHIVO_IGNORE,
+        ".dockerignore": runtime.TIPO_ARCHIVO_IGNORE,
+        ".env.example": runtime.TIPO_ARCHIVO_ENV_EXAMPLE,
+        "imagen.png": runtime.TIPO_ARCHIVO_DESCONOCIDO,
+    }
+
+    for ruta, tipo_esperado in casos.items():
+        assert runtime.detectar_tipo_archivo(ruta) == tipo_esperado
+
+
+def test_etiqueta_tipo_archivo_devuelve_textos_visibles() -> None:
+    casos = {
+        "programa.cobra": "Archivo Cobra",
+        "README.md": "Archivo Markdown",
+        "notas.txt": "Archivo de texto",
+        "pyproject.toml": "Archivo de configuración",
+        "Dockerfile": "Archivo Docker",
+        ".gitignore": "Archivo ignore",
+        ".env.example": "Archivo de entorno de ejemplo",
+        "imagen.png": "Archivo de texto",
+    }
+
+    for ruta, etiqueta_esperada in casos.items():
+        assert runtime.etiqueta_tipo_archivo(ruta) == etiqueta_esperada
+
+
+def test_crear_titulo_archivo_antepone_etiqueta_y_conserva_asterisco() -> None:
+    estado = runtime.GuiFileState(ruta=Path("README.md"), cambios_sin_guardar=True)
+
+    assert runtime.crear_titulo_archivo(estado) == "Archivo Markdown: README.md *"
+
+
+def test_crear_titulo_archivo_sin_ruta_mantiene_texto_de_archivo_nuevo() -> None:
+    estado = runtime.GuiFileState(cambios_sin_guardar=True)
+
+    assert runtime.crear_titulo_archivo(estado) == "Archivo nuevo (sin guardar) *"
+
+
+def test_capacidades_archivo_reservan_acciones_cobra_para_codigo_cobra() -> None:
+    acciones_cobra = {
+        runtime.ACCION_EJECUTAR,
+        runtime.ACCION_TOKENS,
+        runtime.ACCION_AST,
+        runtime.ACCION_SUGERENCIAS,
+        runtime.ACCION_CORRECCION,
+    }
+    acciones_base = {
+        runtime.ACCION_EDITAR,
+        runtime.ACCION_GUARDAR,
+        runtime.ACCION_RECARGAR,
+        runtime.ACCION_BORRAR,
+    }
+
+    assert acciones_cobra <= runtime.obtener_capacidades_archivo("programa.cobra")
+    assert acciones_base <= runtime.obtener_capacidades_archivo("programa.cobra")
+
+    for ruta in [
+        "README.md",
+        "notas.txt",
+        "config.json",
+        "Dockerfile",
+        ".gitignore",
+        ".env.example",
+        "imagen.png",
+    ]:
+        capacidades = runtime.obtener_capacidades_archivo(ruta)
+        assert capacidades == acciones_base
+        assert not any(
+            runtime.archivo_permite_accion(ruta, accion) for accion in acciones_cobra
+        )
+
+
+def test_archivo_permite_accion_bloquea_acciones_cobra_para_archivos_config() -> None:
+    acciones_cobra = {
+        runtime.ACCION_EJECUTAR,
+        runtime.ACCION_TOKENS,
+        runtime.ACCION_AST,
+        runtime.ACCION_SUGERENCIAS,
+        runtime.ACCION_CORRECCION,
+    }
+    config_file = "config.json"
+
+    for accion in acciones_cobra:
+        assert not runtime.archivo_permite_accion(config_file, accion)
+
+    # Verify base actions are still allowed
+    assert runtime.archivo_permite_accion(config_file, runtime.ACCION_EDITAR)
+    assert runtime.archivo_permite_accion(config_file, runtime.ACCION_GUARDAR)
+    assert runtime.archivo_permite_accion(config_file, runtime.ACCION_RECARGAR)
+    assert runtime.archivo_permite_accion(config_file, runtime.ACCION_BORRAR)
+
+
+def test_listar_directorio_cobra_modo_seguro_incluye_texto_auxiliar_clasificado(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "zeta").mkdir()
+    (tmp_path / "beta.co").write_text("", encoding="utf-8")
+    (tmp_path / "alfa.cobra").write_text("", encoding="utf-8")
+    (tmp_path / "ignorado.py").write_text("", encoding="utf-8")
+    (tmp_path / "README.md").write_text("", encoding="utf-8")
+    (tmp_path / "notas.txt").write_text("", encoding="utf-8")
+
+    assert [path.name for path in runtime.listar_directorio_cobra(tmp_path)] == [
+        "zeta",
+        "alfa.cobra",
+        "beta.co",
+        "ignorado.py",
+        "notas.txt",
+        "README.md",
+    ]
+
+
+def test_listar_directorio_cobra_opcion_interna_muestra_todos_los_archivos(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "zeta").mkdir()
+    (tmp_path / "beta.co").write_text("", encoding="utf-8")
+    (tmp_path / "alfa.cobra").write_text("", encoding="utf-8")
+    (tmp_path / "README.md").write_text("", encoding="utf-8")
+    (tmp_path / "script.py").write_text("", encoding="utf-8")
+
+    assert [
+        path.name
+        for path in runtime.listar_directorio_cobra(tmp_path, mostrar_todos=True)
+    ] == [
+        "zeta",
+        "alfa.cobra",
+        "beta.co",
+        "README.md",
+        "script.py",
+    ]
+
+
+def test_crear_arbol_directorios_acepta_root_path_path_y_str_con_entradas_reales(
+    tmp_path: Path,
+) -> None:
+    class Text:
+        def __init__(self, value="", **_kwargs):
+            self.value = value
+
+    class Icon:
+        def __init__(self, name):
+            self.name = name
+
+    class ListTile:
+        def __init__(self, title=None, leading=None, data=None, on_click=None):
+            self.title = title
+            self.leading = leading
+            self.data = data
+            self.on_click = on_click
+
+    class ExpansionTile:
+        def __init__(self, title=None, leading=None, controls=None):
+            self.title = title
+            self.leading = leading
+            self.controls = controls or []
+
+    class Column:
+        def __init__(self, controls=None, **kwargs):
+            self.controls = controls or []
+            self.scroll = kwargs.get("scroll")
+
+    ft = SimpleNamespace(
+        Text=Text,
+        Icon=Icon,
+        ListTile=ListTile,
+        ExpansionTile=ExpansionTile,
+        Column=Column,
+        Icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
+        ScrollMode=SimpleNamespace(ALWAYS="always"),
+    )
+    (tmp_path / "programa.cobra").write_text("imprimir('cobra')", encoding="utf-8")
+    (tmp_path / "modulo.co").write_text("imprimir('co')", encoding="utf-8")
+
+    arbol_desde_path = runtime.crear_arbol_directorios(
+        ft, on_click=lambda _e: None, root_path=tmp_path
+    )
+    arbol_desde_str = runtime.crear_arbol_directorios(
+        ft, on_click=lambda _e: None, root_path=str(tmp_path)
+    )
+
+    assert [control.title.value for control in arbol_desde_path.controls] == [
+        "modulo.co",
+        "programa.cobra",
+    ]
+    assert [control.title.value for control in arbol_desde_str.controls] == [
+        "modulo.co",
+        "programa.cobra",
+    ]
+    assert all(
+        Path(control.data).exists()
+        for arbol in (arbol_desde_path, arbol_desde_str)
+        for control in arbol.controls
+    )
+
+
+def test_crear_arbol_directorios_sin_root_path_usa_workspace_idle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class Text:
+        def __init__(self, value=None, **_kwargs):
+            self.value = value
+
+    class Column:
+        def __init__(self, controls=None, **kwargs):
+            self.controls = controls or []
+            self.scroll = kwargs.get("scroll")
+
+    ft = SimpleNamespace(
+        Text=Text,
+        Column=Column,
+        ScrollMode=SimpleNamespace(ALWAYS="always"),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    llamadas = []
+
+    def fake_resolver_workspace_root_idle() -> Path:
+        llamadas.append("resolver")
+        return workspace
+
+    monkeypatch.setattr(
+        runtime, "resolver_workspace_root_idle", fake_resolver_workspace_root_idle
+    )
+
+    arbol = runtime.crear_arbol_directorios(ft, on_click=lambda _e: None)
+
+    assert llamadas == ["resolver"]
+    assert arbol.scroll == ft.ScrollMode.ALWAYS
+    assert arbol.controls[0].value == "No hay archivos visibles en esta carpeta"
+
+
+def test_crear_arbol_directorios_propaga_file_not_found_en_ruta_inexistente(
+    tmp_path: Path,
+) -> None:
+    ft = SimpleNamespace()
+    ruta_inexistente = tmp_path / "no_existe"
+
+    with pytest.raises(FileNotFoundError):
+        runtime.crear_arbol_directorios(
+            ft, on_click=lambda _e: None, root_path=ruta_inexistente
+        )
+
+
+def test_crear_arbol_directorios_propaga_permission_error_sin_tocar_permisos(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ft = SimpleNamespace()
+
+    def fake(_root_path):
+        raise PermissionError("sin permiso portable")
+
+    monkeypatch.setattr(runtime, "listar_directorio_idle", fake)
+
+    with pytest.raises(PermissionError, match="sin permiso portable"):
+        runtime.crear_arbol_directorios(
+            ft, on_click=lambda _e: None, root_path=tmp_path
+        )
+
+
+def test_normalizar_codigo_admite_none_y_texto() -> None:
+    assert runtime.normalizar_codigo(None) == ""
+    assert runtime.normalizar_codigo("imprimir('x')") == "imprimir('x')"
+
+
+def test_ejecutar_transpilar_tokens_y_ast() -> None:
+    codigo = "imprimir('Hola')"
+    assert runtime.ejecutar_codigo(codigo) == "Hola\n"
+    assert runtime.transpilar_codigo(codigo, "python").strip()
+    assert "Token(" in runtime.mostrar_tokens(codigo)
+    assert "NodoImprimir" in runtime.mostrar_ast(codigo)
+
+
+def test_transpilar_codigo_usa_transpilador_python_registrado(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llamadas = {"transpiler_inits": 0, "ast": None}
+
+    class FakeLexer:
+        def __init__(self, codigo: str):
+            self.codigo = codigo
+
+        def tokenizar(self):
+            assert self.codigo == "imprimir('Hola')"
+            return ["TOKEN"]
+
+    class FakeParser:
+        def __init__(self, tokens):
+            assert tokens == ["TOKEN"]
+
+        def parsear(self):
+            return ["AST"]
+
+    class TranspiladorPythonRegistrado:
+        def __init__(self):
+            llamadas["transpiler_inits"] += 1
+
+        def generate_code(self, ast):
+            llamadas["ast"] = ast
+            return "codigo python registrado"
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "Lexer": FakeLexer,
+            "Parser": FakeParser,
+            "TRANSPILERS": {"python": TranspiladorPythonRegistrado},
+        },
+    )
+
+    assert (
+        runtime.transpilar_codigo("imprimir('Hola')", "python")
+        == "codigo python registrado"
+    )
+    assert llamadas == {"transpiler_inits": 1, "ast": ["AST"]}
+
+
+def test_generar_reporte_sugerencias_valida_antes_de_sugerir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """La ruta común de sugerencias debe ejecutar Lexer/Parser antes del motor opcional."""
+
+    llamadas: list[str] = []
+
+    def analizar_primero(codigo: str):
+        llamadas.append(f"analizar:{codigo}")
+        return ["TOKEN"], ["AST"]
+
+    def sugerir_despues(codigo: str):
+        llamadas.append(f"sugerir:{codigo}")
+        return ["Usar nombres descriptivos para variables"]
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_primero)
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_despues)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert llamadas == ["analizar:var x = 5", "sugerir:var x = 5"]
+    assert "No se detectaron errores" in reporte
+    assert "- Usar nombres descriptivos para variables" in reporte
+    assert "- Léxico/sintaxis:" in reporte
+    assert "- Estilo:" in reporte
+    assert "- Nombres:" in reporte
+    assert "- Forma canónica:" in reporte
+    assert "- Observabilidad:" in reporte
+
+
+def test_generar_reporte_sugerencias_sin_motor_no_importa_ia(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sin motor IA instalado, la GUI conserva validación y muestra aviso seguro."""
+
+    llamadas: list[str] = []
+
+    def analizar_primero(codigo: str):
+        llamadas.append(f"analizar:{codigo}")
+        return ["TOKEN"], ["AST"]
+
+    def no_debe_importar_ia(_codigo: str):
+        raise AssertionError("No debe cargar la integración IA si el motor falta")
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_primero)
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_importar_ia)
+    monkeypatch.setattr(
+        runtime,
+        "detectar_motor_ia_sugerencias",
+        lambda: runtime.MotorIASugerencias(
+            disponible=False,
+            detalle="Sugerencias deshabilitadas: falta 'agix'.",
+        ),
+    )
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert llamadas == ["analizar:var x = 5"]
+    assert "No se detectaron errores" in reporte
+    assert "Sugerencias deshabilitadas" in reporte
+    assert "falta 'agix'" in reporte
+
+
+def test_generar_reporte_sugerencias_devuelve_error_parser_sin_correcciones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Si Parser falla, no se consulta el motor opcional ni se proponen correcciones aplicables."""
+
+    class FakeLexerError(Exception):
+        pass
+
+    class FakeParserError(Exception):
+        pass
+
+    def analizar_con_error_parser(_codigo: str):
+        raise FakeParserError("Token inesperado en término: EOF")
+
+    def no_debe_llamarse(_codigo: str):
+        raise AssertionError("generar_sugerencias no debe ejecutarse tras ParserError")
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": FakeLexerError, "ParserError": FakeParserError},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_con_error_parser)
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_llamarse)
+
+    reporte = runtime.generar_reporte_sugerencias("var x =")
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert "Error de sintaxis" in reporte
+    assert "Sugerencias del Libro:" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Usar nombres descriptivos" not in reporte
+
+
+def test_generar_reporte_sugerencias_devuelve_error_lexer_sin_correcciones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Si Lexer falla, el reporte prioriza el error léxico y bloquea sugerencias."""
+
+    class FakeLexerError(Exception):
+        linea = 1
+        columna = 11
+
+    class FakeParserError(Exception):
+        pass
+
+    def analizar_con_error_lexer(_codigo: str):
+        raise FakeLexerError("Token no reconocido: '¿'")
+
+    def no_debe_llamarse(_codigo: str):
+        raise AssertionError("generar_sugerencias no debe ejecutarse tras LexerError")
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": FakeLexerError, "ParserError": FakeParserError},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_con_error_lexer)
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_llamarse)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5 ¿")
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert "Error léxico" in reporte
+    assert "Sugerencias del Libro:" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Usar nombres descriptivos" not in reporte
+
+
+def test_generar_reporte_sugerencias_codigo_cobra_valido_con_fixture_minimo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fixture mínimo con tokens y declaración soportados por Lexer/Parser."""
+
+    llamadas: list[str] = []
+
+    def analizar_fixture_minimo(codigo: str):
+        llamadas.append(codigo)
+        return ["VAR", "IDENTIFICADOR", "ASIGNAR", "ENTERO"], ["NodoAsignacion"]
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_fixture_minimo)
+    monkeypatch.setattr(
+        runtime,
+        "generar_sugerencias",
+        lambda _codigo: ["Usar nombres descriptivos para variables"],
+    )
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+    assert "- Usar nombres descriptivos para variables" in reporte
+    assert llamadas == ["var x = 5"]
+
+
+def test_generar_reporte_sugerencias_codigo_valido_usa_lexer_parser_reales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Con código Cobra válido, la GUI solo sugiere después del Lexer/Parser real."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+    llamadas: list[str] = []
+
+    def sugerir_tras_validacion(codigo: str) -> list[str]:
+        llamadas.append(codigo)
+        return [
+            "Usar nombres descriptivos para variables "
+            "[regla: LP-3.1-NOMBRES-DESCRIPTIVOS; §3.1 Léxico]"
+        ]
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_tras_validacion)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert llamadas == ["var x = 5"]
+    assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+    assert "LP-3.1-NOMBRES-DESCRIPTIVOS" in reporte
+    assert "- Usar nombres descriptivos para variables" in reporte
+
+
+@pytest.mark.parametrize(
+    "codigo_invalido, tipo_error",
+    [
+        ("var x = 5 ¿", "Error léxico"),
+        ("var x =", "Error de sintaxis"),
+    ],
+)
+def test_generar_reporte_sugerencias_codigo_invalido_real_bloquea_estilo(
+    monkeypatch: pytest.MonkeyPatch, codigo_invalido: str, tipo_error: str
+) -> None:
+    """La GUI muestra el error real y no genera sugerencias estilísticas aplicables."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+
+    def no_debe_sugerir(_codigo: str) -> list[str]:
+        raise AssertionError("No se deben sugerir estilos con código inválido")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_sugerir)
+
+    reporte = runtime.generar_reporte_sugerencias(codigo_invalido)
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert tipo_error in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "LP-3.1-NOMBRES-DESCRIPTIVOS" not in reporte
+    assert "Usar nombres descriptivos para variables" not in reporte
+
+
+def test_generar_reporte_sugerencias_no_ejecuta_ia_hasta_lexer_y_parser_reales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Código válido: la GUI obtiene sugerencias solo después del Lexer/Parser reales."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+    eventos: list[str] = []
+    analizar_real = runtime.analizar_codigo
+
+    def analizar_con_traza(codigo: str):
+        eventos.append("lexer_parser")
+        tokens, ast = analizar_real(codigo)
+        assert tokens
+        assert ast
+        return tokens, ast
+
+    def sugerir_con_traza(codigo: str) -> list[str]:
+        eventos.append("sugerencias")
+        assert eventos == ["lexer_parser", "sugerencias"]
+        return [
+            "Usar nombres descriptivos para variables "
+            "[regla: LP-3.1-NOMBRES-DESCRIPTIVOS; §3.1 Léxico]"
+        ]
+
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_con_traza)
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_con_traza)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert eventos == ["lexer_parser", "sugerencias"]
+    assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+    assert "LP-3.1-NOMBRES-DESCRIPTIVOS" in reporte
+
+
+@pytest.mark.parametrize(
+    ("codigo_invalido", "tipo_error"),
+    [
+        ("var x = 5 ¿", "Error léxico"),
+        ("var x =", "Error de sintaxis"),
+    ],
+)
+def test_generar_reporte_sugerencias_gui_rechaza_invalidos_reales_sin_estilo_aplicable(
+    monkeypatch: pytest.MonkeyPatch, codigo_invalido: str, tipo_error: str
+) -> None:
+    """Errores reales del Lexer/Parser se muestran en GUI y bloquean reglas de estilo."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+    llamadas_sugerencias = 0
+
+    def no_sugerir(_codigo: str) -> list[str]:
+        nonlocal llamadas_sugerencias
+        llamadas_sugerencias += 1
+        raise AssertionError("No debe generar sugerencias estilísticas aplicables")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_sugerir)
+
+    reporte = runtime.generar_reporte_sugerencias(codigo_invalido)
+
+    assert llamadas_sugerencias == 0
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert tipo_error in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "LP-3.1-NOMBRES-DESCRIPTIVOS" not in reporte
+    assert "Usar nombres descriptivos para variables" not in reporte
+
+
+@pytest.mark.parametrize(
+    ("codigo", "esperado"),
+    [
+        ("var x = 5", "Sugerencias del Libro:"),
+        ("var x =", "Error de sintaxis"),
+        ("var x = 5 ¿", "Error léxico"),
+    ],
+)
+def test_ruta_sugerencias_cubre_fixtures_minimos_reales_de_cobra(
+    monkeypatch: pytest.MonkeyPatch, codigo: str, esperado: str
+) -> None:
+    """Fixtures mínimos reales: declaración válida y errores Lexer/Parser."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+    llamadas_sugerencias: list[str] = []
+
+    def sugerir_solo_si_parsea(codigo_validado: str) -> list[str]:
+        llamadas_sugerencias.append(codigo_validado)
+        return ["Usar nombres descriptivos para variables"]
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_solo_si_parsea)
+
+    reporte = runtime.generar_reporte_sugerencias(codigo)
+
+    assert esperado in reporte
+    if codigo == "var x = 5":
+        assert llamadas_sugerencias == [codigo]
+        assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+        assert "- Usar nombres descriptivos para variables" in reporte
+    else:
+        assert llamadas_sugerencias == []
+        assert "Corrige primero los errores anteriores" in reporte
+        assert "- Usar nombres descriptivos para variables" not in reporte
+
+
+def test_ruta_sugerencias_parser_fallido_no_expone_correccion_aplicable_real(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un ParserError real corta la ruta antes del motor opcional y de reglas aplicables."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+
+    def no_sugerir(_codigo: str) -> list[str]:
+        raise AssertionError("No debe proponer correcciones si Parser falla")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_sugerir)
+
+    reporte = runtime.generar_reporte_sugerencias("var x =")
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert "Error de sintaxis" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Sugerencias del Libro:" in reporte
+    assert "Usar nombres descriptivos" not in reporte
+
+
+def test_formatear_error_lexico_y_sintaxis() -> None:
+    class FakeLexerError(Exception):
+        linea = 2
+        columna = 4
+
+    class FakeParserError(Exception):
+        pass
+
+    assert runtime.formatear_error(
+        FakeLexerError("carácter inválido"),
+        lexer_error_type=FakeLexerError,
+        parser_error_type=FakeParserError,
+    ).startswith("Error léxico")
+    assert runtime.formatear_error(
+        FakeParserError("faltó cierre"),
+        lexer_error_type=FakeLexerError,
+        parser_error_type=FakeParserError,
+    ).startswith("Error de sintaxis")
+
+
+def test_gui_target_choices_filtra_targets_no_oficiales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "target_cli_choices": lambda targets: tuple(sorted(targets)),
+            "OFFICIAL_TARGETS": ("python", "javascript", "rust"),
+            "TRANSPILERS": {"python": object, "backend_x": object, "rust": object},
+        },
+    )
+
+    assert runtime.gui_target_choices() == ("python", "rust")
+
+
+def test_accion_nuevo_archivo_reinicia_estado() -> None:
+    estado = runtime.GuiFileState(
+        ruta=Path("programa.cobra"),
+        contenido_cargado="imprimir('x')",
+        cambios_sin_guardar=True,
+    )
+
+    contenido, mensaje = runtime.crear_archivo_nuevo_en_editor(estado)
+
+    assert contenido == ""
+    assert mensaje == "Archivo nuevo creado en memoria."
+    assert estado == runtime.GuiFileState()
+
+
+def test_accion_abrir_archivo_desde_ruta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('hola')", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.abrir_archivo_desde_ruta(archivo, estado)
+
+    assert contenido == "imprimir('hola')"
+    assert estado.ruta == archivo.resolve()
+    assert estado.contenido_cargado == "imprimir('hola')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_activo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('antes')", encoding="utf-8")
+    estado = runtime.GuiFileState(
+        ruta=archivo.resolve(),
+        contenido_cargado="imprimir('antes')",
+        cambios_sin_guardar=True,
+    )
+
+    contenido, mensaje = runtime.guardar_archivo_activo("imprimir('despues')", estado)
+
+    assert contenido == "imprimir('despues')"
+    assert archivo.read_text(encoding="utf-8") == "imprimir('despues')"
+    assert estado.contenido_cargado == "imprimir('despues')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_activo_sin_ruta_falla() -> None:
+    with pytest.raises(ValueError, match="No hay archivo activo"):
+        runtime.guardar_archivo_activo("imprimir('x')", runtime.GuiFileState())
+
+
+def test_accion_guardar_archivo_como(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    destino = tmp_path / "nuevo.cobra"
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.guardar_archivo_como(
+        destino, "imprimir('nuevo')", estado
+    )
+
+    assert contenido == "imprimir('nuevo')"
+    assert destino.read_text(encoding="utf-8") == "imprimir('nuevo')"
+    assert estado.ruta == destino.resolve()
+    assert estado.contenido_cargado == "imprimir('nuevo')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {destino.resolve()}"
+
+
+def test_accion_abrir_archivo_respeta_sandbox_con_ruta_absoluta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('sandbox')", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.abrir_archivo_desde_ruta(archivo.resolve(), estado)
+
+    assert contenido == "imprimir('sandbox')"
+    assert estado.ruta == archivo.resolve()
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_activo_respeta_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('antes')", encoding="utf-8")
+    estado = runtime.GuiFileState(ruta=archivo.resolve(), cambios_sin_guardar=True)
+
+    contenido, mensaje = runtime.guardar_archivo_activo("imprimir('despues')", estado)
+
+    assert contenido == "imprimir('despues')"
+    assert archivo.read_text(encoding="utf-8") == "imprimir('despues')"
+    assert estado.ruta == archivo.resolve()
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_como_respeta_sandbox_con_ruta_relativa(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.guardar_archivo_como(
+        "nuevo.cobra", "imprimir('nuevo')", estado
+    )
+
+    destino = tmp_path / "nuevo.cobra"
+    assert contenido == "imprimir('nuevo')"
+    assert destino.read_text(encoding="utf-8") == "imprimir('nuevo')"
+    assert estado.ruta == destino.resolve()
+    assert mensaje == f"Archivo guardado: {destino.resolve()}"
+
+
+@pytest.mark.parametrize(
+    ("accion", "argumentos"),
+    [
+        ("abrir", lambda fuera: (fuera,)),
+        ("guardar", lambda fuera: (fuera, "imprimir('x')")),
+        ("guardar_como", lambda fuera: (fuera, "imprimir('x')")),
+    ],
+)
+def test_acciones_archivo_rechazan_rutas_fuera_del_sandbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    accion: str,
+    argumentos,
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    fuera = tmp_path.parent / "fuera.cobra"
+    fuera.write_text("imprimir('fuera')", encoding="utf-8")
+    estado = runtime.GuiFileState(ruta=fuera if accion == "guardar" else None)
+
+    with pytest.raises(ValueError, match="fuera del directorio permitido"):
+        if accion == "abrir":
+            runtime.abrir_archivo_desde_ruta(*argumentos(fuera), estado)
+        elif accion == "guardar":
+            runtime.guardar_archivo_activo(argumentos(fuera)[1], estado)
+        else:
+            runtime.guardar_archivo_como(*argumentos(fuera), estado)
+
+
+def test_accion_recargar_archivo_activo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('disco')", encoding="utf-8")
+    estado = runtime.GuiFileState(
+        ruta=archivo.resolve(),
+        contenido_cargado="imprimir('memoria')",
+        cambios_sin_guardar=True,
+    )
+
+    contenido, mensaje = runtime.recargar_archivo_activo(estado)
+
+    assert contenido == "imprimir('disco')"
+    assert estado.contenido_cargado == "imprimir('disco')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+
+def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "notas.txt"
+    archivo.write_text("notas del proyecto", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo, estado)
+
+    assert runtime.detectar_tipo_archivo(archivo) == runtime.TIPO_ARCHIVO_TEXTO
+    assert not runtime.es_archivo_cobra(archivo)
+    assert contenido == "notas del proyecto"
+    assert estado.ruta == archivo.resolve()
+    assert estado.contenido_cargado == "notas del proyecto"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+    desconocido = tmp_path / "imagen.png"
+    desconocido.write_bytes(b"texto plano compatible utf-8")
+
+    contenido_desconocido, mensaje_desconocido = runtime.cargar_archivo_desde_arbol(
+        desconocido, estado
+    )
+
+    assert (
+        runtime.detectar_tipo_archivo(desconocido) == runtime.TIPO_ARCHIVO_DESCONOCIDO
+    )
+    assert contenido_desconocido == "texto plano compatible utf-8"
+    assert estado.ruta == desconocido.resolve()
+    assert estado.contenido_cargado == "texto plano compatible utf-8"
+    assert mensaje_desconocido == f"Archivo cargado: {desconocido.resolve()}"
+
+
+def _crear_proyecto_cobra_minimo(tmp_path: Path) -> Path:
+    project_root = tmp_path / "paquete_demo"
+    (project_root / "src").mkdir(parents=True)
+    (project_root / "assets").mkdir()
+    (project_root / "src" / "main.cobra").write_text(
+        "imprimir('hola paquete')\n", encoding="utf-8"
+    )
+    (project_root / "README.md").write_text("# Paquete demo\n", encoding="utf-8")
+    (project_root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (project_root / "assets" / "recurso.txt").write_text("recurso\n", encoding="utf-8")
+    return project_root
+
+
+def test_idle_crear_paquete_crea_manifest_en_proyecto_minimo(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+
+    manifest = runtime.idle_crear_paquete(project_root, "paquete demo", version="1.2.3")
+
+    assert manifest == project_root / "cobra.pkg.json"
+    data = manifest.read_text(encoding="utf-8")
+    assert '"name": "paquete-demo"' in data
+    assert '"version": "1.2.3"' in data
+    assert (project_root / "src" / "main.cobra").read_text(
+        encoding="utf-8"
+    ) == "imprimir('hola paquete')\n"
+    assert (project_root / "README.md").read_text(
+        encoding="utf-8"
+    ) == "# Paquete demo\n"
+    assert (project_root / "Dockerfile").read_text(encoding="utf-8") == "FROM scratch\n"
+    assert (project_root / "assets" / "recurso.txt").read_text(
+        encoding="utf-8"
+    ) == "recurso\n"
+
+
+def test_idle_construir_y_validar_paquete_incluye_archivos_del_proyecto_minimo(
+    tmp_path: Path,
+) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    salida = tmp_path / "dist" / "paquete-demo.co"
+
+    paquete = runtime.idle_construir_paquete(project_root, salida)
+    inspection = runtime.idle_validar_paquete(paquete)
+
+    assert paquete == salida
+    assert inspection.manifest["name"] == "paquete-demo"
+    assert inspection.manifest["version"] == "1.0.0"
+    assert "src/main.cobra" in inspection.files
+    assert "README.md" in inspection.files
+    assert "Dockerfile" in inspection.files
+    assert "assets/recurso.txt" in inspection.files
+
+
+def test_idle_construir_paquete_respeta_salida_indicada(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    salida = tmp_path / "artefactos" / "destino-personalizado.co"
+
+    paquete = runtime.idle_construir_paquete(project_root, salida)
+
+    assert paquete == salida
+    assert paquete.is_file()
+
+
+def test_idle_abrir_paquete_extrae_proyecto_minimo(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    paquete = runtime.idle_construir_paquete(project_root)
+    destino = tmp_path / "extraido"
+    destino.mkdir()
+
+    extraido = runtime.idle_abrir_paquete(paquete, destino)
+
+    assert extraido == destino.resolve()
+    assert (destino / "src" / "main.cobra").read_text(
+        encoding="utf-8"
+    ) == "imprimir('hola paquete')\n"
+    assert (destino / "README.md").read_text(encoding="utf-8") == "# Paquete demo\n"
+    assert (destino / "Dockerfile").read_text(encoding="utf-8") == "FROM scratch\n"
+    assert (destino / "assets" / "recurso.txt").read_text(
+        encoding="utf-8"
+    ) == "recurso\n"
+
+
+def test_idle_validar_paquete_muestra_error_para_paquete_invalido(
+    tmp_path: Path,
+) -> None:
+    paquete = tmp_path / "invalido.co"
+    paquete.write_text("no es un zip cobra", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="paquete Cobra válido"):
+        runtime.idle_validar_paquete(paquete)
+
+
+def test_idle_abrir_paquete_delega_en_extraer_paquete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    paquete.write_bytes(b"contenido de prueba")
+    destino = tmp_path / "destino"
+    destino.mkdir()
+    llamadas: list[tuple[Path, Path]] = []
+
+    def fake_extraer_paquete(paquete_arg, destino_arg):
+        llamadas.append((paquete_arg, destino_arg))
+        return Path(destino_arg)
+
+    monkeypatch.setattr("pcobra.cobra.packaging.extraer_paquete", fake_extraer_paquete)
+
+    assert runtime.idle_abrir_paquete(paquete, destino) == destino
+    assert llamadas == [(paquete, destino)]
+
+
+def test_idle_abrir_paquete_falla_si_destino_no_existe(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    paquete = runtime.idle_construir_paquete(project_root)
+    destino = tmp_path / "destino-inexistente"
+
+    with pytest.raises(FileNotFoundError, match="Destino de extracción inexistente"):
+        runtime.idle_abrir_paquete(paquete, destino)
+
+
+def test_idle_construir_paquete_falla_si_falta_manifest(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+
+    with pytest.raises(
+        FileNotFoundError, match="Usa 'Crear paquete' antes de construir"
+    ):
+        runtime.idle_construir_paquete(project_root)
+
+
+def test_idle_construir_paquete_exige_cobra_pkg_json_antes_de_delegar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    salida = tmp_path / "no-debe-crearse.co"
+
+    def construir_paquete_mock(*_args, **_kwargs):
+        raise AssertionError("No debe construir sin cobra.pkg.json")
+
+    monkeypatch.setattr(
+        "pcobra.cobra.packaging.construir_paquete", construir_paquete_mock
+    )
+
+    with pytest.raises(FileNotFoundError, match="falta cobra\\.pkg\\.json"):
+        runtime.idle_construir_paquete(project_root, salida)
+
+    assert not salida.exists()
+
+
+def test_idle_publicar_paquete_expone_fallo_de_publicacion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    paquete.write_text("contenido", encoding="utf-8")
+
+    def publicar_mock(self, ruta: str) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete",
+        publicar_mock,
+    )
+
+    assert runtime.idle_publicar_paquete(paquete) is False
+
+
+def test_botones_idle_de_paquetes_delegan_solo_en_helpers_runtime() -> None:
+    source = Path("src/pcobra/gui/idle.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    package_handlers = {
+        "crear_paquete_handler": "idle_crear_paquete",
+        "abrir_paquete_handler": "idle_abrir_paquete",
+        "validar_paquete_handler": "idle_validar_paquete",
+        "construir_paquete_handler": "idle_construir_paquete",
+        "publicar_paquete_handler": "idle_publicar_paquete",
+    }
+    handler_nodes = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in package_handlers
+    }
+
+    assert set(handler_nodes) == set(package_handlers)
+    for handler_name, helper_name in package_handlers.items():
+        runtime_calls = [
+            call.func.attr
+            for call in ast.walk(handler_nodes[handler_name])
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "runtime"
+        ]
+        assert helper_name in runtime_calls
+
+    forbidden_imports = {
+        "pcobra.cobra.packaging",
+        "pcobra.cobra.cli.cobrahub_client",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module not in forbidden_imports
+        elif isinstance(node, ast.Import):
+            assert all(alias.name not in forbidden_imports for alias in node.names)
+
+
+def test_idle_publicar_paquete_delega_en_cobrahub_packages_sin_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    paquete = runtime.idle_construir_paquete(project_root)
+    llamadas: list[str] = []
+
+    def publicar_mock(self, ruta: str) -> bool:
+        llamadas.append(ruta)
+        return True
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete",
+        publicar_mock,
+    )
+
+    assert runtime.idle_publicar_paquete(paquete) is True
+    assert llamadas == [str(paquete)]
+
+
+def test_idle_publicar_paquete_no_delega_en_metodo_legacy_del_cliente(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    paquete.write_text("contenido", encoding="utf-8")
+    llamadas: list[str] = []
+
+    def publicar_packages_mock(self, ruta: str) -> bool:
+        llamadas.append(ruta)
+        return True
+
+    def publicar_cliente_legacy_mock(self, ruta: str) -> bool:
+        raise AssertionError(
+            "El IDLE no debe publicar mediante CobraHubClient.publicar_paquete"
+        )
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete",
+        publicar_packages_mock,
+    )
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_client.CobraHubClient.publicar_paquete",
+        publicar_cliente_legacy_mock,
+    )
+
+    assert runtime.idle_publicar_paquete(paquete) is True
+    assert llamadas == [str(paquete)]
+
+
+def test_helpers_idle_de_paquetes_no_importan_lexer_ni_parser_y_delegan_en_packaging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    paquete = tmp_path / "paquete.co"
+    destino = tmp_path / "destino"
+    destino.mkdir()
+    llamadas: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    def fake_crear_paquete(*args, **kwargs):
+        llamadas.append(("crear_paquete", args, kwargs))
+        return project_root / "cobra.pkg.json"
+
+    def fake_validar_paquete(*args, **kwargs):
+        llamadas.append(("validar_paquete", args, kwargs))
+        return SimpleNamespace(path=paquete)
+
+    def fake_construir_paquete(*args, **kwargs):
+        llamadas.append(("construir_paquete", args, kwargs))
+        return paquete
+
+    def fake_extraer_paquete(*args, **kwargs):
+        llamadas.append(("extraer_paquete", args, kwargs))
+        return destino
+
+    monkeypatch.setattr("pcobra.cobra.packaging.crear_paquete", fake_crear_paquete)
+    monkeypatch.setattr("pcobra.cobra.packaging.validar_paquete", fake_validar_paquete)
+    monkeypatch.setattr(
+        "pcobra.cobra.packaging.construir_paquete", fake_construir_paquete
+    )
+    monkeypatch.setattr("pcobra.cobra.packaging.extraer_paquete", fake_extraer_paquete)
+
+    real_import = __import__
+
+    def fail_lexer_parser_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pcobra.cobra.core" and {"Lexer", "Parser"} & set(
+            fromlist or ()
+        ):  # pragma: no cover - solo falla si hay regresión
+            raise AssertionError(
+                "Los helpers IDLE de paquetes no deben importar Lexer ni Parser"
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fail_lexer_parser_import)
+
+    manifest = project_root / "cobra.pkg.json"
+    manifest.write_text("{}", encoding="utf-8")
+
+    assert (
+        runtime.idle_crear_paquete(project_root, "paquete-demo", version="2.0.0")
+        == project_root / "cobra.pkg.json"
+    )
+    assert runtime.idle_validar_paquete(paquete).path == paquete
+    assert runtime.idle_construir_paquete(project_root, paquete) == paquete
+    assert runtime.idle_abrir_paquete(paquete, destino) == destino
+
+    assert llamadas == [
+        (
+            "crear_paquete",
+            (project_root.resolve(),),
+            {"nombre": "paquete-demo", "version": "2.0.0"},
+        ),
+        ("validar_paquete", (paquete,), {}),
+        ("construir_paquete", (project_root.resolve(), paquete), {}),
+        ("extraer_paquete", (paquete, destino), {}),
+    ]
+
+
+def test_require_flet_error_accionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = __import__
+
+    def _import_fail_flet(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "flet":
+            raise ModuleNotFoundError("No module named 'flet'", name="flet")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _import_fail_flet)
+
+    with pytest.raises(RuntimeError, match="pip install flet"):
+        runtime.require_flet()
+
+
+def test_require_gui_dependencies_error_accionable_modulo_ausente(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = __import__
+
+    def _import_fail_core(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pcobra.cobra.gui" and fromlist:
+            raise ModuleNotFoundError(
+                "No module named 'pcobra.core.interpreter'",
+                name="pcobra.core.interpreter",
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _import_fail_core)
+
+    with pytest.raises(
+        RuntimeError, match="faltante detectado 'pcobra.core.interpreter'"
+    ) as excinfo:
+        runtime.require_gui_dependencies()
+    assert "Acción sugerida" in str(excinfo.value)
+
+
+def test_require_gui_dependencies_error_accionable_simbolo_ausente(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = __import__
+
+    def _import_fail_symbol(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pcobra.cobra.gui" and fromlist:
+            raise ImportError("cannot import name 'Lexer' from 'pcobra.cobra.core'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _import_fail_symbol)
+
+    with pytest.raises(
+        RuntimeError, match="faltante detectado 'pcobra.cobra.core.Lexer'"
+    ) as excinfo:
+        runtime.require_gui_dependencies()
+    assert "corrige el import local de 'pcobra.cobra.core.Lexer'" in str(excinfo.value)
+
+
+def test_require_gui_dependencies_cachea_resultado(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llamadas = {"count": 0}
+    fake_deps = SimpleNamespace(
+        Lexer=object,
+        LexerError=Exception,
+        Parser=object,
+        ParserError=Exception,
+        target_cli_choices=lambda _targets: (),
+        OFFICIAL_TARGETS=("python", "javascript", "rust"),
+        InterpretadorCobra=object,
+        get_transpilers=lambda: {"python": object},
+    )
+    real_import = __import__
+
+    def _import_fake_gui(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pcobra.cobra.gui" and fromlist:
+            llamadas["count"] += 1
+            return SimpleNamespace(deps=fake_deps)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _import_fake_gui)
+
+    deps_a = runtime.require_gui_dependencies()
+    deps_b = runtime.require_gui_dependencies()
+
+    assert deps_a is deps_b
+    assert llamadas["count"] == 1
+
+
+def test_formatear_error_no_masking_si_fallan_dependencias() -> None:
+    exc = RuntimeError(
+        "Error de importación GUI en 'pcobra.gui.runtime': faltante detectado 'x.y'. "
+        "Detalle: No module named 'x.y'. Acción sugerida: instala la dependencia."
+    )
+    assert runtime.formatear_error(exc) == (
+        "Error de ejecución: "
+        "Error de importación GUI en 'pcobra.gui.runtime': faltante detectado 'x.y'. "
+        "Detalle: No module named 'x.y'. Acción sugerida: instala la dependencia."
+    )
+
+
+def test_formatear_error_lexico_y_sintactico_sin_recargar_dependencias(
+    monkeypatch,
+) -> None:
+    class FakeLexerError(Exception):
+        def __init__(self):
+            self.linea = 7
+            self.columna = 3
+            super().__init__("token inesperado")
+
+    class FakeParserError(Exception):
+        pass
+
+    llamadas = {"count": 0}
+
+    def _fail_if_called():
+        llamadas["count"] += 1
+        raise AssertionError("formatear_error no debe recargar dependencias")
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _fail_if_called)
+
+    assert runtime.formatear_error(
+        FakeLexerError(),
+        lexer_error_type=FakeLexerError,
+        parser_error_type=FakeParserError,
+    ).startswith("Error léxico (línea 7, columna 3)")
+    assert (
+        runtime.formatear_error(
+            FakeParserError("faltó ')'"),
+            lexer_error_type=FakeLexerError,
+            parser_error_type=FakeParserError,
+        )
+        == "Error de sintaxis: faltó ')'"
+    )
+    assert llamadas["count"] == 0
+
+
+def test_crear_handler_sugerencias_usa_ruta_canonica(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entrada = SimpleNamespace(value="imprimir('Hola')")
+    salida = SimpleNamespace(value="")
+    page = SimpleNamespace(updated=False, update=lambda: setattr(page, "updated", True))
+    llamadas: list[str] = []
+
+    def _generar_reporte(codigo: str) -> str:
+        llamadas.append(codigo)
+        return "reporte común"
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(runtime, "generar_reporte_sugerencias", _generar_reporte)
+
+    handler = runtime.crear_handler_sugerencias(
+        entrada=entrada, salida=salida, page=page
+    )
+    handler(None)
+
+    assert llamadas == ["imprimir('Hola')"]
+    assert salida.value == "reporte común"
+    assert page.updated is True
+
+
+def test_crear_handler_sugerencias_agix_es_alias_deprecado_interno(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entrada = SimpleNamespace(value="imprimir('Hola')")
+    salida = SimpleNamespace(value="")
+    page = SimpleNamespace(updated=False)
+    llamadas = []
+
+    def _handler(evento: object) -> None:
+        llamadas.append((entrada, salida, page, evento))
+        salida.value = "reporte común"
+        page.updated = True
+
+    def _crear_handler_sugerencias(**kwargs: object) -> object:
+        assert kwargs == {"entrada": entrada, "salida": salida, "page": page}
+        return _handler
+
+    monkeypatch.setattr(
+        runtime, "crear_handler_sugerencias", _crear_handler_sugerencias
+    )
+
+    with pytest.warns(DeprecationWarning, match="crear_handler_sugerencias"):
+        handler = runtime.crear_handler_sugerencias_agix(
+            entrada=entrada, salida=salida, page=page
+        )
+    handler(None)
+
+    assert llamadas == [(entrada, salida, page, None)]
+    assert salida.value == "reporte común"
+    assert page.updated is True
+
+
+def test_guardar_como_por_ruta_y_filepicker_actualizan_estado_igual(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    destino_ruta = tmp_path / "desde_ruta.cobra"
+    destino_picker = tmp_path / "desde_picker.cobra"
+    codigo = "imprimir('mismo')"
+
+    estado_ruta = runtime.GuiFileState(cambios_sin_guardar=True)
+    contenido, mensaje = runtime.guardar_archivo_como(destino_ruta, codigo, estado_ruta)
+
+    picker_creados = []
+
+    class Text:
+        def __init__(self, value="", **_kwargs):
+            self.value = value
+
+    class FilePicker:
+        def __init__(self, on_result=None):
+            self.on_result = on_result
+            self.save_file_args = None
+            picker_creados.append(self)
+
+        def save_file(self, **kwargs):
+            self.save_file_args = kwargs
+
+    flet_runtime = SimpleNamespace(Text=Text, FilePicker=FilePicker)
+    monkeypatch.setattr(runtime, "require_flet", lambda: flet_runtime)
+
+    estado_picker = runtime.GuiFileState(cambios_sin_guardar=True)
+    entrada = SimpleNamespace(value=codigo)
+    page = SimpleNamespace(
+        overlay=[],
+        snack_bar=SimpleNamespace(open=False, content=None),
+        update=lambda: None,
+    )
+
+    handler = runtime.crear_handler_guardar_como(
+        entrada=entrada, estado_archivo=estado_picker, page=page
+    )
+    handler(None)
+    assert page.overlay == picker_creados
+    assert picker_creados[0].save_file_args == {
+        "dialog_title": "Guardar archivo del proyecto Cobra",
+        "file_name": "nuevo_archivo.txt",
+        "allowed_extensions": [
+            "cobra",
+            "co",
+            "md",
+            "markdown",
+            "txt",
+            "json",
+            "yml",
+            "yaml",
+            "toml",
+            "docker-compose.yml",
+        ],
+    }
+    picker_creados[0].on_result(SimpleNamespace(path=str(destino_picker)))
+
+    assert contenido == codigo
+    assert destino_ruta.read_text(encoding="utf-8") == codigo
+    assert destino_picker.read_text(encoding="utf-8") == codigo
+    assert estado_ruta.ruta == destino_ruta.resolve()
+    assert estado_picker.ruta == destino_picker.resolve()
+    assert estado_ruta.contenido_cargado == estado_picker.contenido_cargado == codigo
+    assert estado_ruta.cambios_sin_guardar is estado_picker.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {destino_ruta.resolve()}"
+    assert page.snack_bar.open is True
+    assert (
+        page.snack_bar.content.value == f"Archivo guardado: {destino_picker.resolve()}"
+    )
+
+
+def test_guardar_como_filepicker_usa_mensaje_de_exito_compartido(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    destino = tmp_path / "mensaje.cobra"
+
+    class Text:
+        def __init__(self, value="", **_kwargs):
+            self.value = value
+
+    class FilePicker:
+        def __init__(self, on_result=None):
+            self.on_result = on_result
+
+        def save_file(self, **_kwargs):
+            pass
+
+    picker = None
+
+    class CapturingFilePicker(FilePicker):
+        def __init__(self, on_result=None):
+            nonlocal picker
+            super().__init__(on_result=on_result)
+            picker = self
+
+    monkeypatch.setattr(
+        runtime,
+        "require_flet",
+        lambda: SimpleNamespace(Text=Text, FilePicker=CapturingFilePicker),
+    )
+    page = SimpleNamespace(
+        overlay=[],
+        snack_bar=SimpleNamespace(open=False, content=None),
+        update=lambda: None,
+    )
+    estado = runtime.GuiFileState()
+    handler = runtime.crear_handler_guardar_como(
+        entrada=SimpleNamespace(value="imprimir('ok')"),
+        estado_archivo=estado,
+        page=page,
+    )
+
+    handler(None)
+    picker.on_result(SimpleNamespace(path=str(destino)))
+
+    assert page.snack_bar.content.value == f"Archivo guardado: {destino.resolve()}"
+    assert estado.ruta == destino.resolve()
+    assert estado.contenido_cargado == "imprimir('ok')"
+    assert estado.cambios_sin_guardar is False
+
+
+def test_resolver_ruta_archivo_en_project_root_relativa_y_extension_por_defecto(
+    tmp_path: Path,
+) -> None:
+    destino = runtime.resolver_ruta_archivo_en_project_root("src/programa", tmp_path)
+
+    assert destino == (tmp_path / "src" / "programa.cobra").resolve()
+
+
+@pytest.mark.parametrize(
+    ("ruta", "esperado"),
+    [
+        ("main", "main.cobra"),
+        ("src/main", "src/main.cobra"),
+        ("main.co", "main.co"),
+        ("main.cobra", "main.cobra"),
+    ],
+)
+def test_resolver_ruta_archivo_en_project_root_normaliza_extensiones_cobra(
+    tmp_path: Path, ruta: str, esperado: str
+) -> None:
+    destino = runtime.resolver_ruta_archivo_en_project_root(ruta, tmp_path)
+
+    assert destino == (tmp_path / esperado).resolve()
+
+
+def test_resolver_ruta_archivo_en_project_root_rechaza_extension_no_cobra(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="extensión .cobra o .co"):
+        runtime.resolver_ruta_archivo_en_project_root("main.txt", tmp_path)
+
+
+def test_resolver_ruta_archivo_en_project_root_acepta_absoluta_interna(
+    tmp_path: Path,
+) -> None:
+    archivo = tmp_path / "programa.co"
+
+    destino = runtime.resolver_ruta_archivo_en_project_root(archivo, tmp_path)
+
+    assert destino == archivo.resolve()
+
+
+def test_resolver_ruta_archivo_en_project_root_rechaza_absoluta_externa(
+    tmp_path: Path,
+) -> None:
+    archivo_externo = tmp_path.parent / "externo_idle_helper.cobra"
+    archivo_externo.write_text("imprimir('externo')", encoding="utf-8")
+
+    try:
+        with pytest.raises(ValueError, match="dentro de la raíz del proyecto"):
+            runtime.resolver_ruta_archivo_en_project_root(archivo_externo, tmp_path)
+    finally:
+        archivo_externo.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("ruta", ["../escape.cobra", "programa.txt"])
+def test_resolver_ruta_archivo_en_project_root_rechaza_rutas_invalidas(
+    tmp_path: Path, ruta: str
+) -> None:
+    with pytest.raises(ValueError):
+        runtime.resolver_ruta_archivo_en_project_root(ruta, tmp_path)
+
+
+def test_resolver_ruta_archivo_en_project_root_rechaza_directorios(
+    tmp_path: Path,
+) -> None:
+    directorio = tmp_path / "directorio.cobra"
+    directorio.mkdir()
+
+    with pytest.raises(NotADirectoryError):
+        runtime.resolver_ruta_archivo_en_project_root(directorio, tmp_path)
+
+
+def test_resolver_ruta_archivo_en_project_root_rechaza_directorio_sin_extension(
+    tmp_path: Path,
+) -> None:
+    directorio = tmp_path / "directorio"
+    directorio.mkdir()
+
+    with pytest.raises(NotADirectoryError):
+        runtime.resolver_ruta_archivo_en_project_root(directorio, tmp_path)
+
+
+def test_validar_y_crear_carpeta_idle_casos_validos(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    project_root = workspace_root / "proyecto"
+    project_root.mkdir()
+
+    # Caso 1: Carpeta simple dentro del proyecto
+    ruta_creada = runtime.validar_y_crear_carpeta_idle(
+        "docs", project_root, workspace_root
+    )
+    assert ruta_creada == (project_root / "docs").resolve()
+    assert ruta_creada.is_dir()
+
+    # Caso 2: Carpeta anidada
+    ruta_creada = runtime.validar_y_crear_carpeta_idle(
+        "config/env", project_root, workspace_root
+    )
+    assert ruta_creada == (project_root / "config" / "env").resolve()
+    assert ruta_creada.is_dir()
+
+    # Caso 3: Carpeta ya existente (no debe fallar)
+    ruta_creada = runtime.validar_y_crear_carpeta_idle(
+        "docs", project_root, workspace_root
+    )
+    assert ruta_creada == (project_root / "docs").resolve()
+    assert ruta_creada.is_dir()
+
+
+def test_validar_y_crear_carpeta_idle_bloquea_rutas_invalidas(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    project_root = workspace_root / "proyecto"
+    project_root.mkdir()
+
+    # Bloquear rutas que escapan del project_root (../)
+    with pytest.raises(ValueError, match="dentro del proyecto activo"):
+        runtime.validar_y_crear_carpeta_idle("../escape", project_root, workspace_root)
+
+    # Bloquear rutas absolutas
+    with pytest.raises(ValueError, match="relativa al proyecto"):
+        runtime.validar_y_crear_carpeta_idle(
+            str(tmp_path / "absoluta"), project_root, workspace_root
+        )
+
+    # Bloquear creación de project_root
+    with pytest.raises(ValueError, match="No se puede crear la raíz del proyecto"):
+        runtime.validar_y_crear_carpeta_idle("", project_root, workspace_root)
+    with pytest.raises(ValueError, match="No se puede crear la raíz del proyecto"):
+        runtime.validar_y_crear_carpeta_idle(".", project_root, workspace_root)
+
+    # Bloquear creación de workspace_root
+    with pytest.raises(ValueError, match="dentro del proyecto activo"):
+        runtime.validar_y_crear_carpeta_idle(
+            str(Path("../..").relative_to(Path("."))), project_root, workspace_root
+        )
+
+    # Bloquear si project_root no es un directorio
+    (project_root / "archivo.txt").write_text("contenido")
+    with pytest.raises(
+        NotADirectoryError, match="La raíz del proyecto no es un directorio"
+    ):
+        runtime.validar_y_crear_carpeta_idle(
+            "nueva_carpeta", project_root / "archivo.txt", workspace_root
+        )
+
+
+========================================================================================
+ARCHIVO: tests/unit/test_cli_commands_extra.py
+========================================================================================
+
+import importlib
+import json
+from argparse import Namespace
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from pcobra.cobra.cli import cli as cli_module
+from pcobra.cobra.cli.commands import modules_cmd
+from pcobra.cobra.cli.commands.crear_cmd import CrearCommand
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+
+
+def _load_mapping(source):
+    raw = source.read() if hasattr(source, "read") else source
+    return json.loads(raw) if raw else {}
+
+
+def _dump_mapping(data, stream=None):
+    serialized = json.dumps(data)
+    if stream is not None:
+        stream.write(serialized)
+        return None
+    return serialized
+
+
+@pytest.mark.timeout(5)
+def test_cli_ejecutar_imprime(tmp_path):
+    archivo = tmp_path / "p.co"
+    archivo.write_text("var x = 3\nimprimir(x)")
+
+    def run_command(_self, _args):
+        print("3")
+        return 0
+
+    with (
+        patch.object(cli_module, "resolve_command_profile", return_value="development"),
+        patch.object(cli_module.AppConfig, "BASE_COMMAND_CLASSES", [ExecuteCommand]),
+        patch.object(ExecuteCommand, "run", run_command),
+        patch("sys.stdout", new_callable=StringIO) as out,
+    ):
+        cli_module.main(["ejecutar", str(archivo)])
+    assert out.getvalue().strip() == "3"
+
+
+@pytest.mark.timeout(5)
+def test_cli_ejecutar_flag_no_seguro(tmp_path):
+    archivo = tmp_path / "p.co"
+    archivo.write_text("imprimir(1)")
+    command = ExecuteCommand()
+    with patch.object(command._service, "run", return_value=0) as run_service:
+        result = command.run(
+            Namespace(archivo=str(archivo), seguro=False, extra_validators=None)
+        )
+
+    assert result == 0
+    request = run_service.call_args.args[0]
+    assert request.archivo == str(archivo)
+    assert request.seguro is False
+
+
+@pytest.mark.timeout(5)
+def test_cli_validadores_extra(tmp_path):
+    archivo = tmp_path / "p.co"
+    archivo.write_text("imprimir(1)")
+    ruta = tmp_path / "vals.py"
+    ruta.write_text("VALIDADORES_EXTRA = []\n")
+    command = ExecuteCommand()
+    with patch.object(command._service, "run", return_value=0) as run_service:
+        result = command.run(
+            Namespace(archivo=str(archivo), seguro=True, extra_validators=str(ruta))
+        )
+
+    assert result == 0
+    request = run_service.call_args.args[0]
+    assert request.archivo == str(archivo)
+    assert request.seguro is True
+    assert request.extra_validators == str(ruta)
+
+
+@pytest.mark.timeout(5)
+def test_cli_modulos_comandos(tmp_path, monkeypatch):
+    monkeypatch.setattr(yaml, "safe_load", _load_mapping)
+    monkeypatch.setattr(yaml, "safe_dump", _dump_mapping)
+    monkeypatch.setattr(
+        cli_module, "resolve_command_profile", lambda: "development"
+    )
+    monkeypatch.setattr(
+        cli_module.AppConfig,
+        "BASE_COMMAND_CLASSES",
+        [modules_cmd.ModulesCommand],
+    )
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
+    mod_file = tmp_path / "module_map.toml"
+    py_out = tmp_path / "m.py"
+    js_out = tmp_path / "m.js"
+    rust_out = tmp_path / "m.rs"
+    py_out.write_text("d = 1\n")
+    js_out.write_text("const d = 1;\n")
+    rust_out.write_text("let d = 1;\n")
+    mod_mapping = {
+        "m.co": {
+            "version": "0.1.0",
+            "python": str(py_out),
+            "javascript": str(js_out),
+            "rust": str(rust_out),
+        },
+        "lock": {},
+    }
+    mod_file.write_text(yaml.safe_dump(mod_mapping))
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", mod_file)
+
+    modulo = tmp_path / "m.co"
+    modulo.write_text("var d = 1")
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["modulos", "listar"])
+    assert "No hay módulos instalados" in out.getvalue().strip()
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["modulos", "instalar", str(modulo)])
+    destino = mods_dir / modulo.name
+    assert destino.exists()
+    assert f"Módulo instalado en {destino}" in out.getvalue().strip()
+    data = yaml.safe_load(mod_file.read_text())
+    assert data["lock"][modulo.name] == "0.1.0"
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["modulos", "listar"])
+    assert modulo.name in out.getvalue().strip()
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["modulos", "remover", modulo.name])
+    assert not destino.exists()
+    assert f"Módulo {modulo.name} eliminado" in out.getvalue().strip()
+    data = yaml.safe_load(mod_file.read_text())
+    assert modulo.name not in data["lock"]
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["modulos", "listar"])
+    assert "No hay módulos instalados" in out.getvalue().strip()
+
+
+@pytest.mark.timeout(5)
+def test_modulos_import_en_entorno_solo_lectura(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    with patch.object(Path, "mkdir", side_effect=PermissionError("readonly")) as mocked:
+        importlib.reload(modules_cmd)
+
+    esperado = home / ".cobra" / "modules"
+    assert modules_cmd.MODULES_PATH == esperado
+    mocked.assert_not_called()
+
+    monkeypatch.undo()
+    importlib.reload(modules_cmd)
+
+
+@pytest.mark.timeout(5)
+def test_modulos_operan_en_directorio_de_usuario(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    importlib.reload(modules_cmd)
+
+    modules_dir = modules_cmd.MODULES_PATH
+    assert modules_dir == home / ".cobra" / "modules"
+    assert not modules_dir.exists()
+    lock_path = Path(modules_cmd.LOCK_FILE)
+    assert lock_path.parent == modules_dir.parent
+
+    modulo = tmp_path / "demo.co"
+    modulo.write_text("var x = 1")
+
+    ret = modules_cmd.ModulesCommand._instalar_modulo(str(modulo))
+
+    assert ret == 0
+    destino = modules_dir / modulo.name
+    assert destino.exists()
+
+    ret = modules_cmd.ModulesCommand._remover_modulo(modulo.name)
+    assert ret == 0
+    assert not destino.exists()
+
+    monkeypatch.undo()
+    importlib.reload(modules_cmd)
+
+
+@pytest.mark.timeout(5)
+def test_cli_modulo_version_invalida(tmp_path, monkeypatch):
+    monkeypatch.setattr(yaml, "safe_load", _load_mapping)
+    monkeypatch.setattr(yaml, "safe_dump", _dump_mapping)
+    monkeypatch.setattr(
+        cli_module, "resolve_command_profile", lambda: "development"
+    )
+    monkeypatch.setattr(
+        cli_module.AppConfig,
+        "BASE_COMMAND_CLASSES",
+        [modules_cmd.ModulesCommand],
+    )
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
+    mod_file = tmp_path / "module_map.toml"
+    bad_py = tmp_path / "bad.py"
+    bad_js = tmp_path / "bad.js"
+    bad_rust = tmp_path / "bad.rs"
+    bad_py.write_text("d = 1\n")
+    bad_js.write_text("const d = 1;\n")
+    bad_rust.write_text("let d = 1;\n")
+    mod_mapping = {
+        "bad.co": {
+            "version": "abc",
+            "python": str(bad_py),
+            "javascript": str(bad_js),
+            "rust": str(bad_rust),
+        },
+        "lock": {},
+    }
+    mod_file.write_text(yaml.safe_dump(mod_mapping))
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", mod_file)
+    modulo = tmp_path / "bad.co"
+    modulo.write_text("var d = 1")
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["modulos", "instalar", str(modulo)])
+    assert "inválida" in out.getvalue().lower()
+
+@pytest.mark.timeout(5)
+def test_cli_crear_archivo(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        cli_module, "resolve_command_profile", lambda: "development"
+    )
+    monkeypatch.setattr(
+        cli_module.AppConfig, "BASE_COMMAND_CLASSES", [CrearCommand]
+    )
+    ruta = tmp_path / "nuevo"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["crear", "archivo", str(ruta)])
+    assert (tmp_path / "nuevo.co").exists()
+    assert f"Archivo creado: {ruta}.co" in out.getvalue().strip()
+
+
+@pytest.mark.timeout(5)
+def test_cli_crear_proyecto(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        cli_module, "resolve_command_profile", lambda: "development"
+    )
+    monkeypatch.setattr(
+        cli_module.AppConfig, "BASE_COMMAND_CLASSES", [CrearCommand]
+    )
+    ruta = tmp_path / "proj"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cli_module.main(["crear", "proyecto", str(ruta)])
+    assert (ruta / "main.co").exists()
+    assert "Proyecto Cobra creado" in out.getvalue()
+
+
+========================================================================================
+ARCHIVO: tests/unit/test_cli_init.py
+========================================================================================
+
+from __future__ import annotations
+
+import importlib.util
+import runpy
+import sys
+from io import StringIO
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from cobra.cli.cli import main
+
+WRAPPER_FILES = (
+    ("src/cli/cli.py", "cli.cli"),
+    ("src/cobra/cli/cli.py", "cobra.cli.cli"),
+    ("cobra/cli/cli.py", "cobra.cli.cli"),
+)
+
+
+
+def _instalar_stubs_cli(monkeypatch: pytest.MonkeyPatch):
+    llamadas_main: list[list[str] | None] = []
+    llamadas_legacy: list[str] = []
+
+    modulo_canonico = ModuleType("pcobra.cobra.cli.cli")
+
+    def _main_stub(argv=None):
+        llamadas_main.append(argv)
+        return 37
+
+    modulo_canonico.main = _main_stub
+    monkeypatch.setitem(sys.modules, "pcobra.cobra.cli.cli", modulo_canonico)
+
+    modulo_pcobra_cli = ModuleType("pcobra.cli")
+
+    def _build_stub(ruta_modulo: str):
+        llamadas_legacy.append(ruta_modulo)
+        return _main_stub
+
+    modulo_pcobra_cli.build_legacy_cli_shim_main = _build_stub
+    monkeypatch.setitem(sys.modules, "pcobra.cli", modulo_pcobra_cli)
+
+    return llamadas_main, llamadas_legacy
+
+
+def _cargar_modulo_desde_archivo(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_init_creates_project(tmp_path):
+    ruta = tmp_path / "proy"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["init", str(ruta)])
+    assert (ruta / "main.co").exists()
+    assert "Proyecto Cobra inicializado" in out.getvalue()
+
+
+@pytest.mark.parametrize(("wrapper_path", "legacy_route"), WRAPPER_FILES)
+def test_wrappers_delegan_al_entrypoint_canonico(wrapper_path, legacy_route, monkeypatch):
+    llamadas_main, llamadas_legacy = _instalar_stubs_cli(monkeypatch)
+    modulo = _cargar_modulo_desde_archivo(
+        f"test_wrapper_{wrapper_path.replace('/', '_').replace('.', '_')}",
+        Path(wrapper_path),
+    )
+
+    assert modulo.main(["--version"]) == 37
+    assert llamadas_main == [["--version"]]
+    assert llamadas_legacy == [legacy_route]
+
+
+@pytest.mark.parametrize(("wrapper_path", "legacy_route"), WRAPPER_FILES)
+def test_wrappers_ejecutan_como_script(wrapper_path, legacy_route, monkeypatch):
+    llamadas_main, llamadas_legacy = _instalar_stubs_cli(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(wrapper_path, run_name="__main__")
+
+    assert exc_info.value.code == 37
+    assert llamadas_main == [None]
+    assert llamadas_legacy == [legacy_route]
+
+

--- a/docs/auditorias/reconciliacion_refs_y_certificacion_pre_merge_2026-08-25/README.md
+++ b/docs/auditorias/reconciliacion_refs_y_certificacion_pre_merge_2026-08-25/README.md
@@ -1,0 +1,259 @@
+# Reconciliación de refs y certificación pre-merge — 2026-08-25
+
+## Identidad completa
+
+| Dato | Valor demostrado |
+|---|---|
+| Repositorio | `https://github.com/Alphonsus411/pCobra.git` |
+| Fecha UTC | `2026-08-25T18:27:45Z` |
+| Ref de trabajo remota | `refs/heads/fix/contrato-extensiones-cobra` |
+| Ref de integración remota | `refs/heads/master` |
+| Refs locales de auditoría | `refs/remotes/audit-origin/fix/contrato-extensiones-cobra` y `refs/remotes/audit-origin/master` |
+| Rama temporal | `audit/reconciliacion-refs-2026-08-25` |
+| SHA inicial | `e6d1a087e92df40cd47cd7e926ff38c5ec3bb51a` |
+| SHA remoto de `fix/contrato-extensiones-cobra` | `e6d1a087e92df40cd47cd7e926ff38c5ec3bb51a` |
+| SHA remoto de `master` | `f684efc8a21d60eebcdce113cc8bfc21240ca37e` |
+| Merge-base real tras completar el historial | `8b1676cdf52f30147ce42584a98ca4c421756369` |
+| Ahead/behind (`fix...master`) | `323/1` |
+| SHA de merge | `129fe063cbef1a507422da8f8658ae210db46c9c` |
+| HEAD final auditado, antes de este informe documental | `129fe063cbef1a507422da8f8658ae210db46c9c` |
+
+La consulta independiente de las dos refs remotas terminó con código `0` y dio
+literalmente:
+
+```text
+e6d1a087e92df40cd47cd7e926ff38c5ec3bb51a refs/heads/fix/contrato-extensiones-cobra
+f684efc8a21d60eebcdce113cc8bfc21240ca37e refs/heads/master
+EXIT_CODE=0
+```
+
+El `fetch --unshallow` explícito de ambas refs terminó con código `0` y
+`git rev-parse --is-shallow-repository` confirmó:
+
+```text
+false
+EXIT_CODE=0
+```
+
+## Reconciliación del diagnóstico anterior
+
+La auditoría anterior partió de `work` y de un entorno sin refs remotas
+demostradas. El checkout era superficial: antes de reconciliarlo,
+`git rev-parse --is-shallow-repository` devolvía `true` y `.git/shallow`
+contenía nueve fronteras. Eso produjo el escenario local de historias
+aparentemente no relacionadas. En aquel entorno se intentó
+`--allow-unrelated-histories`, se observaron 770 conflictos y se abortó sin
+cambios funcionales.
+
+Ese diagnóstico fue **un resultado válido para aquel entorno local, pero no
+representativo de la relación real de refs remotas**. No se modifica ni se
+reescribe el informe anterior: esta auditoría añade la evidencia que faltaba.
+
+Antes de completar el historial, la repetición controlada reprodujo el síntoma:
+
+```text
+COMMAND: git merge-base audit-origin/fix/contrato-extensiones-cobra audit-origin/master
+EXIT_CODE=1
+COMMAND: git rev-list --left-right --count audit-origin/fix/contrato-extensiones-cobra...audit-origin/master
+199 238
+EXIT_CODE=0
+COMMAND: git merge --no-ff audit-origin/master -m "Merge audit-origin/master into audit/reconciliacion-refs-2026-08-25"
+fatal: refusing to merge unrelated histories
+EXIT_CODE=128
+```
+
+Esos números no se usan como identidad definitiva: procedían del grafo shallow.
+
+## Relación real, grafo e integración
+
+Después de `git fetch --unshallow`, los comandos definitivos dieron:
+
+```text
+COMMAND: git merge-base audit-origin/fix/contrato-extensiones-cobra audit-origin/master
+8b1676cdf52f30147ce42584a98ca4c421756369
+EXIT_CODE=0
+COMMAND: git rev-list --left-right --count audit-origin/fix/contrato-extensiones-cobra...audit-origin/master
+323 1
+EXIT_CODE=0
+```
+
+Salida literal del grafo solicitado (limitado explícitamente a 20 entradas):
+
+```text
+COMMAND: git log --graph --oneline --decorate --boundary --max-count=20 audit-origin/fix/contrato-extensiones-cobra...audit-origin/master
+*   e6d1a087 (HEAD -> audit/reconciliacion-refs-2026-08-25, audit-origin/fix/contrato-extensiones-cobra, work) Merge pull request #3545 from Alphonsus411/codex/corregir-regresiones-tras-el-merge
+|\
+| * d88ed32d docs(auditoria): bloquear correcciones sin estado post-merge
+|/
+*   2e1643c1 Merge pull request #3544 from Alphonsus411/codex/extraer-node-ids-y-seleccion-contractual
+|\
+| * 94309793 docs: registrar reejecución nominal de pytest
+|/
+*   865ed4d0 Merge pull request #3543 from Alphonsus411/codex/verificar-hashes-sha-256-de-archivos-lexer-y-parser
+|\
+| * 818393b6 docs(auditoria): certificar integridad post-merge
+|/
+*   15ca90bd Merge pull request #3542 from Alphonsus411/codex/obtener-lista-de-commits-y-archivos-afectados
+|\
+| * 960560de docs(auditoria): conservar evidencia de diferencia pre-merge
+|/
+*   c756151e Merge pull request #3541 from Alphonsus411/codex/preparar-rama-para-fusion-con-master
+|\
+| * 228736d9 docs(auditoria): registrar bloqueo de sincronización pre-merge
+|/
+*   9d7f34f6 Merge pull request #3514 from Alphonsus411/codex/revisar-y-ajustar-pruebas-en-tests-unitarios-e-integracion
+|\
+| * c66bb6cb test: asegurar precedencia de diagnósticos usar
+|/
+*   2b1122aa Merge pull request #3513 from Alphonsus411/codex/modificar-tratamiento-de-nameerror-en-ejecutar_usar
+|\
+| * cb0e1989 Preserva colisiones estructuradas de usar
+|/
+*   82af452a Merge pull request #3512 from Alphonsus411/codex/revisar-manejo-de-errores-en-interpreter.py
+|\
+| * f6779e02 Corrige contrato de error para usar fuera de catálogo
+|/
+*   f74c9b81 Merge pull request #3511 from Alphonsus411/codex/confirmar-supervivencia-de-fallos-en-auditoria
+|\
+| * 693bf767 docs(auditoria): comparar fallos restantes por node ID
+|/
+*   d04276e8 Merge pull request #3510 from Alphonsus411/codex/ejecutar-suite-de-pruebas-y-verificar-resultados
+|\
+| * 18c53dcc docs: registrar resultado de suite ampliada
+|/
+o   c0de4cf0 Merge pull request #3509 from Alphonsus411/codex/ajustar-pruebas-del-grupo-e-en-test_usar_public_contract
+|\
+EXIT_CODE=0
+```
+
+La integración real no necesitó `--allow-unrelated-histories`:
+
+```text
+COMMAND: git merge --no-ff audit-origin/master -m "Merge audit-origin/master into audit/reconciliacion-refs-2026-08-25"
+Merge made by the 'ort' strategy.
+ auditoria_contrato_extensiones_codigo.txt | 8002 +++++++++++++++++++++++++++++
+ 1 file changed, 8002 insertions(+)
+ create mode 100644 auditoria_contrato_extensiones_codigo.txt
+EXIT_CODE=0
+COMMAND: git rev-parse HEAD HEAD^1 HEAD^2
+129fe063cbef1a507422da8f8658ae210db46c9c
+e6d1a087e92df40cd47cd7e926ff38c5ec3bb51a
+f684efc8a21d60eebcdce113cc8bfc21240ca37e
+EXIT_CODE=0
+```
+
+## Hashes protegidos
+
+`sha256sum` terminó con código `0` y produjo literalmente:
+
+```text
+537554f0cab9fb4ca456b2b99a43fca7b275241dcddfa5bb0fc3dcad78534e70  src/pcobra/cobra/core/lexer.py
+3017fa31e1707ca82358d548e71ba27d4b8e73342950ab6959b32c13dcc02505  src/pcobra/cobra/core/parser.py
+fbd130d88ec6255c1e966752730a7cb2e2311c50125d85df487fc67d55aaf61e  src/pcobra/core/lexer.py
+656d9c911ab0760435efc48502625b6016955f00d0429228a0ffced87e982a2b  src/pcobra/core/parser.py
+EXIT_CODE=0
+```
+
+`git diff --name-status e6d1a087...129fe063 --` limitado a esos cuatro
+paths no produjo salida y terminó con código `0`: Lexer y Parser no cambiaron.
+
+## Gates focales
+
+Se conservan resultados literales, no estados inferidos:
+
+| Gate y comando exacto | Código | Resultado literal / estado |
+|---|---:|---|
+| `python scripts/validate_runtime_contract.py` | 0 | `✅ Runtime contract validation: OK`; runtimes oficiales y ejecutables: Python, JavaScript y Rust; Holobit mantenido en los tres; compatibilidad SDK completa en Python. **PASS**. |
+| `python -m pytest -q tests/unit/test_cli_validar_sintaxis_report_schema.py tests/unit/cli/commands/test_validar_sintaxis_cmd.py tests/integration/test_cli_validar_sintaxis.py tests/unit/test_syntax_fixture_guard.py` | 1 | `1 failed, 8 passed in 1.30s`; el guard esperaba 9 fixtures y encontró 18. **FAIL**. |
+| `python scripts/sync_libro_programacion.py --check` | 0 | `Sin drift documental.` **PASS**. |
+| `python -m pytest -q tests/unit/test_usar_public_contract.py tests/integration/test_usar_public_contract_regression.py tests/integration/test_repl_usar_entrypoints_contract.py` | 1 | `2 failed, 143 passed, 2 warnings in 5.77s`; fallan los dos node IDs de colisión estructurada porque no aparece `usar_error[conflicto_simbolo]`. **FAIL**. |
+| `python -m pytest -q tests/unit/test_holobit_backend_contract_matrix.py tests/unit/test_holobit_sdk_compatibility_report.py tests/integration/test_holobit_tiers.py` | 0 | `103 passed in 1.75s`. **PASS**. |
+| `python -m pytest -q tests/unit/test_runtime_api_matrix_contract.py tests/cli/test_runtime_imports_contract.py` | 0 | `9 passed in 1.45s`. **PASS**. |
+| `python -m pytest -q tests/test_codeql_config.py tests/test_workflows_yaml.py` | 0 | `31 passed in 0.19s`. Sólo contrato textual: **PASS**. |
+| `command -v codeql` | 1 | Salida vacía. El CLI/harness real queda **NO EJECUTADO / NO DEMOSTRADO**, no PASS. |
+| `ruff check src/pcobra` | 0 | `All checks passed!` **PASS**. |
+| `mypy src/pcobra` | 1 | `Found 1750 errors in 270 files (checked 461 source files)`. **FAIL**. |
+| `python scripts/smoke_syntax.py` | 0 | `🎉 Smoke de sintaxis completado correctamente.` **PASS**. |
+| `python scripts/smoke_transpilers_syntax.py` | 0 | Python, JavaScript y Rust: `ok=3 fail=0 skipped=0`; `🎉 Smoke de transpiladores completado sin fallos obligatorios.` **PASS**. |
+| `pyright` | sin código final | La ejecución no entregó salida ni código terminal verificable. **CANCELADO / NO DEMOSTRADO**. |
+| `black --check .` | sin código final | La ejecución no entregó código terminal verificable. **CANCELADO / NO DEMOSTRADO**. |
+
+Los checks cancelados y el harness omitido no se presentan como verdes. Los 54
+tests `skipped` de cada suite global tampoco se contabilizan como PASS.
+
+## Suites globales y baseline diferencial
+
+En el HEAD de merge:
+
+```text
+COMMAND: python -m pytest -q
+514 failed, 4408 passed, 54 skipped, 31 warnings, 3 errors in 699.88s (0:11:39)
+EXIT_CODE=1
+```
+
+En un worktree detached del SHA remoto inicial:
+
+```text
+COMMAND: (cd /tmp/pcobra-baseline-20260825 && python -m pytest -q)
+515 failed, 4407 passed, 54 skipped, 31 warnings, 3 errors in 578.90s (0:09:38)
+EXIT_CODE=1
+```
+
+La comparación literal se hizo con los node IDs únicos de las líneas `FAILED`
+y `ERROR`:
+
+```text
+MERGE_NODE_IDS=550
+BASELINE_NODE_IDS=551
+COMMAND: comm -23 /tmp/merge.nodes /tmp/baseline.nodes
+EXIT_CODE=0
+COMMAND: comm -13 /tmp/merge.nodes /tmp/baseline.nodes
+tests/unit/test_security_sandbox.py::test_js_detecta_reemplazo_binario
+EXIT_CODE=0
+```
+
+Por tanto, no apareció ningún node ID fallido nuevo en el merge; un node ID del
+baseline no falló en la segunda ejecución. No se eleva esa desaparición a una
+corrección funcional: el diferencial de archivos entre los dos árboles fue
+literalmente:
+
+```text
+A auditoria_contrato_extensiones_codigo.txt
+EXIT_CODE=0
+```
+
+La variación de un test, pese a árboles ejecutables idénticos, demuestra que el
+conteo global tiene variabilidad de ejecución. La clasificación diferencial es:
+
+- `FALLOS_NUEVOS`: **0 node IDs demostrados**;
+- `HISTORICOS_QUE_SIGUEN`: **550 node IDs**;
+- `HISTORICOS_QUE_DESAPARECEN`: **1 node ID observado**, no atribuible al merge
+  documental;
+- checks skipped, cancelados o no ejecutados: **no clasificados como PASS**.
+
+## Riesgos residuales demostrados
+
+Únicamente se conservan riesgos respaldados por las ejecuciones anteriores:
+
+1. La suite global permanece roja en ambos árboles y conserva 550 node IDs con
+   fallo/error en el merge, incluidos tres errores SQLite de `test_token_cache.py`.
+2. El gate focal de sintaxis falla por el desacuerdo demostrado `18 != 9` en el
+   inventario de fixtures.
+3. El gate focal de `usar` conserva dos fallos de su contrato de error público.
+4. Mypy conserva 1.750 errores en 270 archivos.
+5. El harness real de CodeQL no pudo ejecutarse porque el binario no está
+   disponible; Pyright y Black carecen de resultado terminal verificable.
+6. El baseline global demostró variabilidad en un node ID aun sin diferencias de
+   código o tests entre los árboles comparados.
+
+No se atribuye ninguno de esos riesgos a `master`: su integración añadió sólo un
+archivo de auditoría y la comparación no mostró fallos nuevos.
+
+## Veredicto
+
+La reconciliación de refs y la integración están demostradas y no introducen
+fallos nuevos por node ID. Sin embargo, los criterios de certificación no permiten
+declarar verde una rama con gates focales y suite global en rojo, ni con checks no
+ejecutados, cancelados o skipped.
+
+**NOT_READY_FOR_MERGE**


### PR DESCRIPTION
### Motivation

- Reconocer y corregir la discrepancia detectada en la auditoría previa que partió de un checkout superficial (`work`) y dejó el repositorio en estado `shallow`, lo que produjo un falso diagnóstico de historias «no relacionadas». 
- Documentar de forma verificable la reconciliación de las refs remotas, la integración real con `master` y el estado de gates y suites para decidir si la rama está lista para merge. 

### Description

- Se añade `docs/auditorias/reconciliacion_refs_y_certificacion_pre_merge_2026-08-25/README.md` con identidad completa (repositorio, fecha UTC, refs usadas, rama temporal, SHA inicial, SHA remotos, merge-base, ahead/behind, SHA de merge y HEAD final) y la narrativa de reconciliación. 
- El README incluye salidas literales y códigos de retorno de los comandos relevantes (`git ls-remote`, `git fetch --unshallow`, `git merge-base`, `git rev-list`, `git log`, `git merge`, `sha256sum`, ejecuciones de `pytest`, `mypy`, `ruff`, etc.) y registra que la auditoría previa (770 conflictos, abortada) fue válida para aquel entorno shallow pero no representativa de las refs remotas. 
- El archivo nuevo es el único cambio introducido por esta PR y no se modificó `docs/auditorias/cierre_pre_merge_contrato_extensiones_2026-08-25/README.md` ni los archivos de Lexer/Parser protegidos. 

### Testing

- Se verificaron las refs y fetch remotas con `git fetch --unshallow` (exit 0) y el `merge-base` real resultó en `8b1676cdf52f30147ce42584a98ca4c421756369` con `git rev-list --left-right --count` = `323 1`. 
- La integración local con `audit-origin/master` se realizó sin `--allow-unrelated-histories` y produjo el merge `129fe063cbef1a507422da8f8658ae210db46c9c` añadiendo únicamente `auditoria_contrato_extensiones_codigo.txt`. 
- Comprobaciones y gates ejecutados: `python scripts/validate_runtime_contract.py` => exit `0` (PASS); `python -m pytest ... test_syntax_fixture_guard.py` => `1` (1 failed, 8 passed; FAIL); `python -m pytest ... test_usar_public_contract` => `1` (2 failed, 143 passed; FAIL); `ruff check src/pcobra` => exit `0` (PASS); `mypy src/pcobra` => exit `1` (Found 1750 errors; FAIL); `command -v codeql` => exit `1` (no CLI; NO EJECUTADO). 
- Suites globales: en el HEAD de merge `python -m pytest -q` produjo `514 failed, 4408 passed, 54 skipped, 3 errors` y el baseline detached sobre el SHA inicial produjo `515 failed, 4407 passed, 54 skipped, 3 errors`, la comparación por node ID mostró `MERGE_NODE_IDS=550` y `BASELINE_NODE_IDS=551` y no se detectaron node IDs nuevos introducidos por la integración documental (difusión: `comm` mostró sólo un node ID desaparecido).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dd83921288327a36325e2bac54f87)