### PR TITLE
docs(auditoria): agregar higiene final previa al merge de fix/contrato-extensiones-cobra

### DIFF
--- a/docs/auditorias/higiene_final_pre_merge_2026-08-26/README.md
+++ b/docs/auditorias/higiene_final_pre_merge_2026-08-26/README.md
@@ -1,0 +1,64 @@
+# Higiene final previa al merge de `fix/contrato-extensiones-cobra`
+
+Fecha de ejecución: 2026-08-26 (UTC).
+
+## Preparación del repositorio
+
+El repositorio no tenía remoto configurado y estaba en la rama local `work`,
+sin modificaciones preexistentes en el árbol de trabajo. Se añadió `origin` con
+la URL `https://github.com/Alphonsus411/pCobra.git`, se obtuvieron
+`origin/master` y `origin/fix/contrato-extensiones-cobra` y se cambió a la rama
+local de seguimiento `fix/contrato-extensiones-cobra` sin descartar cambios.
+
+El clon era superficial. Se completó el historial mediante
+`git fetch --unshallow origin` para poder calcular correctamente el ancestro
+común. No se realizó merge, rebase, reset ni force push.
+
+## Estado y referencias registrados
+
+Después de completar el grafo, el registro solicitado fue:
+
+```text
+$ git status --short --branch
+## fix/contrato-extensiones-cobra...origin/fix/contrato-extensiones-cobra
+$ git rev-parse HEAD
+787b022bf14b3923f702325d7ce21d4bebf6120c
+$ git rev-parse origin/master
+f684efc8a21d60eebcdce113cc8bfc21240ca37e
+$ git rev-parse origin/fix/contrato-extensiones-cobra
+787b022bf14b3923f702325d7ce21d4bebf6120c
+$ git merge-base origin/master origin/fix/contrato-extensiones-cobra
+8b1676cdf52f30147ce42584a98ca4c421756369
+$ git rev-list --left-right --count origin/master...origin/fix/contrato-extensiones-cobra
+1	337
+```
+
+`HEAD` coincidía con la referencia remota de la rama de corrección. El conteo
+indica un commit exclusivo de `origin/master` y 337 commits exclusivos de
+`origin/fix/contrato-extensiones-cobra`.
+
+## Comprobaciones focales
+
+Solo se ejecutaron las tres comprobaciones solicitadas:
+
+| Comando | Resultado |
+|---|---|
+| `python -m compileall -q src` | PASS (código 0) |
+| `python scripts/validate_runtime_contract.py` | PASS (código 0); contrato de runtime válido |
+| `python scripts/sync_libro_programacion.py --check` | PASS (código 0); sin drift documental |
+
+No se ejecutaron suites adicionales.
+
+## Alcance del cambio
+
+Esta auditoría crea únicamente este informe. No modifica Lexer, Parser, código
+fuente, pruebas, ejemplos ni la documentación normativa del lenguaje.
+
+## Conclusión
+
+El remoto y las dos referencias requeridas quedaron disponibles, la rama local
+quedó vinculada a `origin/fix/contrato-extensiones-cobra`, el grafo completo
+permitió obtener un merge-base válido y los tres controles focales terminaron
+correctamente. La divergencia registrada no es cero: `origin/master` conserva
+un commit que no pertenece a la rama de corrección y debe considerarse al
+realizar el merge.


### PR DESCRIPTION
### Motivation

- Registrar de forma mínima y reproducible la higiene y comprobaciones previas al merge de la rama `fix/contrato-extensiones-cobra` para dejar evidencia operacional antes de publicar cambios.
- Asegurar que las comprobaciones focales requeridas se ejecutaron y documentar el estado del grafo y referencias remotas observado en el entorno.
- Mantener la auditoría separada de cualquier cambio en Lexer/Parser, código fuente, pruebas o documentación normativa.

### Description

- Se añadió el archivo `docs/auditorias/higiene_final_pre_merge_2026-08-26/README.md` que documenta la preparación del repositorio, la vinculación a la rama de seguimiento y el estado de referencias observado después de completar el grafo superficial.
- El informe contiene el `merge-base` detectado, la divergencia observada entre las referencias remotas y el resultado resumido de las comprobaciones focales ejecutadas.
- No se modificaron archivos de Lexer ni Parser, ni se tocaron ejemplos, pruebas ni la documentación normativa del lenguaje, y el cambio es únicamente la creación de dicho README.

### Testing

- Se ejecutaron las tres comprobaciones solicitadas y todas terminaron correctamente: `python -m compileall -q src` (exit 0), `python scripts/validate_runtime_contract.py` (exit 0) y `python scripts/sync_libro_programacion.py --check` (exit 0).
- Se intentó publicar el cambio en el remoto y abrir el pull request desde este entorno, pero la operación falló por falta de credenciales/soporte para publicar (entorno sin acceso a las credenciales necesarias), por lo que el commit quedó solo en el repositorio local.
- No se ejecutaron suites adicionales ni se cambiaron aserciones o pruebas existentes para hacerlas pasar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f2b2b77a88327a41ef7dba0751067)